### PR TITLE
Fix: calculate expiry date using signing date instead of current date

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -45,7 +45,7 @@ type AttributeList struct {
 	*MetadataAttribute  `json:"-"`
 	Ints                []*big.Int
 	Revoked             bool `json:",omitempty"`
-	RevocationSupported bool `json:,omitempty`
+	RevocationSupported bool `json:",omitempty"`
 	strings             []TranslatedString
 	attrMap             map[AttributeTypeIdentifier]TranslatedString
 	info                *CredentialInfo


### PR DESCRIPTION
This pull request should fix the error why in the new `irmamobile` app the logs sometimes stop loading more logs.