### PR TITLE
Fix: RootCmd.Execute() already prints the error it returns, so dont d…

### DIFF
--- a/irma/cmd/root.go
+++ b/irma/cmd/root.go
@@ -19,7 +19,6 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
…o that twice.