### PR TITLE
Deprecation tags

### DIFF
--- a/descriptions.go
+++ b/descriptions.go
@@ -49,6 +49,7 @@ type Issuer struct {
 	SchemeManagerID string           `xml:"SchemeManager"`
 	ContactAddress  string
 	ContactEMail    string
+	DeprecatedSince Timestamp
 	XMLVersion      int `xml:"version,attr"`
 
 	Valid bool `xml:"-"`
@@ -67,6 +68,7 @@ type CredentialType struct {
 	XMLVersion      int              `xml:"version,attr"`
 	XMLName         xml.Name         `xml:"IssueSpecification"`
 	IssueURL        TranslatedString `xml:"IssueURL"`
+	DeprecatedSince Timestamp
 
 	Valid bool `xml:"-"`
 }

--- a/requests.go
+++ b/requests.go
@@ -651,6 +651,11 @@ func (t Timestamp) After(u Timestamp) bool {
 	return time.Time(t).After(time.Time(u))
 }
 
+// To check whether Timestamp is uninitialized
+func (t Timestamp) IsZero() bool {
+	return time.Time(t).IsZero()
+}
+
 func (t *Timestamp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(t.String(), start)
 }

--- a/requests.go
+++ b/requests.go
@@ -2,6 +2,7 @@ package irma
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -648,6 +649,19 @@ func (t Timestamp) Before(u Timestamp) bool {
 
 func (t Timestamp) After(u Timestamp) bool {
 	return time.Time(t).After(time.Time(u))
+}
+
+func (t *Timestamp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(t.String(), start)
+}
+
+func (t *Timestamp) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var ts int64
+	if err := d.DecodeElement(&ts, &start); err != nil {
+		return err
+	}
+	*t = Timestamp(time.Unix(ts, 0))
+	return nil
 }
 
 // MarshalJSON marshals a timestamp.

--- a/server/api.go
+++ b/server/api.go
@@ -47,7 +47,7 @@ type Configuration struct {
 	// Required to be set to true if URL does not begin with https:// in production mode.
 	// In this case, the server would communicate with IRMA apps over plain HTTP. You must otherwise
 	// ensure (using eg a reverse proxy with TLS enabled) that the attributes are protected in transit.
-	DisableTLS bool `json:"disable_tls" mapstructure:"disable_tls"`
+	DisableTLS bool `json:"no_tls" mapstructure:"no_tls"`
 	// (Optional) email address of server admin, for incidental notifications such as breaking API changes
 	// See https://github.com/privacybydesign/irmago/tree/master/server#specifying-an-email-address
 	// for more information


### PR DESCRIPTION
This pull request adds irmago support for deprecation tags in schemes. With these tags issuers and credentials can be deprecated without having to remove the data from the scheme. This can be done by adding a `DeprecatedSince` tag to an issuer or credential with the time of deprecation in it, i.e.

```<DeprecatedSince>1571903161</DeprecatedSince>```

This is needed to remove public key expiry warnings of deprecated keys by `irma scheme verify` and in the future potentially for deprecation warnings on the [attribute index page](https://privacybydesign.foundation/attribute-index/en/).