### PR TITLE
Manual sigrequests

### DIFF
--- a/irmaclient/logs.go
+++ b/irmaclient/logs.go
@@ -29,7 +29,7 @@ type LogEntry struct {
 
 const actionRemoval = irma.Action("removal")
 
-func (session *session) createLogEntry(response interface{}) (*LogEntry, error) {
+func (session *interactiveSession) createLogEntry(response interface{}) (*LogEntry, error) {
 	entry := &LogEntry{
 		Type:        session.Action,
 		Time:        irma.Timestamp(time.Now()),

--- a/irmaclient/manual_session_test.go
+++ b/irmaclient/manual_session_test.go
@@ -1,16 +1,16 @@
 package irmaclient
 
 import (
-  "fmt"
-  "testing"
-  "github.com/credentials/irmago"
+	"fmt"
+	"github.com/privacybydesign/irmago"
+	"testing"
 )
 
 type ManualSessionHandler struct {
 	permissionHandler PermissionHandler
 	pinHandler        PinHandler
-	t				  *testing.T
-	c				  chan *irma.SessionError
+	t                 *testing.T
+	c                 chan *irma.SessionError
 }
 
 var client *Client
@@ -51,15 +51,15 @@ func TestManualKeyShareSession(t *testing.T) {
 	}
 }
 
-
 func (sh *ManualSessionHandler) Success(irmaAction irma.Action, result string) {
-  fmt.Println("Result: " + result)
 	sh.c <- nil
 }
-func (sh *ManualSessionHandler) UnsatisfiableRequest(irmaAction irma.Action, missingAttributes irma.AttributeDisjunctionList) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) UnsatisfiableRequest(irmaAction irma.Action, missingAttributes irma.AttributeDisjunctionList) {
+	sh.t.Fail()
+}
 
 // Done in irma bridge?
-func (sh *ManualSessionHandler) StatusUpdate(irmaAction irma.Action, status irma.Status) { }
+func (sh *ManualSessionHandler) StatusUpdate(irmaAction irma.Action, status irma.Status) {}
 func (sh *ManualSessionHandler) RequestPin(remainingAttempts int, ph PinHandler) {
 	ph(true, "12345")
 }
@@ -70,10 +70,18 @@ func (sh *ManualSessionHandler) RequestSignaturePermission(request irma.Signatur
 
 // These handlers should not be called, fail test if they are called
 func (sh *ManualSessionHandler) Cancelled(irmaAction irma.Action) { sh.t.Fail() }
-func (sh *ManualSessionHandler) MissingKeyshareEnrollment(manager irma.SchemeManagerIdentifier) {  sh.t.Fail() }
-func (sh *ManualSessionHandler) RequestIssuancePermission(request irma.IssuanceRequest, issuerName string, ph PermissionHandler) {  sh.t.Fail() }
-func (sh *ManualSessionHandler) RequestSchemeManagerPermission(manager *irma.SchemeManager, callback func(proceed bool)) {  sh.t.Fail() }
-func (sh *ManualSessionHandler) RequestVerificationPermission(request irma.DisclosureRequest, verifierName string, ph PermissionHandler) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) MissingKeyshareEnrollment(manager irma.SchemeManagerIdentifier) {
+	sh.t.Fail()
+}
+func (sh *ManualSessionHandler) RequestIssuancePermission(request irma.IssuanceRequest, issuerName string, ph PermissionHandler) {
+	sh.t.Fail()
+}
+func (sh *ManualSessionHandler) RequestSchemeManagerPermission(manager *irma.SchemeManager, callback func(proceed bool)) {
+	sh.t.Fail()
+}
+func (sh *ManualSessionHandler) RequestVerificationPermission(request irma.DisclosureRequest, verifierName string, ph PermissionHandler) {
+	sh.t.Fail()
+}
 func (sh *ManualSessionHandler) Failure(irmaAction irma.Action, err *irma.SessionError) {
 	fmt.Println(err.Err)
 	sh.t.Fail()

--- a/irmaclient/manual_session_test.go
+++ b/irmaclient/manual_session_test.go
@@ -52,7 +52,8 @@ func TestManualKeyShareSession(t *testing.T) {
 }
 
 
-func (sh *ManualSessionHandler) Success(irmaAction irma.Action) {
+func (sh *ManualSessionHandler) Success(irmaAction irma.Action, result string) {
+  fmt.Println("Result: " + result)
 	sh.c <- nil
 }
 func (sh *ManualSessionHandler) UnsatisfiableRequest(irmaAction irma.Action, missingAttributes irma.AttributeDisjunctionList) {  sh.t.Fail() }
@@ -67,7 +68,7 @@ func (sh *ManualSessionHandler) RequestSignaturePermission(request irma.Signatur
 	ph(true, &c)
 }
 
-// These handler should not be called, fail test if they are called
+// These handlers should not be called, fail test if they are called
 func (sh *ManualSessionHandler) Cancelled(irmaAction irma.Action) { sh.t.Fail() }
 func (sh *ManualSessionHandler) MissingKeyshareEnrollment(manager irma.SchemeManagerIdentifier) {  sh.t.Fail() }
 func (sh *ManualSessionHandler) RequestIssuancePermission(request irma.IssuanceRequest, issuerName string, ph PermissionHandler) {  sh.t.Fail() }

--- a/irmaclient/manual_session_test.go
+++ b/irmaclient/manual_session_test.go
@@ -1,0 +1,79 @@
+package irmaclient
+
+import (
+  "fmt"
+  "testing"
+  "github.com/credentials/irmago"
+)
+
+type ManualSessionHandler struct {
+	permissionHandler PermissionHandler
+	pinHandler        PinHandler
+	t				  *testing.T
+	c				  chan *irma.SessionError
+}
+
+var client *Client
+
+func TestManualSession(t *testing.T) {
+	request := "{\"nonce\": 0, \"message\":\"I owe you everything\",\"messageType\":\"STRING\",\"content\":[{\"label\":\"Student number (RU)\",\"attributes\":[\"irma-demo.RU.studentCard.studentID\"]}]}"
+
+	channel := make(chan *irma.SessionError)
+	manualSessionHandler := ManualSessionHandler{t: t, c: channel}
+
+	client = parseStorage(t)
+	TestAndroidParse(t)
+
+	client.NewManualSession(request, &manualSessionHandler)
+
+	teardown(t)
+
+	if err := <-channel; err != nil {
+		t.Fatal(*err)
+	}
+}
+
+func TestManualKeyShareSession(t *testing.T) {
+	keyshareRequest := "{\"nonce\": 0, \"message\":\"I owe you everything\",\"messageType\":\"STRING\",\"content\":[{\"label\":\"Student number (RU)\",\"attributes\":[\"test.test.mijnirma.email\"]}]}"
+
+	channel := make(chan *irma.SessionError)
+	manualSessionHandler := ManualSessionHandler{t: t, c: channel}
+
+	client = parseStorage(t)
+	TestAndroidParse(t)
+
+	client.NewManualSession(keyshareRequest, &manualSessionHandler)
+
+	teardown(t)
+
+	if err := <-channel; err != nil {
+		t.Fatal(*err)
+	}
+}
+
+
+func (sh *ManualSessionHandler) Success(irmaAction irma.Action) {
+	sh.c <- nil
+}
+func (sh *ManualSessionHandler) UnsatisfiableRequest(irmaAction irma.Action, missingAttributes irma.AttributeDisjunctionList) {  sh.t.Fail() }
+
+// Done in irma bridge?
+func (sh *ManualSessionHandler) StatusUpdate(irmaAction irma.Action, status irma.Status) { }
+func (sh *ManualSessionHandler) RequestPin(remainingAttempts int, ph PinHandler) {
+	ph(true, "12345")
+}
+func (sh *ManualSessionHandler) RequestSignaturePermission(request irma.SignatureRequest, requesterName string, ph PermissionHandler) {
+	c := irma.DisclosureChoice{request.Candidates[0]}
+	ph(true, &c)
+}
+
+// These handler should not be called, fail test if they are called
+func (sh *ManualSessionHandler) Cancelled(irmaAction irma.Action) { sh.t.Fail() }
+func (sh *ManualSessionHandler) MissingKeyshareEnrollment(manager irma.SchemeManagerIdentifier) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) RequestIssuancePermission(request irma.IssuanceRequest, issuerName string, ph PermissionHandler) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) RequestSchemeManagerPermission(manager *irma.SchemeManager, callback func(proceed bool)) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) RequestVerificationPermission(request irma.DisclosureRequest, verifierName string, ph PermissionHandler) {  sh.t.Fail() }
+func (sh *ManualSessionHandler) Failure(irmaAction irma.Action, err *irma.SessionError) {
+	fmt.Println(err.Err)
+	sh.t.Fail()
+}

--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -55,7 +55,6 @@ type baseSession interface {
 }
 
 type session struct {
-	baseSession
 	Action  irma.Action
 	Handler Handler
 	Version irma.Version
@@ -65,6 +64,9 @@ type session struct {
 	downloaded  *irma.IrmaIdentifierSet
 	irmaSession irma.IrmaSession
 }
+
+// We implement baseSessino for a session
+var _ baseSession = (*session)(nil)
 
 // A interactiveSession is an interactive IRMA session
 type interactiveSession struct {

--- a/irmaclient/session_test.go
+++ b/irmaclient/session_test.go
@@ -26,7 +26,7 @@ func (th TestHandler) MissingKeyshareEnrollment(manager irma.SchemeManagerIdenti
 }
 
 func (th TestHandler) StatusUpdate(action irma.Action, status irma.Status) {}
-func (th TestHandler) Success(action irma.Action) {
+func (th TestHandler) Success(action irma.Action, result string) {
 	th.c <- nil
 }
 func (th TestHandler) Cancelled(action irma.Action) {

--- a/messages.go
+++ b/messages.go
@@ -76,6 +76,7 @@ type SessionInfo struct {
 const (
 	StatusConnected     = Status("connected")
 	StatusCommunicating = Status("communicating")
+	StatusManualStarted = Status("manualStarted")
 )
 
 // Actions


### PR DESCRIPTION
This PR adds support for handling manual signature session (i.e. session started with a signature request blob, without using the IRMA API server).

Manual signature requests can be created with the [IRMA Signature App](https://github.com/privacybydesign/irma_signature_app).