### PR TITLE
Rename 'credentials/irmago' to 'privacybydesign/irmago'

### DIFF
--- a/credinfo.go
+++ b/credinfo.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago/internal/fs"
 )
 
 // CredentialInfo contains all information of an IRMA credential.

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/credentials/go-go-gadget-paillier"
-	"github.com/credentials/irmago"
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/getsentry/raven-go"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"

--- a/irmaclient/credential.go
+++ b/irmaclient/credential.go
@@ -1,7 +1,7 @@
 package irmaclient
 
 import (
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/mhe/gabi"
 )
 

--- a/irmaclient/irmaclient_test.go
+++ b/irmaclient/irmaclient_test.go
@@ -9,8 +9,8 @@ import (
 
 	"encoding/json"
 
-	"github.com/credentials/irmago"
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/mhe/gabi"
 	"github.com/stretchr/testify/require"
 )

--- a/irmaclient/keyshare.go
+++ b/irmaclient/keyshare.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"
 )

--- a/irmaclient/logs.go
+++ b/irmaclient/logs.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"
 )

--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -8,7 +8,7 @@ import (
 
 	"math/big"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"
 )

--- a/irmaclient/session_test.go
+++ b/irmaclient/session_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/require"
 )

--- a/irmaclient/storage.go
+++ b/irmaclient/storage.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/credentials/irmago"
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/mhe/gabi"
 )
 

--- a/irmaclient/updates.go
+++ b/irmaclient/updates.go
@@ -8,8 +8,8 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/credentials/irmago"
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"
 )

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -26,7 +26,7 @@ import (
 	"encoding/pem"
 	"math/big"
 
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/go-errors/errors"
 	"github.com/mhe/gabi"
 )

--- a/irmameta/irmameta.go
+++ b/irmameta/irmameta.go
@@ -9,7 +9,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/mhe/gabi"
 )
 

--- a/schememgr/cmd/keygen.go
+++ b/schememgr/cmd/keygen.go
@@ -12,7 +12,7 @@ import (
 
 	"fmt"
 
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 )

--- a/schememgr/cmd/sign.go
+++ b/schememgr/cmd/sign.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/credentials/irmago"
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/internal/fs"
 	"github.com/spf13/cobra"
 )
 

--- a/schememgr/cmd/verify.go
+++ b/schememgr/cmd/verify.go
@@ -5,7 +5,7 @@ import (
 
 	"fmt"
 
-	"github.com/credentials/irmago"
+	"github.com/privacybydesign/irmago"
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 )

--- a/schememgr/main.go
+++ b/schememgr/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/credentials/irmago/schememgr/cmd"
+import "github.com/privacybydesign/irmago/schememgr/cmd"
 
 func main() {
 	cmd.Execute()

--- a/transport.go
+++ b/transport.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/credentials/irmago/internal/fs"
+	"github.com/privacybydesign/irmago/internal/fs"
 )
 
 // HTTPTransport sends and receives JSON messages to a HTTP server.


### PR DESCRIPTION
This prevents the 'use of internal package not allowed' go compile error