### PR TITLE
KeyshareError no longer rebadges existing sessionerrors to ErrorKeyshare

### DIFF
--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -762,8 +762,6 @@ func (session *session) KeyshareError(manager *irma.SchemeManagerIdentifier, err
 	var ok bool
 	if serr, ok = err.(*irma.SessionError); !ok {
 		serr = &irma.SessionError{ErrorType: irma.ErrorKeyshare, Err: err}
-	} else {
-		serr.ErrorType = irma.ErrorKeyshare
 	}
 	session.fail(serr)
 }


### PR DESCRIPTION


This change is done since the rebadge did not provide sufficient value, as
rebadged errors are already recognizable enough on their own.

Fixes https://gitlab.science.ru.nl/irma/irmamobile/-/issues/414