### PR TITLE
Non optional attribute missing

### DIFF
--- a/identifiers.go
+++ b/identifiers.go
@@ -40,12 +40,13 @@ type AttributeIdentifier struct {
 }
 
 // IrmaIdentifierSet contains a set (ensured by using map[...]struct{}) of all scheme managers,
-// all issuers, all credential types and all public keys that are involved in an IRMA session.
+// all issuers, all credential types, all public keys and all attribute types that are involved in an IRMA session.
 type IrmaIdentifierSet struct {
 	SchemeManagers  map[SchemeManagerIdentifier]struct{}
 	Issuers         map[IssuerIdentifier]struct{}
 	CredentialTypes map[CredentialTypeIdentifier]struct{}
 	PublicKeys      map[IssuerIdentifier][]int
+	AttributeTypes  map[AttributeTypeIdentifier]struct{}
 }
 
 func newIrmaIdentifierSet() *IrmaIdentifierSet {
@@ -54,6 +55,7 @@ func newIrmaIdentifierSet() *IrmaIdentifierSet {
 		Issuers:         map[IssuerIdentifier]struct{}{},
 		CredentialTypes: map[CredentialTypeIdentifier]struct{}{},
 		PublicKeys:      map[IssuerIdentifier][]int{},
+		AttributeTypes:  map[AttributeTypeIdentifier]struct{}{},
 	}
 }
 
