### PR TITLE
Fix crashing on credentials that are too short.

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -81,15 +81,9 @@ func (al *AttributeList) Map(conf *Configuration) map[AttributeTypeIdentifier]Tr
 	if al.attrMap == nil {
 		al.attrMap = make(map[AttributeTypeIdentifier]TranslatedString)
 		ctid := al.CredentialType().Identifier()
-		strings := al.Strings()
-		ct := conf.CredentialTypes[ctid]
-		for i := range ct.AttributeTypes {
-			attrid := ct.AttributeTypes[i].GetAttributeTypeIdentifier()
-			if i < len(strings) {
-				al.attrMap[attrid] = strings[i]
-			} else {
-				al.attrMap[attrid] = nil
-			}
+		attrTypes := conf.CredentialTypes[ctid].AttributeTypes
+		for i, val := range al.Strings() {
+			al.attrMap[attrTypes[i].GetAttributeTypeIdentifier()] = val
 		}
 	}
 	return al.attrMap
@@ -159,11 +153,13 @@ func (al *AttributeList) Attribute(identifier AttributeTypeIdentifier) Translate
 	if al.CredentialType().Identifier() != identifier.CredentialTypeIdentifier() {
 		return nil
 	}
-	for i, desc := range al.CredentialType().AttributeTypes {
-		if desc.ID == string(identifier.Name()) {
-			return al.Strings()[i]
+
+	for i, val := range al.Strings() {
+		if al.CredentialType().AttributeTypes[i].ID == string(identifier.Name()) {
+			return val
 		}
 	}
+
 	return nil
 }
 

--- a/attributes.go
+++ b/attributes.go
@@ -85,7 +85,11 @@ func (al *AttributeList) Map(conf *Configuration) map[AttributeTypeIdentifier]Tr
 		ct := conf.CredentialTypes[ctid]
 		for i := range ct.AttributeTypes {
 			attrid := ct.AttributeTypes[i].GetAttributeTypeIdentifier()
-			al.attrMap[attrid] = strings[i]
+			if i < len(strings) {
+				al.attrMap[attrid] = strings[i]
+			} else {
+				al.attrMap[attrid] = nil
+			}
 		}
 	}
 	return al.attrMap


### PR DESCRIPTION
Simple fix to stop Map from crashing on credentials that have too few attributes for their type.