### PR TITLE
Non singleton refresh

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -63,6 +63,22 @@ func (al *AttributeList) Info() *CredentialInfo {
 	return al.info
 }
 
+// EqualsExceptMetadata checks whether two AttributeLists have the same attribute values.
+// The attribute containing the metadata information is skipped in this check.
+func (al *AttributeList) EqualsExceptMetadata(ol *AttributeList) bool {
+	if len(al.Ints) != len(ol.Ints) {
+		return false
+	}
+
+	// Check whether value of all attributes, except for metadata attribute, is equal
+	for i := 1; i < len(al.Ints); i++ {
+		if al.Ints[i].Cmp(ol.Ints[i]) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (al *AttributeList) Hash() string {
 	if al.h == "" {
 		bytes := []byte{}

--- a/internal/sessiontest/handlers_test.go
+++ b/internal/sessiontest/handlers_test.go
@@ -98,6 +98,7 @@ func (th TestHandler) Failure(err *irma.SessionError) {
 		th.t.Fatal(err)
 	}
 }
+func (th TestHandler) ClientReturnURLSet(clientReturnUrl string) {}
 func (th TestHandler) UnsatisfiableRequest(request irma.SessionRequest, serverName irma.TranslatedString, missing irmaclient.MissingAttributes) {
 	th.Failure(&irma.SessionError{
 		ErrorType: irma.ErrorType("UnsatisfiableRequest"),

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -96,6 +96,20 @@ func TestIssuanceOptionalSetAttributes(t *testing.T) {
 	sessionHelper(t, req, "issue", nil)
 }
 
+func TestIssuanceSameAttributesNotSingleton(t *testing.T) {
+	client, _ := parseStorage(t)
+	defer test.ClearTestStorage(t)
+
+	prevLen := len(client.CredentialInfoList())
+
+	req := getIssuanceRequest(true)
+	sessionHelper(t, req, "issue", client)
+
+	req = getIssuanceRequest(false)
+	sessionHelper(t, req, "issue", client)
+	require.Equal(t, prevLen+1, len(client.CredentialInfoList()))
+}
+
 func TestLargeAttribute(t *testing.T) {
 	client, _ := parseStorage(t)
 	defer test.ClearTestStorage(t)

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -222,9 +222,18 @@ func (client *Client) addCredential(cred *credential, storeAttributes bool) (err
 	}
 
 	// If this is a singleton credential type, ensure we have at most one by removing any previous instance
-	if !id.Empty() && cred.CredentialType().IsSingleton {
-		for len(client.attrs(id)) != 0 {
-			client.remove(id, 0, false)
+	// If a credential already exists with exactly the same attribute values (except metadata), delete the previous credential
+	if !id.Empty() {
+		if cred.CredentialType().IsSingleton {
+			for len(client.attrs(id)) != 0 {
+				_ = client.remove(id, 0, false)
+			}
+		}
+
+		for i := len(client.attrs(id)) - 1; i >= 0; i-- { // Go backwards through array because remove manipulates it
+			if client.attrs(id)[i].EqualsExceptMetadata(cred.AttributeList()) {
+				_ = client.remove(id, i, false)
+			}
 		}
 	}
 


### PR DESCRIPTION
When a credential expires that is not singleton (let's say that `pbdf.pbdf.mobilenumber` has expired) and the user refreshes/gets re-issued this credential, the current behaviour is that a new `mobilenumber` credential is added and the old, expired one is still present in the user's wallet. This means the user has to manually remove this old credential. This is not very user-friendly.

This PR proposes to delete previous credentials, when adding a new credential with exactly the same attribute values as the old one. Only expiry date and issuance time are ignored, because it is logical that these dates might differ over multiple issuance sessions. When differences are detected, nothing is done (for example because the user added another mobile number or because the issuer changed the numer format a bit), nothing is done. Then the user is responsible himself to remove the previous credentials. This to prevent that we accidentally remove a credential that is still useful to the user.

In the future it might be useful to add some message in the `irma_mobile` app to explain that the old credential will be overwritten or something such that they understand why the previous credential is gone. Personally, I think people will actually expect this behaviour where the expiry date is updated, but this might be interesting to look at.