### PR TITLE
Create separate LogoPath field in RequestorInfo for file path

### DIFF
--- a/descriptions.go
+++ b/descriptions.go
@@ -289,3 +289,13 @@ func (id *Issuer) Identifier() IssuerIdentifier {
 func (id *Issuer) SchemeManagerIdentifier() SchemeManagerIdentifier {
 	return NewSchemeManagerIdentifier(id.SchemeManagerID)
 }
+
+func (ri *RequestorInfo) logoPath(scheme *RequestorScheme) string {
+	if ri.Logo != nil {
+		logoPath := filepath.Join(scheme.path(), "assets", *ri.Logo+".png")
+		if exists, _ := common.PathExists(logoPath); exists {
+			return logoPath
+		}
+	}
+	return ""
+}

--- a/descriptions.go
+++ b/descriptions.go
@@ -125,6 +125,7 @@ type RequestorInfo struct {
 	Industry   *TranslatedString         `json:"industry"`
 	Hostnames  []string                  `json:"hostnames"`
 	Logo       *string                   `json:"logo"`
+	LogoPath   *string                   `json:"logoPath,omitempty"`
 	ValidUntil *Timestamp                `json:"valid_until"`
 	Unverified bool                      `json:"unverified"`
 }

--- a/schemes.go
+++ b/schemes.go
@@ -1193,6 +1193,13 @@ func (scheme *RequestorScheme) setPath(path string) { scheme.storagepath = path 
 
 func (scheme *RequestorScheme) parseContents(conf *Configuration) error {
 	for _, requestor := range scheme.requestors {
+		if requestor.Logo != nil {
+			logoPath := filepath.Join(scheme.path(), "assets", *requestor.Logo+".png")
+			if exists, _ := common.PathExists(logoPath); !exists {
+				return errors.Errorf("Asset could not be found for logo %s", requestor.Logo)
+			}
+			requestor.LogoPath = &logoPath
+		}
 		for _, hostname := range requestor.Hostnames {
 			if _, ok := conf.Requestors[hostname]; ok {
 				return errors.Errorf("Double occurence of hostname %s", hostname)

--- a/schemes.go
+++ b/schemes.go
@@ -1193,11 +1193,7 @@ func (scheme *RequestorScheme) setPath(path string) { scheme.storagepath = path 
 
 func (scheme *RequestorScheme) parseContents(conf *Configuration) error {
 	for _, requestor := range scheme.requestors {
-		if requestor.Logo != nil {
-			logoPath := filepath.Join(scheme.path(), "assets", *requestor.Logo+".png")
-			if exists, _ := common.PathExists(logoPath); !exists {
-				return errors.Errorf("Asset could not be found for logo %s", requestor.Logo)
-			}
+		if logoPath := requestor.logoPath(scheme); logoPath != "" {
 			requestor.LogoPath = &logoPath
 		}
 		for _, hostname := range requestor.Hostnames {
@@ -1249,7 +1245,7 @@ func (scheme *RequestorScheme) validate(conf *Configuration) (error, SchemeManag
 		if err != nil {
 			return err, SchemeManagerStatusParsingError
 		}
-		if _, err = conf.readHashedFile(filepath.Join(scheme.path(), "assets", *requestor.Logo+".png"), hash); err != nil {
+		if _, err = conf.readHashedFile(requestor.logoPath(scheme), hash); err != nil {
 			return err, SchemeManagerStatusInvalidSignature
 		}
 	}


### PR DESCRIPTION
For consistency, we also store the LogoPath in a separate field for `RequestorInfo`, just like we did for wizards (PR #118).