### PR TITLE
Shoulder surf chained sessions

### DIFF
--- a/internal/sessiontest/legacy_test.go
+++ b/internal/sessiontest/legacy_test.go
@@ -40,7 +40,7 @@ func TestWithoutPairingSupport(t *testing.T) {
 	defer func() {
 		maxClientVersion = defaultMaxVersion
 	}()
-	maxClientVersion = &irma.ProtocolVersion{Major: 2, Minor: 6}
+	maxClientVersion = &irma.ProtocolVersion{Major: 2, Minor: 7}
 
 	t.Run("TestSigningSession", TestSigningSession)
 	t.Run("TestDisclosureSession", TestDisclosureSession)

--- a/internal/sessiontest/main_test.go
+++ b/internal/sessiontest/main_test.go
@@ -275,7 +275,7 @@ func extractPrivateField(i interface{}, field string) interface{} {
 }
 
 func setPairingMethod(method irma.PairingMethod, handler *TestHandler) string {
-	optionsRequest := irma.NewOptionsRequest()
+	optionsRequest := irma.NewFrontendOptionsRequest()
 	optionsRequest.PairingMethod = method
 	options := &irma.SessionOptions{}
 	err := handler.frontendTransport.Post("frontend/options", options, optionsRequest)

--- a/internal/sessiontest/main_test.go
+++ b/internal/sessiontest/main_test.go
@@ -131,7 +131,7 @@ func getMultipleIssuanceRequest() *irma.IssuanceRequest {
 
 var TestType = "irmaserver-jwt"
 
-func startSession(t *testing.T, request irma.SessionRequest, sessiontype string) (*server.SessionPackage, irma.FrontendAuthorization) {
+func startSession(t *testing.T, request irma.SessionRequest, sessiontype string) (*server.SessionPackage, *irma.FrontendSessionRequest) {
 	var (
 		sesPkg server.SessionPackage
 		err    error
@@ -152,7 +152,7 @@ func startSession(t *testing.T, request irma.SessionRequest, sessiontype string)
 	}
 
 	require.NoError(t, err)
-	return &sesPkg, sesPkg.FrontendAuth
+	return &sesPkg, sesPkg.FrontendRequest
 }
 
 func getJwt(t *testing.T, request irma.SessionRequest, sessiontype string, alg jwt.SigningMethod) string {
@@ -219,7 +219,7 @@ func sessionHelperWithFrontendOptions(
 		defer StopRequestorServer()
 	}
 
-	sesPkg, frontendAuth := startSession(t, request, sessiontype)
+	sesPkg, frontendRequest := startSession(t, request, sessiontype)
 
 	c := make(chan *SessionResult)
 	h := &TestHandler{
@@ -232,7 +232,7 @@ func sessionHelperWithFrontendOptions(
 	if frontendOptionsHandler != nil || pairingHandler != nil {
 		h.pairingCodeChan = make(chan string)
 		h.frontendTransport = irma.NewHTTPTransport(sesPkg.SessionPtr.URL, false)
-		h.frontendTransport.SetHeader(irma.AuthorizationHeader, string(frontendAuth))
+		h.frontendTransport.SetHeader(irma.AuthorizationHeader, string(frontendRequest.Authorization))
 	}
 	if frontendOptionsHandler != nil {
 		frontendOptionsHandler(h)

--- a/internal/sessiontest/main_test.go
+++ b/internal/sessiontest/main_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Defines the maximum protocol version of an irmaclient in tests
-var maxClientVersion = &irma.ProtocolVersion{Major: 2, Minor: 7}
+var maxClientVersion = &irma.ProtocolVersion{Major: 2, Minor: 8}
 
 func TestMain(m *testing.M) {
 	// Create HTTP server for scheme managers

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -145,8 +145,8 @@ func TestIssuancePairing(t *testing.T) {
 		pairingCode = setPairingMethod(irma.PairingMethodPin, handler)
 	}
 	pairingHandler := func(handler *TestHandler) {
-		// Below protocol version 2.7 pairing is not supported, so then the pairing stage is expected to be skipped.
-		if extractClientMaxVersion(handler.client).Below(2, 7) {
+		// Below protocol version 2.8 pairing is not supported, so then the pairing stage is expected to be skipped.
+		if extractClientMaxVersion(handler.client).Below(2, 8) {
 			return
 		}
 

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -162,7 +162,7 @@ func TestIssuancePairing(t *testing.T) {
 		require.Equal(t, string(server.ErrorPairingRequired.Type), sessionErr.RemoteError.ErrorName)
 
 		// Check whether pairing cannot be disabled again after client is connected.
-		request := irma.NewOptionsRequest()
+		request := irma.NewFrontendOptionsRequest()
 		result := &irma.SessionOptions{}
 		err = handler.frontendTransport.Post("frontend/options", result, request)
 		require.Error(t, err)

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -119,7 +119,7 @@ func libraryRequest(
 	// Enable pairing if necessary
 	var sessionOptions *irma.SessionOptions
 	if pairing {
-		optionsRequest := irma.NewOptionsRequest()
+		optionsRequest := irma.NewFrontendOptionsRequest()
 		optionsRequest.PairingMethod = irma.PairingMethodPin
 		if sessionOptions, err = irmaServer.SetFrontendOptions(requestorToken, &optionsRequest); err != nil {
 			return nil, errors.WrapPrefix(err, "Failed to enable pairing", 0)
@@ -170,7 +170,7 @@ func serverRequest(
 	if pairing {
 		frontendTransport = irma.NewHTTPTransport(qr.URL, false)
 		frontendTransport.SetHeader(irma.AuthorizationHeader, string(frontendAuth))
-		optionsRequest := irma.NewOptionsRequest()
+		optionsRequest := irma.NewFrontendOptionsRequest()
 		optionsRequest.PairingMethod = irma.PairingMethodPin
 		err = frontendTransport.Post("frontend/options", sessionOptions, optionsRequest)
 		if err != nil {

--- a/irmaclient/irmaclient_test.go
+++ b/irmaclient/irmaclient_test.go
@@ -124,7 +124,7 @@ func TestCandidates(t *testing.T) {
 	// but we should also get the option to get another value
 	request := irma.NewDisclosureRequest(attrtype)
 	disjunction := request.Disclose[0]
-	request.ProtocolVersion = &irma.ProtocolVersion{Major: 2, Minor: 7}
+	request.ProtocolVersion = &irma.ProtocolVersion{Major: 2, Minor: 8}
 	attrs, satisfiable, err := client.candidatesDisCon(request, disjunction)
 	require.NoError(t, err)
 	require.True(t, satisfiable)

--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -257,10 +257,10 @@ func (session *session) getSessionInfo() {
 	session.Handler.StatusUpdate(session.Action, irma.ClientStatusCommunicating)
 
 	// Get the first IRMA protocol message and parse it
-	cr := &irma.ClientRequest{
+	cr := &irma.ClientSessionRequest{
 		Request: session.request, // As request is an interface, it needs to be initialized with a specific instance.
 	}
-	// UnmarshalJSON of ClientRequest takes into account legacy protocols, so we do not have to check that here.
+	// UnmarshalJSON of ClientSessionRequest takes into account legacy protocols, so we do not have to check that here.
 	err := session.transport.Get("", cr)
 	if err != nil {
 		session.fail(err.(*irma.SessionError))

--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -111,7 +111,8 @@ var supportedVersions = map[int][]int{
 		4, // old protocol with legacy session requests
 		5, // introduces condiscon feature
 		6, // introduces nonrevocation proofs
-		7, // introduces chained sessions and session binding
+		7, // introduces chained sessions
+		8, // introduces session binding
 	},
 }
 
@@ -233,8 +234,8 @@ func (client *Client) newQrSession(qr *irma.Qr, handler Handler) *session {
 	session.transport.SetHeader(irma.MinVersionHeader, min.String())
 	session.transport.SetHeader(irma.MaxVersionHeader, client.maxVersion.String())
 
-	// From protocol version 2.7 also an authorization header must be included.
-	if client.maxVersion.Above(2, 6) {
+	// From protocol version 2.8 also an authorization header must be included.
+	if client.maxVersion.Above(2, 7) {
 		clientAuth := common.NewSessionToken()
 		session.transport.SetHeader(irma.AuthorizationHeader, clientAuth)
 	}

--- a/messages.go
+++ b/messages.go
@@ -168,6 +168,9 @@ type Qr struct {
 	Type Action `json:"irmaqr"`
 	// Indicator to the frontend that shows whether pairing is recommended when starting the session
 	PairingRecommended bool `json:"pairingHint,omitempty"`
+
+	MinProtocolVersion *ProtocolVersion `json:"minProtocolVersion"`
+	MaxProtocolVersion *ProtocolVersion `json:"maxProtocolVersion"`
 }
 
 // Tokens to identify a session from the perspective of the different agents
@@ -387,4 +390,9 @@ type ServerSessionResponse struct {
 	// needed for legacy (un)marshaling
 	ProtocolVersion *ProtocolVersion `json:"-"`
 	SessionType     Action           `json:"-"`
+}
+
+type FrontendSessionStatus struct {
+	Status      ServerStatus `json:"status"`
+	NextSession *Qr          `json:"nextSession,omitempty"`
 }

--- a/messages.go
+++ b/messages.go
@@ -166,11 +166,6 @@ type Qr struct {
 	URL string `json:"u"`
 	// Session type (disclosing, signing, issuing)
 	Type Action `json:"irmaqr"`
-	// Indicator to the frontend that shows whether pairing is recommended when starting the session
-	PairingRecommended bool `json:"pairingHint,omitempty"`
-
-	MinProtocolVersion *ProtocolVersion `json:"minProtocolVersion"`
-	MaxProtocolVersion *ProtocolVersion `json:"maxProtocolVersion"`
 }
 
 // Tokens to identify a session from the perspective of the different agents

--- a/requests.go
+++ b/requests.go
@@ -227,6 +227,18 @@ type FrontendOptionsRequest struct {
 	PairingMethod PairingMethod `json:"pairingMethod"`
 }
 
+// FrontendSessionRequest contains session parameters for the frontend.
+type FrontendSessionRequest struct {
+	// Authorization token to access frontend endpoints.
+	Authorization FrontendAuthorization `json:"authorization"`
+	// PairingRecommended indictes to the frontend that pairing is recommended when starting the session.
+	PairingRecommended bool `json:"pairingHint,omitempty"`
+	// MinProtocolVersion that the server supports for the frontend protocol.
+	MinProtocolVersion *ProtocolVersion `json:"minProtocolVersion"`
+	// MaxProtocolVersion that the server supports for the frontend protocol.
+	MaxProtocolVersion *ProtocolVersion `json:"maxProtocolVersion"`
+}
+
 type RevocationRequest struct {
 	LDContext      string                   `json:"@context,omitempty"`
 	CredentialType CredentialTypeIdentifier `json:"type"`

--- a/requests.go
+++ b/requests.go
@@ -19,14 +19,14 @@ import (
 )
 
 const (
-	LDContextDisclosureRequest = "https://irma.app/ld/request/disclosure/v2"
-	LDContextSignatureRequest  = "https://irma.app/ld/request/signature/v2"
-	LDContextIssuanceRequest   = "https://irma.app/ld/request/issuance/v2"
-	LDContextRevocationRequest = "https://irma.app/ld/request/revocation/v1"
-	LDContextOptionsRequest    = "https://irma.app/ld/request/options/v1"
-	LDContextClientRequest     = "https://irma.app/ld/request/client/v1"
-	LDContextSessionOptions    = "https://irma.app/ld/options/v1"
-	DefaultJwtValidity         = 120
+	LDContextDisclosureRequest      = "https://irma.app/ld/request/disclosure/v2"
+	LDContextSignatureRequest       = "https://irma.app/ld/request/signature/v2"
+	LDContextIssuanceRequest        = "https://irma.app/ld/request/issuance/v2"
+	LDContextRevocationRequest      = "https://irma.app/ld/request/revocation/v1"
+	LDContextFrontendOptionsRequest = "https://irma.app/ld/request/frontendoptions/v1"
+	LDContextClientRequest          = "https://irma.app/ld/request/client/v1"
+	LDContextSessionOptions         = "https://irma.app/ld/options/v1"
+	DefaultJwtValidity              = 120
 )
 
 // BaseRequest contains information used by all IRMA session types, such the context and nonce,
@@ -221,8 +221,8 @@ const (
 	PairingMethodPin  = "pin"
 )
 
-// An OptionsRequest asks for a options change of a particular session.
-type OptionsRequest struct {
+// An FrontendOptionsRequest asks for a options change of a particular session.
+type FrontendOptionsRequest struct {
 	LDContext     string        `json:"@context,omitempty"`
 	PairingMethod PairingMethod `json:"pairingMethod"`
 }
@@ -1124,16 +1124,16 @@ func NewAttributeRequest(attr string) AttributeRequest {
 	return AttributeRequest{Type: NewAttributeTypeIdentifier(attr)}
 }
 
-// NewOptionsRequest returns a new options request initialized with default values for each option
-func NewOptionsRequest() OptionsRequest {
-	return OptionsRequest{
-		LDContext:     LDContextOptionsRequest,
+// NewFrontendOptionsRequest returns a new options request initialized with default values for each option
+func NewFrontendOptionsRequest() FrontendOptionsRequest {
+	return FrontendOptionsRequest{
+		LDContext:     LDContextFrontendOptionsRequest,
 		PairingMethod: PairingMethodNone,
 	}
 }
 
-func (or *OptionsRequest) Validate() error {
-	if or.LDContext != LDContextOptionsRequest {
+func (or *FrontendOptionsRequest) Validate() error {
+	if or.LDContext != LDContextFrontendOptionsRequest {
 		return errors.New("Not an options request")
 	}
 	return nil

--- a/requests.go
+++ b/requests.go
@@ -1146,7 +1146,7 @@ func NewFrontendOptionsRequest() FrontendOptionsRequest {
 
 func (or *FrontendOptionsRequest) Validate() error {
 	if or.LDContext != LDContextFrontendOptionsRequest {
-		return errors.New("Not an options request")
+		return errors.New("Not a frontend options request")
 	}
 	return nil
 }

--- a/requests.go
+++ b/requests.go
@@ -24,7 +24,7 @@ const (
 	LDContextIssuanceRequest        = "https://irma.app/ld/request/issuance/v2"
 	LDContextRevocationRequest      = "https://irma.app/ld/request/revocation/v1"
 	LDContextFrontendOptionsRequest = "https://irma.app/ld/request/frontendoptions/v1"
-	LDContextClientRequest          = "https://irma.app/ld/request/client/v1"
+	LDContextClientSessionRequest   = "https://irma.app/ld/request/client/v1"
 	LDContextSessionOptions         = "https://irma.app/ld/options/v1"
 	DefaultJwtValidity              = 120
 )
@@ -259,8 +259,8 @@ type SessionOptions struct {
 	PairingCode   string        `json:"pairingCode,omitempty"`
 }
 
-// ClientRequest contains all information irmaclient needs to know to initiate a session.
-type ClientRequest struct {
+// ClientSessionRequest contains all information irmaclient needs to know to initiate a session.
+type ClientSessionRequest struct {
 	LDContext       string           `json:"@context,omitempty"`
 	ProtocolVersion *ProtocolVersion `json:"protocolVersion,omitempty"`
 	Options         *SessionOptions  `json:"options,omitempty"`
@@ -1151,14 +1151,14 @@ func (or *FrontendOptionsRequest) Validate() error {
 	return nil
 }
 
-func (cr *ClientRequest) UnmarshalJSON(data []byte) error {
+func (cr *ClientSessionRequest) UnmarshalJSON(data []byte) error {
 	// Unmarshal in alias first to prevent infinite recursion
-	type alias ClientRequest
+	type alias ClientSessionRequest
 	err := json.Unmarshal(data, (*alias)(cr))
 	if err != nil {
 		return err
 	}
-	if cr.LDContext == LDContextClientRequest {
+	if cr.LDContext == LDContextClientSessionRequest {
 		return nil
 	}
 
@@ -1167,7 +1167,7 @@ func (cr *ClientRequest) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	cr.LDContext = LDContextClientRequest
+	cr.LDContext = LDContextClientSessionRequest
 	cr.ProtocolVersion = cr.Request.Base().ProtocolVersion
 	cr.Options = &SessionOptions{
 		LDContext:     LDContextSessionOptions,
@@ -1176,8 +1176,8 @@ func (cr *ClientRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (cr *ClientRequest) Validate() error {
-	if cr.LDContext != LDContextClientRequest {
+func (cr *ClientSessionRequest) Validate() error {
+	if cr.LDContext != LDContextClientSessionRequest {
 		return errors.New("Not a client request")
 	}
 	// The 'Request' field is not required. When this field is empty, we have to skip the validation.

--- a/server/api.go
+++ b/server/api.go
@@ -26,9 +26,9 @@ import (
 var Logger *logrus.Logger = logrus.StandardLogger()
 
 type SessionPackage struct {
-	SessionPtr   *irma.Qr                   `json:"sessionPtr"`
-	Token        irma.RequestorToken        `json:"token"`
-	FrontendAuth irma.FrontendAuthorization `json:"frontendAuth"`
+	SessionPtr      *irma.Qr                     `json:"sessionPtr"`
+	Token           irma.RequestorToken          `json:"token"`
+	FrontendRequest *irma.FrontendSessionRequest `json:"frontendRequest"`
 }
 
 // SessionResult contains session information such as the session status, type, possible errors,

--- a/server/api.go
+++ b/server/api.go
@@ -65,9 +65,10 @@ type LegacySessionResult struct {
 }
 
 const (
-	ComponentRevocation = "revocation"
-	ComponentSession    = "session"
-	ComponentStatic     = "static"
+	ComponentRevocation      = "revocation"
+	ComponentSession         = "session"
+	ComponentFrontendSession = "frontendsession"
+	ComponentStatic          = "static"
 )
 
 const (

--- a/server/irmac/irmac.go
+++ b/server/irmac/irmac.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	irma "github.com/privacybydesign/irmago"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+
+	irma "github.com/privacybydesign/irmago"
 
 	"github.com/privacybydesign/irmago/server"
 	"github.com/privacybydesign/irmago/server/irmaserver"
@@ -50,10 +51,10 @@ func Initialize(IrmaConfiguration *C.char) *C.char {
 func StartSession(requestString *C.char) (r *C.char) {
 	// Create struct for return information
 	result := struct {
-		IrmaQr         string
-		RequestorToken string
-		FrontendAuth   string
-		Error          string
+		IrmaQr          string
+		RequestorToken  string
+		FrontendRequest *irma.FrontendSessionRequest
+		Error           string
 	}{}
 	defer func() {
 		j, _ := json.Marshal(result)
@@ -67,7 +68,7 @@ func StartSession(requestString *C.char) (r *C.char) {
 	}
 
 	// Run the actual core function
-	qr, requestorToken, frontendAuth, err := s.StartSession(C.GoString(requestString), nil)
+	qr, requestorToken, frontendRequest, err := s.StartSession(C.GoString(requestString), nil)
 
 	// And properly return the result
 	if err != nil {
@@ -82,7 +83,7 @@ func StartSession(requestString *C.char) (r *C.char) {
 	// return actual results
 	result.IrmaQr = string(qrJson)
 	result.RequestorToken = string(requestorToken)
-	result.FrontendAuth = string(frontendAuth)
+	result.FrontendRequest = frontendRequest
 	return
 }
 

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -116,6 +116,7 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 		r.Get("/statusevents", s.handleSessionStatusEvents)
 		r.Route("/frontend", func(r chi.Router) {
 			r.Use(s.frontendMiddleware)
+			r.Get("/status", s.handleFrontendStatus)
 			r.Post("/options", s.handleFrontendOptionsPost)
 			r.Post("/pairingcompleted", s.handleFrontendPairingCompleted)
 		})
@@ -224,6 +225,8 @@ func (s *Server) StartSession(req interface{}, handler server.SessionHandler,
 		Type:               action,
 		URL:                s.conf.URL + "session/" + string(session.clientToken),
 		PairingRecommended: pairingRecommended,
+		MinProtocolVersion: minFrontendProtocolVersion,
+		MaxProtocolVersion: maxFrontendProtocolVersion,
 	}, session.requestorToken, session.frontendAuth, nil
 }
 

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -196,7 +196,9 @@ func (s *Server) StartSession(req interface{}, handler server.SessionHandler,
 	}
 
 	pairingRecommended := false
-	if action == irma.ActionDisclosing {
+	if rrequest.Base().NextSession != nil && rrequest.Base().NextSession.URL != "" {
+		pairingRecommended = true
+	} else if action == irma.ActionDisclosing {
 		err := request.Disclosure().Disclose.Iterate(func(attr *irma.AttributeRequest) error {
 			if attr.Value != nil {
 				pairingRecommended = true

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -117,6 +117,7 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 		r.Route("/frontend", func(r chi.Router) {
 			r.Use(s.frontendMiddleware)
 			r.Get("/status", s.handleFrontendStatus)
+			r.Get("/statusevents", s.handleFrontendStatusEvents)
 			r.Post("/options", s.handleFrontendOptionsPost)
 			r.Post("/pairingcompleted", s.handleFrontendPairingCompleted)
 		})
@@ -345,6 +346,7 @@ func (s *Server) SubscribeServerSentEvents(w http.ResponseWriter, r *http.Reques
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 		s.serverSentEvents.SendMessage("session/"+token, sse.NewMessage("", "", "open"))
+		s.serverSentEvents.SendMessage("frontendsession/"+token, sse.NewMessage("", "", "open"))
 	}()
 	s.serverSentEvents.ServeHTTP(w, r)
 	return nil

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -274,10 +274,10 @@ func (s *Server) CancelSession(requestorToken irma.RequestorToken) error {
 // Returns the updated session options struct. Frontend options can only be
 // changed when the client is not connected yet. Otherwise an error is returned.
 // Options that are not specified in the request, keep their old value.
-func SetFrontendOptions(requestorToken irma.RequestorToken, request *irma.OptionsRequest) (*irma.SessionOptions, error) {
+func SetFrontendOptions(requestorToken irma.RequestorToken, request *irma.FrontendOptionsRequest) (*irma.SessionOptions, error) {
 	return s.SetFrontendOptions(requestorToken, request)
 }
-func (s *Server) SetFrontendOptions(requestorToken irma.RequestorToken, request *irma.OptionsRequest) (*irma.SessionOptions, error) {
+func (s *Server) SetFrontendOptions(requestorToken irma.RequestorToken, request *irma.FrontendOptionsRequest) (*irma.SessionOptions, error) {
 	session := s.sessions.get(requestorToken)
 	if session == nil {
 		return nil, server.LogError(errors.Errorf("can't set frontend options of unknown session %s", requestorToken))

--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -48,9 +48,9 @@ func (session *session) handleGetClientRequest(min, max *irma.ProtocolVersion, c
 		return nil, session.fail(server.ErrorProtocolVersion, "")
 	}
 
-	// Protocol versions below 2.7 don't include an authorization header. Therefore skip the authorization
+	// Protocol versions below 2.8 don't include an authorization header. Therefore skip the authorization
 	// header presence check if a lower version is used.
-	if clientAuth == "" && session.version.Above(2, 6) {
+	if clientAuth == "" && session.version.Above(2, 7) {
 		return nil, session.fail(server.ErrorIrmaUnauthorized, "No authorization header provided")
 	}
 	session.clientAuth = clientAuth
@@ -72,7 +72,7 @@ func (session *session) handleGetClientRequest(min, max *irma.ProtocolVersion, c
 	logger.WithFields(logrus.Fields{"version": session.version.String()}).Debugf("Protocol version negotiated")
 	session.request.Base().ProtocolVersion = session.version
 
-	if session.options.PairingMethod != irma.PairingMethodNone && session.version.Above(2, 6) {
+	if session.options.PairingMethod != irma.PairingMethodNone && session.version.Above(2, 7) {
 		session.setStatus(irma.ServerStatusPairing)
 	} else {
 		session.setStatus(irma.ServerStatusConnected)
@@ -84,7 +84,7 @@ func (session *session) handleGetClientRequest(min, max *irma.ProtocolVersion, c
 		return legacy, nil
 	}
 
-	if session.version.Below(2, 7) {
+	if session.version.Below(2, 8) {
 		// These versions do not support the ClientSessionRequest format, so send the SessionRequest.
 		request, err := session.getRequest()
 		if err != nil {
@@ -425,7 +425,7 @@ func (s *Server) handleSessionGet(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSessionGetRequest(w http.ResponseWriter, r *http.Request) {
 	session := r.Context().Value("session").(*session)
-	if session.version.Below(2, 7) {
+	if session.version.Below(2, 8) {
 		server.WriteError(w, server.ErrorUnexpectedRequest, "Endpoint is not support in used protocol version")
 		return
 	}

--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -309,6 +309,7 @@ func (s *Server) startNext(session *session, res *irma.ServerSessionResponse) er
 	if err != nil {
 		return err
 	}
+	session.next = qr
 
 	// All attributes that were disclosed in the previous session, as well as any attributes
 	// from sessions before that, need to be disclosed in the new session as well
@@ -433,6 +434,12 @@ func (s *Server) handleSessionGetRequest(w http.ResponseWriter, r *http.Request)
 		rerr = session.fail(server.ErrorRevocation, err.Error())
 	}
 	server.WriteResponse(w, request, rerr)
+}
+
+func (s *Server) handleFrontendStatus(w http.ResponseWriter, r *http.Request) {
+	session := r.Context().Value("session").(*session)
+	status := irma.FrontendSessionStatus{Status: session.status, NextSession: session.next}
+	server.WriteResponse(w, status, nil)
 }
 
 func (s *Server) handleFrontendOptionsPost(w http.ResponseWriter, r *http.Request) {

--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -457,7 +457,7 @@ func (s *Server) handleFrontendStatusEvents(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleFrontendOptionsPost(w http.ResponseWriter, r *http.Request) {
-	optionsRequest := &irma.OptionsRequest{}
+	optionsRequest := &irma.FrontendOptionsRequest{}
 	bts, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		server.WriteError(w, server.ErrorMalformedInput, err.Error())

--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -315,6 +315,7 @@ func (s *Server) startNext(session *session, res *irma.ServerSessionResponse) er
 	// from sessions before that, need to be disclosed in the new session as well
 	newsession := s.sessions.get(token)
 	newsession.implicitDisclosure = disclosed
+	newsession.frontendAuth = session.frontendAuth
 	res.NextSession = qr
 
 	return nil

--- a/server/irmaserver/handle.go
+++ b/server/irmaserver/handle.go
@@ -85,7 +85,7 @@ func (session *session) handleGetClientRequest(min, max *irma.ProtocolVersion, c
 	}
 
 	if session.version.Below(2, 7) {
-		// These versions do not support the ClientRequest format, so send the SessionRequest.
+		// These versions do not support the ClientSessionRequest format, so send the SessionRequest.
 		request, err := session.getRequest()
 		if err != nil {
 			return nil, session.fail(server.ErrorRevocation, err.Error())

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -64,18 +64,18 @@ func (session *session) onUpdate() {
 // Checks whether requested options are valid in the current session context.
 func (session *session) updateFrontendOptions(request *irma.OptionsRequest) (*irma.SessionOptions, error) {
 	if session.status != irma.ServerStatusInitialized {
-		return nil, errors.New("Frontend options cannot be updated when client is already connected")
+		return nil, errors.New("Frontend options can only be updated when session is in initialized state")
 	}
-	if request.PairingMethod != "" {
-		if request.PairingMethod == irma.PairingMethodNone {
-			session.options.PairingCode = ""
-		} else if request.PairingMethod == irma.PairingMethodPin {
-			session.options.PairingCode = common.NewPairingCode()
-		} else {
-			return nil, errors.New("Pairing method unknown")
-		}
-		session.options.PairingMethod = request.PairingMethod
+	if request.PairingMethod == "" {
+		return &session.options, nil
+	} else if request.PairingMethod == irma.PairingMethodNone {
+		session.options.PairingCode = ""
+	} else if request.PairingMethod == irma.PairingMethodPin {
+		session.options.PairingCode = common.NewPairingCode()
+	} else {
+		return nil, errors.New("Pairing method unknown")
 	}
+	session.options.PairingMethod = request.PairingMethod
 	return &session.options, nil
 }
 

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -308,9 +308,9 @@ func (session *session) getProofP(commitments *irma.IssueCommitmentMessage, sche
 	return session.kssProofs[scheme], nil
 }
 
-func (session *session) getClientRequest() (*irma.ClientRequest, error) {
-	info := irma.ClientRequest{
-		LDContext:       irma.LDContextClientRequest,
+func (session *session) getClientRequest() (*irma.ClientSessionRequest, error) {
+	info := irma.ClientSessionRequest{
+		LDContext:       irma.LDContextClientSessionRequest,
 		ProtocolVersion: session.version,
 		Options:         &session.options,
 	}

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -67,7 +67,7 @@ func (session *session) onUpdate() {
 }
 
 // Checks whether requested options are valid in the current session context.
-func (session *session) updateFrontendOptions(request *irma.OptionsRequest) (*irma.SessionOptions, error) {
+func (session *session) updateFrontendOptions(request *irma.FrontendOptionsRequest) (*irma.SessionOptions, error) {
 	if session.status != irma.ServerStatusInitialized {
 		return nil, errors.New("Frontend options can only be updated when session is in initialized state")
 	}

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -50,6 +50,8 @@ func (session *session) onUpdate() {
 		}
 	}
 
+	frontendstatus, _ := json.Marshal(irma.FrontendSessionStatus{Status: session.status, NextSession: session.next})
+
 	if session.sse == nil {
 		return
 	}
@@ -58,6 +60,9 @@ func (session *session) onUpdate() {
 	)
 	session.sse.SendMessage("session/"+string(session.requestorToken),
 		sse.SimpleMessage(fmt.Sprintf(`"%s"`, session.status)),
+	)
+	session.sse.SendMessage("frontendsession/"+string(session.clientToken),
+		sse.SimpleMessage(string(frontendstatus)),
 	)
 }
 
@@ -424,6 +429,8 @@ func eventServer(conf *server.Configuration) *sse.Server {
 			switch ssectx.(common.SSECtx).Component {
 			case server.ComponentSession:
 				return "session/" + ssectx.(common.SSECtx).Arg
+			case server.ComponentFrontendSession:
+				return "frontendsession/" + ssectx.(common.SSECtx).Arg
 			case server.ComponentRevocation:
 				return "revocation/" + ssectx.(common.SSECtx).Arg
 			default:

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -78,7 +78,7 @@ const (
 
 var (
 	minProtocolVersion = irma.NewVersion(2, 4)
-	maxProtocolVersion = irma.NewVersion(2, 7)
+	maxProtocolVersion = irma.NewVersion(2, 8)
 
 	minFrontendProtocolVersion = irma.NewVersion(1, 0)
 	maxFrontendProtocolVersion = irma.NewVersion(1, 1)

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -28,6 +28,7 @@ type session struct {
 	request            irma.SessionRequest
 	legacyCompatible   bool // if the request is convertible to pre-condiscon format
 	implicitDisclosure irma.AttributeConDisCon
+	next               *irma.Qr
 
 	options        irma.SessionOptions
 	status         irma.ServerStatus
@@ -78,6 +79,9 @@ const (
 var (
 	minProtocolVersion = irma.NewVersion(2, 4)
 	maxProtocolVersion = irma.NewVersion(2, 7)
+
+	minFrontendProtocolVersion = irma.NewVersion(1, 0)
+	maxFrontendProtocolVersion = irma.NewVersion(1, 1)
 )
 
 func (s *memorySessionStore) get(t irma.RequestorToken) *session {

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -114,6 +114,7 @@ func (s *memorySessionStore) stop() {
 		if session.sse != nil {
 			session.sse.CloseChannel("session/" + string(session.requestorToken))
 			session.sse.CloseChannel("session/" + string(session.clientToken))
+			session.sse.CloseChannel("frontendsession/" + string(session.clientToken))
 		}
 	}
 }
@@ -152,6 +153,7 @@ func (s *memorySessionStore) deleteExpired() {
 		if session.sse != nil {
 			session.sse.CloseChannel("session/" + string(session.requestorToken))
 			session.sse.CloseChannel("session/" + string(session.clientToken))
+			session.sse.CloseChannel("frontendsession/" + string(session.clientToken))
 		}
 		delete(s.client, session.clientToken)
 		delete(s.requestor, token)

--- a/server/requestorserver/server.go
+++ b/server/requestorserver/server.go
@@ -512,16 +512,16 @@ func (s *Server) createSession(w http.ResponseWriter, requestor string, rrequest
 	}
 
 	// Everything is authenticated and parsed, we're good to go!
-	qr, requestorToken, frontendAuth, err := s.irmaserv.StartSession(rrequest, s.doResultCallback)
+	qr, requestorToken, frontendRequest, err := s.irmaserv.StartSession(rrequest, s.doResultCallback)
 	if err != nil {
 		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
 		return
 	}
 
 	server.WriteJson(w, server.SessionPackage{
-		SessionPtr:   qr,
-		Token:        requestorToken,
-		FrontendAuth: frontendAuth,
+		SessionPtr:      qr,
+		Token:           requestorToken,
+		FrontendRequest: frontendRequest,
 	})
 }
 

--- a/wait_status.go
+++ b/wait_status.go
@@ -2,9 +2,10 @@ package irma
 
 import (
 	"context"
-	sseclient "github.com/sietseringers/go-sse"
 	"strings"
 	"time"
+
+	sseclient "github.com/sietseringers/go-sse"
 )
 
 const pollInterval = 1000 * time.Millisecond
@@ -30,15 +31,16 @@ func subscribeSSE(transport *HTTPTransport, statuschan chan ServerStatus, errorc
 	go func() {
 		for {
 			e := <-events
-			if e != nil && e.Type != "open" {
-				status := ServerStatus(strings.Trim(string(e.Data), `"`))
-				statuschan <- status
-				if untilNextOnly || status.Finished() {
-					errorchan <- nil
-					cancelled = true
-					cancel()
-					return
-				}
+			if e == nil || e.Type == "open" {
+				return
+			}
+			status := ServerStatus(strings.Trim(string(e.Data), `"`))
+			statuschan <- status
+			if untilNextOnly || status.Finished() {
+				errorchan <- nil
+				cancelled = true
+				cancel()
+				return
 			}
 		}
 	}()

--- a/wait_status.go
+++ b/wait_status.go
@@ -32,7 +32,7 @@ func subscribeSSE(transport *HTTPTransport, statuschan chan ServerStatus, errorc
 		for {
 			e := <-events
 			if e == nil || e.Type == "open" {
-				return
+				continue
 			}
 			status := ServerStatus(strings.Trim(string(e.Data), `"`))
 			statuschan <- status


### PR DESCRIPTION
* Adds new `/irma/frontend/status` and `/irma/frontend/statusevents` endpoints which returns the session status as well as the session pointer to the next session, if applicable
* Instead of an `irma.FrontendAuthorization`, the `StartSession()` function of the `irmaserver` library and the `POST /session` endpoint of the `irma server` now return a new struct, `FrontendSessionRequest`, which contains all data relevant to the frontend:
   * the frontend authorization token
   * new minimum and maximum protocol versions indicating to the frontend the availability of the new status endpoints
   * the `PairingRecommended` which was previously included in `irma.Qr`