### PR TITLE
Added port mismatch warning to irma session

### DIFF
--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	"net/http"
+	neturl "net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -63,6 +64,10 @@ irma session --server http://localhost:8088 --authmethod token --key mytoken --d
 
 		if serverurl == "" {
 			port, _ := flags.GetInt("port")
+			if urlParsed, err := neturl.Parse(url); err == nil && urlParsed.Port() != string(port) {
+				logger.Warnf("Server runs on port %d and port in url is %s. If connection fails, try adding \"--port %[2]s\" flag to command.",
+					port, urlParsed.Port())
+			}
 			privatekeysPath, _ := flags.GetString("privkeys")
 			verbosity, _ := cmd.Flags().GetCount("verbose")
 			result, err = libraryRequest(request, irmaconfig, url, port, privatekeysPath, noqr, verbosity)


### PR DESCRIPTION
A mistake I myself often make when using `irma session` is that I change the port in `--url` and then I forget changing the `--port` setting too. There are scenarios thinkable in which you want another port number in the URL than on which the server is running, for example when a proxy is used in between the server and the phone. A difference in port between `--url` and the `--port` should not result in a complete failure. Therefore I would suggest at least warning the user that he is doing something that is probably not right.

Another option would be just using the port from `--url` when `--port` is not specified.