### PR TITLE
fix: check that disclosure is empty

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -524,7 +524,7 @@ func (dr *DisclosureRequest) Validate() error {
 	if dr.LDContext != LDContextDisclosureRequest {
 		return errors.New("Not a disclosure request")
 	}
-	if len(dr.Disclose) == 0 {
+	if len(dr.Identifiers().AttributeTypes) == 0 {
 		return errors.New("Disclosure request had no attributes")
 	}
 	var err error


### PR DESCRIPTION
Validation of disclosure requests now checks that the disclosure contains any attributes. This means that the server does not accept such requests. On the client side, this enforces that such a request is not even sent.