### PR TITLE
Use verify filepath.Walk symlink fix also for sign

### DIFF
--- a/irma/cmd/sign.go
+++ b/irma/cmd/sign.go
@@ -84,8 +84,8 @@ func signManager(privatekey *ecdsa.PrivateKey, confpath string, skipverification
 
 	// Traverse dir and add file hashes to index
 	var index irma.SchemeManagerIndex = make(map[string]irma.ConfigurationFileHash)
-	err := filepath.Walk(confpath, func(path string, info os.FileInfo, err error) error {
-		return calculateFileHash(path, info, err, confpath, index)
+	err := fs.WalkDir(confpath, func(path string, info os.FileInfo) error {
+		return calculateFileHash(path, info, confpath, index)
 	})
 	if err != nil {
 		return errors.WrapPrefix(err, "Failed to calculate file index:", 0)
@@ -141,10 +141,7 @@ func readPrivateKey(path string) (*ecdsa.PrivateKey, error) {
 	return x509.ParseECPrivateKey(block.Bytes)
 }
 
-func calculateFileHash(path string, info os.FileInfo, err error, confpath string, index irma.SchemeManagerIndex) error {
-	if err != nil {
-		return err
-	}
+func calculateFileHash(path string, info os.FileInfo, confpath string, index irma.SchemeManagerIndex) error {
 	// Skip stuff we don't want
 	if info.IsDir() || // Can only sign files
 		strings.HasSuffix(path, "index") || // Skip the index file itself

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -167,7 +167,7 @@ func (conf *Configuration) ParseFolder() (err error) {
 
 	// Copy any new or updated scheme managers out of the assets into storage
 	if conf.assets != "" {
-		err = iterateSubfolders(conf.assets, func(dir string, _ os.FileInfo) error {
+		err = fs.IterateSubfolders(conf.assets, func(dir string, _ os.FileInfo) error {
 			scheme := NewSchemeManagerIdentifier(filepath.Base(dir))
 			uptodate, err := conf.isUpToDate(scheme)
 			if err != nil {
@@ -185,7 +185,7 @@ func (conf *Configuration) ParseFolder() (err error) {
 
 	// Parse scheme managers in storage
 	var mgrerr *SchemeManagerError
-	err = iterateSubfolders(conf.Path, func(dir string, _ os.FileInfo) error {
+	err = fs.IterateSubfolders(conf.Path, func(dir string, _ os.FileInfo) error {
 		manager := NewSchemeManager(filepath.Base(dir))
 		err := conf.ParseSchemeManagerFolder(dir, manager)
 		if err == nil {
@@ -437,7 +437,7 @@ func (conf *Configuration) Prune() {
 }
 
 func (conf *Configuration) parseIssuerFolders(manager *SchemeManager, path string) error {
-	return iterateSubfolders(path, func(dir string, _ os.FileInfo) error {
+	return fs.IterateSubfolders(path, func(dir string, _ os.FileInfo) error {
 		issuer := &Issuer{}
 		exists, err := conf.pathToDescription(manager, dir+"/description.xml", issuer)
 		if err != nil {
@@ -549,7 +549,7 @@ func (conf *Configuration) matchKeyPattern(issuerid IssuerIdentifier, pattern st
 // parse $schememanager/$issuer/Issues/*/description.xml
 func (conf *Configuration) parseCredentialsFolder(manager *SchemeManager, issuer *Issuer, path string) error {
 	var foundcred bool
-	err := iterateSubfolders(path, func(dir string, _ os.FileInfo) error {
+	err := fs.IterateSubfolders(path, func(dir string, _ os.FileInfo) error {
 		cred := &CredentialType{}
 		exists, err := conf.pathToDescription(manager, dir+"/description.xml", cred)
 		if err != nil {
@@ -579,53 +579,6 @@ func (conf *Configuration) parseCredentialsFolder(manager *SchemeManager, issuer
 		conf.Warnings = append(conf.Warnings, fmt.Sprintf("Issuer %s has no credential types", issuer.Identifier().String()))
 	}
 	return err
-}
-
-// iterateSubfolders iterates over the subfolders of the specified path,
-// calling the specified handler each time. If anything goes wrong, or
-// if the caller returns a non-nil error, an error is immediately returned.
-func iterateSubfolders(path string, handler func(string, os.FileInfo) error) error {
-	return iterateFiles(path, true, handler)
-}
-
-func iterateFiles(path string, onlyDirs bool, handler func(string, os.FileInfo) error) error {
-	files, err := filepath.Glob(filepath.Join(path, "*"))
-	if err != nil {
-		return err
-	}
-
-	for _, file := range files {
-		stat, err := os.Stat(file)
-		if err != nil {
-			return err
-		}
-		if onlyDirs && !stat.IsDir() {
-			continue
-		}
-		if filepath.Base(file) == ".git" {
-			continue
-		}
-		err = handler(file, stat)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// walkDir recursively walks the file tree rooted at path, following symlinks (unlike filepath.Walk).
-// Avoiding loops is the responsibility of the caller.
-func walkDir(path string, handler func(string, os.FileInfo) error) error {
-	return iterateFiles(path, false, func(p string, info os.FileInfo) error {
-		if info.IsDir() {
-			if err := handler(p, info); err != nil {
-				return err
-			}
-			return walkDir(p, handler)
-		}
-		return handler(p, info)
-	})
 }
 
 func (conf *Configuration) pathToDescription(manager *SchemeManager, path string, description interface{}) (bool, error) {
@@ -1030,7 +983,7 @@ func (conf *Configuration) parseIndex(name string, manager *SchemeManager) (Sche
 }
 
 func (conf *Configuration) checkUnsignedFiles(name string, index SchemeManagerIndex) error {
-	return walkDir(filepath.Join(conf.Path, name), func(path string, info os.FileInfo) error {
+	return fs.WalkDir(filepath.Join(conf.Path, name), func(path string, info os.FileInfo) error {
 		relpath, err := filepath.Rel(conf.Path, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
When having symlinks in your irma_configuration folder leaded to errors while verifying and signing. For `irma scheme verify` this was already fixed in [commit 6048c42](https://github.com/privacybydesign/irmago/commit/6048c42ef2541c870b9c9569fd23282bb5578d75). This fix extends this solution to also use this when doing `irma scheme sign`.