### PR TITLE
Respond with a 204 HTTP status code after cancelling a Session

### DIFF
--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/signed"
-	"github.com/privacybydesign/irmago"
+	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/privacybydesign/irmago/server"
 	"github.com/sirupsen/logrus"
@@ -284,7 +284,7 @@ func (s *Server) handleSessionStatusEvents(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleSessionDelete(w http.ResponseWriter, r *http.Request) {
 	r.Context().Value("session").(*session).handleDelete()
-	w.WriteHeader(200)
+	w.WriteHeader(204)
 }
 
 func (s *Server) handleSessionGet(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
According to the official HTTP/1.1 specs a successful DELETE request can be handled in various ways.

> If a DELETE method is successfully applied, the origin server SHOULD send a 202 (Accepted) status code if the action will likely succeed but has not yet been enacted, a 204 (No Content) status code if the action has been enacted and no further information is to be supplied, or a 200 (OK) status code if the action has been enacted and the response message includes a representation describing the status.

This will make sure a 204 HTTP status code is returned after successfully cancelling the session and it fixes #140 

I assumed the session will be cancelled right-away and it's not some sort of asynchronous task. If that do is the case (the session is not yet cancelled when the response is already returned) we should change the HTTP response code to a `202`.

I'm looking for some help on writing the tests for the HTTP status code. It seems there are none yet, but I'm not entirely sure what is the best way to add them and how to add them.