### PR TITLE
Fix for keyshare enrollment missing error being overruled by failure

### DIFF
--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -533,16 +533,16 @@ func (session *session) getProof() (interface{}, error) {
 
 // checkKeyshareEnrollment checks if we are enrolled into all involved keyshare servers,
 // and aborts the session if not
-func (session *session) checkKeyshareEnrollment() bool {
+func (session *session) checkKeyshareEnrollment() error {
 	for id := range session.request.Identifiers().SchemeManagers {
 		distributed := session.client.Configuration.SchemeManagers[id].Distributed()
 		_, enrolled := session.client.keyshareServers[id]
 		if distributed && !enrolled {
 			session.Handler.KeyshareEnrollmentMissing(id)
-			return false
+			return &irma.SessionError{ErrorType: irma.ErrorKeyshare, Handled: true}
 		}
 	}
-	return true
+	return nil
 }
 
 func (session *session) checkAndUpdateConfiguration() error {
@@ -561,8 +561,8 @@ func (session *session) checkAndUpdateConfiguration() error {
 	}
 
 	// Check if we are enrolled into all involved keyshare servers
-	if !session.checkKeyshareEnrollment() {
-		return &irma.SessionError{ErrorType: irma.ErrorKeyshare}
+	if err = session.checkKeyshareEnrollment(); err != nil {
+		return err
 	}
 
 	if err = session.request.Disclosure().Disclose.Validate(session.client.Configuration); err != nil {
@@ -643,7 +643,7 @@ func (session *session) delete() bool {
 }
 
 func (session *session) fail(err *irma.SessionError) {
-	if session.delete() {
+	if session.delete() && !err.Handled {
 		err.Err = errors.Wrap(err.Err, 0)
 		session.Handler.Failure(err)
 	}

--- a/messages.go
+++ b/messages.go
@@ -104,6 +104,7 @@ type SessionError struct {
 	Info         string
 	RemoteError  *RemoteError
 	RemoteStatus int
+	Handled      bool // set to true when error status is already communicated to session handler
 }
 
 // RemoteError is an error message returned by the API server on errors.

--- a/messages.go
+++ b/messages.go
@@ -104,7 +104,6 @@ type SessionError struct {
 	Info         string
 	RemoteError  *RemoteError
 	RemoteStatus int
-	Handled      bool // set to true when error status is already communicated to session handler
 }
 
 // RemoteError is an error message returned by the API server on errors.
@@ -186,6 +185,8 @@ const (
 	ErrorSerialization = ErrorType("serialization")
 	// Error in keyshare protocol
 	ErrorKeyshare = ErrorType("keyshare")
+	// The user is not enrolled at one of the keyshare servers needed for the request
+	ErrorKeyshareUnenrolled = ErrorType("keyshareUnenrolled")
 	// API server error
 	ErrorApi = ErrorType("api")
 	// Server returned unexpected or malformed response


### PR DESCRIPTION
When a user is doing a session and he has no keyshare enrollment, the current behaviour is that both a `KeyshareEnrollmentMissing` and a `Failure` event are being generated. In the end this makes that in the IRMA app the nice 'user has no account' error screen is being overrulled by a failure and an exception report.

This pull request introduces a new boolean in `SessionError` to communicate that an error already has been handled in a nice way. In this way the fail function knows it does not have to send its 'an unexpected error occurred' failure.