@@ -194,6 +196,9 @@ func (set *IrmaIdentifierSet) join(other *IrmaIdentifierSet) {
 	for ct := range other.CredentialTypes {
 		set.CredentialTypes[ct] = struct{}{}
 	}
+	for at := range other.AttributeTypes {
+		set.AttributeTypes[at] = struct{}{}
+	}
 	for issuer := range other.PublicKeys {
 		if len(set.PublicKeys[issuer]) == 0 {
 			set.PublicKeys[issuer] = make([]int, 0, len(other.PublicKeys[issuer]))
@@ -227,6 +232,9 @@ func (set *IrmaIdentifierSet) allSchemes() map[SchemeManagerIdentifier]struct{} 
 	for c := range set.CredentialTypes {
 		schemes[c.IssuerIdentifier().SchemeManagerIdentifier()] = struct{}{}
 	}
+	for a := range set.AttributeTypes {
+		schemes[a.CredentialTypeIdentifier().IssuerIdentifier().SchemeManagerIdentifier()] = struct{}{}
+	}
 	return schemes
 }
 
@@ -246,6 +254,9 @@ func (set *IrmaIdentifierSet) String() string {
 	for c := range set.CredentialTypes {
 		builder.WriteString(c.String() + ", ")
 	}
+	for a := range set.AttributeTypes {
+		builder.WriteString(a.String() + ", ")
+	}
 	s := builder.String()
 	if len(s) > 0 { // strip trailing comma
 		s = s[:len(s)-2]
@@ -254,5 +265,5 @@ func (set *IrmaIdentifierSet) String() string {
 }
 
 func (set *IrmaIdentifierSet) Empty() bool {
-	return len(set.SchemeManagers) == 0 && len(set.Issuers) == 0 && len(set.CredentialTypes) == 0 && len(set.PublicKeys) == 0
+	return len(set.SchemeManagers) == 0 && len(set.Issuers) == 0 && len(set.CredentialTypes) == 0 && len(set.PublicKeys) == 0 && len(set.AttributeTypes) == 0
 }

--- a/internal/servercore/api.go
+++ b/internal/servercore/api.go
@@ -190,14 +190,14 @@ func (s *Server) StartSession(req interface{}) (*irma.Qr, string, error) {
 	request := rrequest.SessionRequest()
 	action := request.Action()
 
+	if err := s.validateRequest(request); err != nil {
+		return nil, "", err
+	}
+
 	if action == irma.ActionIssuing {
 		if err := s.validateIssuanceRequest(request.(*irma.IssuanceRequest)); err != nil {
 			return nil, "", err
 		}
-	}
-
-	if err := s.validateRequest(request); err != nil {
-		return nil, "", err
 	}
 
 	session := s.newSession(action, rrequest)

--- a/internal/servercore/api.go
+++ b/internal/servercore/api.go
@@ -190,14 +190,14 @@ func (s *Server) StartSession(req interface{}) (*irma.Qr, string, error) {
 	request := rrequest.SessionRequest()
 	action := request.Action()
 
-	if err := s.validateRequest(request); err != nil {
-		return nil, "", err
-	}
-
 	if action == irma.ActionIssuing {
 		if err := s.validateIssuanceRequest(request.(*irma.IssuanceRequest)); err != nil {
 			return nil, "", err
 		}
+	}
+
+	if err := s.validateRequest(request); err != nil {
+		return nil, "", err
 	}
 
 	session := s.newSession(action, rrequest)

--- a/internal/servercore/helpers.go
+++ b/internal/servercore/helpers.go
@@ -94,11 +94,6 @@ func (s *Server) validateIssuanceRequest(request *irma.IssuanceRequest) error {
 		}
 		cred.KeyCounter = int(privatekey.Counter)
 
-		// Check that the credential is consistent with irma_configuration
-		if err := cred.Validate(s.conf.IrmaConfiguration); err != nil {
-			return err
-		}
-
 		// Ensure the credential has an expiry date
 		defaultValidity := irma.Timestamp(time.Now().AddDate(0, 6, 0))
 		if cred.Validity == nil {

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -355,6 +355,7 @@ func TestDisclosureNonexistingCredTypeUpdateSchemeManager(t *testing.T) {
 				irma.NewCredentialTypeIdentifier("irma-demo.RU.foo"):  struct{}{},
 				irma.NewCredentialTypeIdentifier("irma-demo.baz.qux"): struct{}{},
 			},
+			AttributeTypes: map[irma.AttributeTypeIdentifier]struct{}{},
 		},
 	}
 	require.True(t, reflect.DeepEqual(expectedErr, err), "Download() returned incorrect missing identifier set")

--- a/messages.go
+++ b/messages.go
@@ -193,6 +193,8 @@ const (
 	ErrorServerResponse = ErrorType("serverResponse")
 	// Credential type not present in our Configuration
 	ErrorUnknownIdentifier = ErrorType("unknownIdentifier")
+	// Non-optional attribute not present in credential
+	ErrorRequiredAttributeMissing = ErrorType("requiredAttributeMissing")
 	// Error during downloading of credential type, issuer, or public keys
 	ErrorConfigurationDownload = ErrorType("configurationDownload")
 	// IRMA requests refers to unknown scheme manager

--- a/requests.go
+++ b/requests.go
@@ -487,7 +487,7 @@ func (cr *CredentialRequest) Validate(conf *Configuration) error {
 			}
 		}
 		if !found {
-			return errors.New("Credential request contaiins unknown attribute")
+			return errors.New("Credential request contains unknown attribute")
 		}
 	}
 

--- a/requests.go
+++ b/requests.go
@@ -417,6 +417,7 @@ func (dr *DisclosureRequest) identifiers() *IrmaIdentifierSet {
 		Issuers:         map[IssuerIdentifier]struct{}{},
 		CredentialTypes: map[CredentialTypeIdentifier]struct{}{},
 		PublicKeys:      map[IssuerIdentifier][]int{},
+		AttributeTypes:  map[AttributeTypeIdentifier]struct{}{},
 	}
 
 	_ = dr.Disclose.Iterate(func(a *AttributeRequest) error {
@@ -424,6 +425,7 @@ func (dr *DisclosureRequest) identifiers() *IrmaIdentifierSet {
 		ids.SchemeManagers[attr.CredentialTypeIdentifier().IssuerIdentifier().SchemeManagerIdentifier()] = struct{}{}
 		ids.Issuers[attr.CredentialTypeIdentifier().IssuerIdentifier()] = struct{}{}
 		ids.CredentialTypes[attr.CredentialTypeIdentifier()] = struct{}{}
+		ids.AttributeTypes[attr] = struct{}{}
 		return nil
 	})
 
@@ -540,6 +542,7 @@ func (ir *IssuanceRequest) Identifiers() *IrmaIdentifierSet {
 			SchemeManagers:  map[SchemeManagerIdentifier]struct{}{},
 			Issuers:         map[IssuerIdentifier]struct{}{},
 			CredentialTypes: map[CredentialTypeIdentifier]struct{}{},
+			AttributeTypes:  map[AttributeTypeIdentifier]struct{}{},
 			PublicKeys:      map[IssuerIdentifier][]int{},
 		}
 
@@ -547,7 +550,11 @@ func (ir *IssuanceRequest) Identifiers() *IrmaIdentifierSet {
 			issuer := credreq.CredentialTypeID.IssuerIdentifier()
 			ir.ids.SchemeManagers[issuer.SchemeManagerIdentifier()] = struct{}{}
 			ir.ids.Issuers[issuer] = struct{}{}
-			ir.ids.CredentialTypes[credreq.CredentialTypeID] = struct{}{}
+			credID := credreq.CredentialTypeID
+			ir.ids.CredentialTypes[credID] = struct{}{}
+			for attr, _ := range credreq.Attributes { // this is kind of ugly
+				ir.ids.AttributeTypes[NewAttributeTypeIdentifier(credID.String()+"."+attr)] = struct{}{}
+			}
 			if ir.ids.PublicKeys[issuer] == nil {
 				ir.ids.PublicKeys[issuer] = []int{}
 			}


### PR DESCRIPTION
This should fix the unclear server responses when non-optional attributes are missing.
For this purpose we made a distinction between identifiers from the request that are not in the configuration and vice versa. This way, we can display different error messages where necessary.
I could add an extra test case in which it actually sends a request with non-optional attributes missing, since it currently only tests if it updates after calling `Download`.