### PR TITLE
Changed irma session command to run updateschemes when starting.

### DIFF
--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -47,6 +47,9 @@ irma session --server http://localhost:48680 --authmethod token --key mytoken --
 		if err != nil {
 			die("", err)
 		}
+		
+		// Make sure we always run with latest configuration
+		irmaconfig.UpdateSchemes()
 
 		var result *server.SessionResult
 		url, _ := cmd.Flags().GetString("url")


### PR DESCRIPTION
This makes sure that irma session never complains about attributes that might not be in the local version of the schemes, but are in the global one.