### PR TITLE
Fix: static sessions cannot be loaded when AllowUnsignedCallbacks is disabled

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -96,8 +96,8 @@ func (conf *Configuration) Check() error {
 		conf.verifyURL,
 		conf.verifyEmail,
 		conf.verifyRevocation,
-		conf.verifyStaticSessions,
 		conf.verifyJwtPrivateKey,
+		conf.verifyStaticSessions,
 	} {
 		if err := f(); err != nil {
 			_ = LogError(err)


### PR DESCRIPTION
When checking the static sessions configuration, the JWT keys need to be loaded. Otherwise, the `conf.JwtRSAPrivateKey == nil` check will always fail.