### PR TITLE
Added docs for variable port in --url to --help

### DIFF
--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -238,7 +238,7 @@ func init() {
 	flags := sessionCmd.Flags()
 	flags.SortFlags = false
 	flags.String("server", "", "External IRMA server to post request to (leave blank to use builtin library)")
-	flags.StringP("url", "u", defaulturl, "external URL to which IRMA app connects (when not using --server)")
+	flags.StringP("url", "u", defaulturl, "external URL to which IRMA app connects (when not using --server), \":port\" being replaced by --port value")
 	flags.IntP("port", "p", 48680, "port to listen at (when not using --server)")
 	flags.Bool("noqr", false, "Print JSON instead of draw QR")
 	flags.StringP("request", "r", "", "JSON session request")

--- a/server/irmad/cmd/root.go
+++ b/server/irmad/cmd/root.go
@@ -108,7 +108,7 @@ func setFlags(cmd *cobra.Command, production bool) error {
 	flags.StringP("privkeys", "k", "", "path to IRMA private keys")
 	flags.String("static-path", "", "Host files under this path as static files (leave empty to disable)")
 	flags.String("static-prefix", "/", "Host static files under this URL prefix")
-	flags.StringP("url", "u", defaulturl, "external URL to server to which the IRMA client connects")
+	flags.StringP("url", "u", defaulturl, "external URL to server to which the IRMA client connects, \":port\" being replaced by --port value")
 	flags.Bool("sse", false, "Enable server sent for status updates (experimental)")
 
 	flags.IntP("port", "p", 8088, "port at which to listen")
@@ -219,15 +219,15 @@ func configure(cmd *cobra.Command) error {
 			SchemesUpdateInterval: viper.GetInt("schemes-update"),
 			DisableSchemesUpdate:  viper.GetBool("disable-schemes-update") || viper.GetInt("schemes-update") == 0,
 			IssuerPrivateKeysPath: viper.GetString("privkeys"),
-			URL:        viper.GetString("url"),
-			DisableTLS: viper.GetBool("no-tls"),
-			Email:      viper.GetString("email"),
-			EnableSSE:  viper.GetBool("sse"),
-			Verbose:    viper.GetInt("verbose"),
-			Quiet:      viper.GetBool("quiet"),
-			LogJSON:    viper.GetBool("log-json"),
-			Logger:     logger,
-			Production: viper.GetBool("production"),
+			URL:                   viper.GetString("url"),
+			DisableTLS:            viper.GetBool("no-tls"),
+			Email:                 viper.GetString("email"),
+			EnableSSE:             viper.GetBool("sse"),
+			Verbose:               viper.GetInt("verbose"),
+			Quiet:                 viper.GetBool("quiet"),
+			LogJSON:               viper.GetBool("log-json"),
+			Logger:                logger,
+			Production:            viper.GetBool("production"),
 		},
 		Permissions: requestorserver.Permissions{
 			Disclosing: handlePermission("disclose-perms"),


### PR DESCRIPTION
When using the option `--url` the port does not have to be specified explicitly, it is filled in the url by irma server/irma session such that it corresponds with the `--port` value. To use this feature the port must be specified in the url as `:port`. For example specify `--url http://localhost:port --port 1234` instead of `--url http://localhost:1234 --port 1234`. I added this in the --help.