### PR TITLE
Bump gabi to rangeproof supporting version

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/eknkc/basex"
 	"github.com/go-errors/errors"
-	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 )
 
 const (
@@ -38,7 +38,7 @@ type metadataField struct {
 // metadataAttribute represents a metadata attribute. Contains the credential type, signing date, validity, and the public key counter.
 type MetadataAttribute struct {
 	Int  *big.Int
-	pk   *gabi.PublicKey
+	pk   *gabikeys.PublicKey
 	Conf *Configuration
 }
 
@@ -248,7 +248,7 @@ func (attr *MetadataAttribute) Bytes() []byte {
 
 // PublicKey extracts identifier of the Idemix public key with which this instance was signed,
 // and returns this public key.
-func (attr *MetadataAttribute) PublicKey() (*gabi.PublicKey, error) {
+func (attr *MetadataAttribute) PublicKey() (*gabikeys.PublicKey, error) {
 	if attr.pk == nil {
 		var err error
 		attr.pk, err = attr.Conf.PublicKey(attr.CredentialType().IssuerIdentifier(), attr.KeyCounter())

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/privacybydesign/gabi v0.0.0-20210311130659-b4e094b964d8
+	github.com/privacybydesign/gabi v0.0.0-20210409092845-6113e0d3ec81
 	github.com/sietseringers/cobra v1.0.1-0.20200909200314-c50c3838234b
 	github.com/sietseringers/go-sse v0.0.0-20200801161811-e2cf2c63ca50
 	github.com/sietseringers/pflag v1.0.4-0.20200909193609-0cde7e893819

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652 h1:cglj/IsZVP
 github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652/go.mod h1:HQ6L5rKBY7qaqcheK6zpaVf7fhGWD0PvUAXJTDws+0M=
 github.com/privacybydesign/gabi v0.0.0-20210311130659-b4e094b964d8 h1:nDH/LwI33DuTBcFGXtrPg/rVviwqeypayf3RKGbyUsk=
 github.com/privacybydesign/gabi v0.0.0-20210311130659-b4e094b964d8/go.mod h1:HQ6L5rKBY7qaqcheK6zpaVf7fhGWD0PvUAXJTDws+0M=
+github.com/privacybydesign/gabi v0.0.0-20210409092845-6113e0d3ec81 h1:tqsIByctPGR225Tj3fYFdkeVeFz+LOsBjTInnkr6Y2Y=
+github.com/privacybydesign/gabi v0.0.0-20210409092845-6113e0d3ec81/go.mod h1:HQ6L5rKBY7qaqcheK6zpaVf7fhGWD0PvUAXJTDws+0M=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/irma/cmd/genkeypair.go
+++ b/irma/cmd/genkeypair.go
@@ -29,7 +29,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/privacybydesign/gabi"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/sietseringers/cobra"
 
 	"github.com/go-errors/errors"
@@ -114,11 +114,11 @@ var genkeypairCmd = &cobra.Command{
 		}
 
 		// Now generate the key pair
-		sysParams, ok := gabi.DefaultSystemParameters[keylength]
+		sysParams, ok := gabikeys.DefaultSystemParameters[keylength]
 		if !ok {
-			return fmt.Errorf("Unsupported key length, should be one of %v", gabi.DefaultKeyLengths)
+			return fmt.Errorf("Unsupported key length, should be one of %v", gabikeys.DefaultKeyLengths)
 		}
-		privk, pubk, err := gabi.GenerateKeyPair(sysParams, numAttributes, counter, expiryDate)
+		privk, pubk, err := gabikeys.GenerateKeyPair(sysParams, numAttributes, counter, expiryDate)
 		if err != nil {
 			return err
 		}

--- a/irma/cmd/issuer-keygen.go
+++ b/irma/cmd/issuer-keygen.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
-	"github.com/privacybydesign/gabi"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/sietseringers/cobra"
 )
@@ -89,11 +89,11 @@ IRMA applications.`,
 
 		// Now generate the key pair
 		fmt.Println("Generating keys (may take several minutes)")
-		sysParams, ok := gabi.DefaultSystemParameters[keylength]
+		sysParams, ok := gabikeys.DefaultSystemParameters[keylength]
 		if !ok {
-			return errors.Errorf("Unsupported key length, should be one of %v", gabi.DefaultKeyLengths)
+			return errors.Errorf("Unsupported key length, should be one of %v", gabikeys.DefaultKeyLengths)
 		}
-		privk, pubk, err := gabi.GenerateKeyPair(sysParams, numAttributes, counter, expiryDate)
+		privk, pubk, err := gabikeys.GenerateKeyPair(sysParams, numAttributes, counter, expiryDate)
 		if err != nil {
 			return err
 		}

--- a/irma/cmd/issuer-keyprove.go
+++ b/irma/cmd/issuer-keyprove.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/keyproof"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/sietseringers/cobra"
@@ -70,13 +70,13 @@ may be used.`,
 		}
 
 		// Try to read public key
-		pk, err := gabi.NewPublicKeyFromFile(pubkeyfile)
+		pk, err := gabikeys.NewPublicKeyFromFile(pubkeyfile)
 		if err != nil {
 			die("Could not read public key", err)
 		}
 
 		// Try to read private key
-		sk, err := gabi.NewPrivateKeyFromFile(privkeyfile, false)
+		sk, err := gabikeys.NewPrivateKeyFromFile(privkeyfile, false)
 		if err != nil {
 			die("Could not read private key", err)
 		}

--- a/irma/cmd/issuer-keyverify.go
+++ b/irma/cmd/issuer-keyverify.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/keyproof"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/sietseringers/cobra"
@@ -66,7 +66,7 @@ On machines of 2 - 3 GHz verification will take some 5 - 15 minutes, during whic
 		}
 
 		// Try to read public key
-		pk, err := gabi.NewPublicKeyFromFile(pubkeyfile)
+		pk, err := gabikeys.NewPublicKeyFromFile(pubkeyfile)
 		if err != nil {
 			die("Error reading public key", err)
 		}

--- a/irma/cmd/meta.go
+++ b/irma/cmd/meta.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
-	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/sietseringers/cobra"
@@ -60,7 +60,7 @@ func printMetadataAttr(metaint *big.Int, confpath string) error {
 
 	meta := irma.MetadataFromInt(metaint, conf)
 	typ := meta.CredentialType()
-	var key *gabi.PublicKey
+	var key *gabikeys.PublicKey
 
 	if typ == nil {
 		fmt.Println("Unknown credential type, hash:", base64.StdEncoding.EncodeToString(meta.CredentialTypeHash()))

--- a/irma/cmd/revocation-keypair.go
+++ b/irma/cmd/revocation-keypair.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/privacybydesign/gabi"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/sietseringers/cobra"
 )
 
@@ -13,7 +13,7 @@ This is required before credential types requiring revocation can be issued unde
 (New keypairs generated with "irma scheme issuer keygen" already support revocation.)`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		sk, err := gabi.NewPrivateKeyFromFile(args[0], false)
+		sk, err := gabikeys.NewPrivateKeyFromFile(args[0], false)
 		if err != nil {
 			die("failed to read private key", err)
 		}
@@ -21,7 +21,7 @@ This is required before credential types requiring revocation can be issued unde
 			die("private key already supports revocation", nil)
 		}
 
-		pk, err := gabi.NewPublicKeyFromFile(args[1])
+		pk, err := gabikeys.NewPublicKeyFromFile(args[1])
 		if err != nil {
 			die("failed to read public key", err)
 		}
@@ -29,7 +29,7 @@ This is required before credential types requiring revocation can be issued unde
 			die("public key already supports revocation", nil)
 		}
 
-		if err = gabi.GenerateRevocationKeypair(sk, pk); err != nil {
+		if err = gabikeys.GenerateRevocationKeypair(sk, pk); err != nil {
 			die("failed to generate revocation keys", err)
 		}
 

--- a/irmaclient/irmaclient_test.go
+++ b/irmaclient/irmaclient_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/privacybydesign/gabi"
+	"github.com/privacybydesign/gabi/gabikeys"
 	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/privacybydesign/irmago/internal/test"
@@ -74,7 +74,7 @@ func verifyClientIsUnmarshaled(t *testing.T, client *Client) {
 }
 
 func verifyCredentials(t *testing.T, client *Client) {
-	var pk *gabi.PublicKey
+	var pk *gabikeys.PublicKey
 	for credtype, credsmap := range client.attributes {
 		for index, attrs := range credsmap {
 			cred, err := client.credential(attrs.CredentialType().Identifier(), index)

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/privacybydesign/gabi"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/irmago/internal/common"
 
 	"github.com/dgrijalva/jwt-go"
@@ -34,7 +34,7 @@ type Configuration struct {
 	CredentialTypes map[CredentialTypeIdentifier]*CredentialType
 	AttributeTypes  map[AttributeTypeIdentifier]*AttributeType
 	kssPublicKeys   map[SchemeManagerIdentifier]map[int]*rsa.PublicKey
-	publicKeys      map[IssuerIdentifier]map[uint]*gabi.PublicKey
+	publicKeys      map[IssuerIdentifier]map[uint]*gabikeys.PublicKey
 	reverseHashes   map[string]CredentialTypeIdentifier
 
 	// RequestorScheme data of the currently loaded requestorscheme
@@ -308,7 +308,7 @@ func (conf *Configuration) AddPrivateKeyRing(ring PrivateKeyRing) error {
 }
 
 // PublicKey returns the specified public key, or nil if not present in the Configuration.
-func (conf *Configuration) PublicKey(id IssuerIdentifier, counter uint) (*gabi.PublicKey, error) {
+func (conf *Configuration) PublicKey(id IssuerIdentifier, counter uint) (*gabikeys.PublicKey, error) {
 	var haveIssuer, haveKey bool
 	var err error
 	_, haveIssuer = conf.publicKeys[id]
@@ -327,7 +327,7 @@ func (conf *Configuration) PublicKey(id IssuerIdentifier, counter uint) (*gabi.P
 }
 
 // PublicKeyLatest returns the latest private key of the specified issuer.
-func (conf *Configuration) PublicKeyLatest(id IssuerIdentifier) (*gabi.PublicKey, error) {
+func (conf *Configuration) PublicKeyLatest(id IssuerIdentifier) (*gabikeys.PublicKey, error) {
 	indices, err := conf.PublicKeyIndices(id)
 	if err != nil {
 		return nil, err
@@ -468,7 +468,7 @@ func (conf *Configuration) hashToCredentialType(hash []byte) *CredentialType {
 // parse $schememanager/$issuer/PublicKeys/$i.xml for $i = 1, ...
 func (conf *Configuration) parseKeysFolder(issuerid IssuerIdentifier) error {
 	scheme := conf.SchemeManagers[issuerid.SchemeManagerIdentifier()]
-	conf.publicKeys[issuerid] = map[uint]*gabi.PublicKey{}
+	conf.publicKeys[issuerid] = map[uint]*gabikeys.PublicKey{}
 	pattern := filepath.Join(scheme.path(), issuerid.Name(), "PublicKeys", "*")
 	files, err := filepath.Glob(pattern)
 	if err != nil {
@@ -490,7 +490,7 @@ func (conf *Configuration) parseKeysFolder(issuerid IssuerIdentifier) error {
 		if err != nil || !found {
 			return err
 		}
-		pk, err := gabi.NewPublicKeyFromBytes(bts)
+		pk, err := gabikeys.NewPublicKeyFromBytes(bts)
 		if err != nil {
 			return err
 		}
@@ -536,7 +536,7 @@ func (conf *Configuration) clear() {
 	conf.IssueWizards = make(map[IssueWizardIdentifier]*IssueWizard)
 	conf.DisabledRequestorSchemes = make(map[RequestorSchemeIdentifier]*SchemeManagerError)
 	conf.kssPublicKeys = make(map[SchemeManagerIdentifier]map[int]*rsa.PublicKey)
-	conf.publicKeys = make(map[IssuerIdentifier]map[uint]*gabi.PublicKey)
+	conf.publicKeys = make(map[IssuerIdentifier]map[uint]*gabikeys.PublicKey)
 	conf.reverseHashes = make(map[string]CredentialTypeIdentifier)
 	if conf.PrivateKeys == nil { // keep if already populated
 		conf.PrivateKeys = &privateKeyRingMerge{}

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/revocation"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/privacybydesign/irmago/internal/test"
@@ -732,7 +733,7 @@ func TestRevocationMemoryStore(t *testing.T) {
 	retrieve(t, pk, db, 4, 6)
 }
 
-func revokeMultiple(t *testing.T, sk *revocation.PrivateKey, update *revocation.Update) *revocation.Update {
+func revokeMultiple(t *testing.T, sk *gabikeys.PrivateKey, update *revocation.Update) *revocation.Update {
 	acc := update.SignedAccumulator.Accumulator
 	event := update.Events[len(update.Events)-1]
 	events := update.Events
@@ -745,7 +746,7 @@ func revokeMultiple(t *testing.T, sk *revocation.PrivateKey, update *revocation.
 	return update
 }
 
-func retrieve(t *testing.T, pk *revocation.PublicKey, db *memRevStorage, count uint64, expectedIndex uint64) {
+func retrieve(t *testing.T, pk *gabikeys.PublicKey, db *memRevStorage, count uint64, expectedIndex uint64) {
 	var updates map[uint]*revocation.Update
 	var err error
 	for i := uint64(0); i <= count; i++ {
@@ -762,7 +763,7 @@ func retrieve(t *testing.T, pk *revocation.PublicKey, db *memRevStorage, count u
 	require.Equal(t, expectedIndex, acc.Index)
 }
 
-func revoke(t *testing.T, acc *revocation.Accumulator, parent *revocation.Event, sk *revocation.PrivateKey) (*revocation.Accumulator, *revocation.Event) {
+func revoke(t *testing.T, acc *revocation.Accumulator, parent *revocation.Event, sk *gabikeys.PrivateKey) (*revocation.Accumulator, *revocation.Event) {
 	e, err := rand.Prime(rand.Reader, 100)
 	require.NoError(t, err)
 	acc, event, err := acc.Remove(sk, big.Convert(e), parent)

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/revocation"
 	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/common"
@@ -107,7 +108,7 @@ func (session *session) checkCache(message []byte) (int, []byte) {
 
 // Issuance helpers
 
-func (session *session) computeWitness(sk *gabi.PrivateKey, cred *irma.CredentialRequest) (*revocation.Witness, error) {
+func (session *session) computeWitness(sk *gabikeys.PrivateKey, cred *irma.CredentialRequest) (*revocation.Witness, error) {
 	id := cred.CredentialTypeID
 	credtyp := session.conf.IrmaConfiguration.CredentialTypes[id]
 	if !credtyp.RevocationSupported() || !session.request.Base().RevocationSupported() {
@@ -140,7 +141,7 @@ func (session *session) computeWitness(sk *gabi.PrivateKey, cred *irma.Credentia
 		return nil, err
 	}
 
-	witness, err := sk.RevocationGenerateWitness(acc)
+	witness, err := revocation.RandomWitness(sk, acc)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (session *session) computeWitness(sk *gabi.PrivateKey, cred *irma.Credentia
 }
 
 func (session *session) computeAttributes(
-	sk *gabi.PrivateKey, cred *irma.CredentialRequest,
+	sk *gabikeys.PrivateKey, cred *irma.CredentialRequest,
 ) ([]*big.Int, *revocation.Witness, error) {
 	id := cred.CredentialTypeID
 	witness, err := session.computeWitness(sk, cred)

--- a/server/requestorserver/conf.go
+++ b/server/requestorserver/conf.go
@@ -340,7 +340,7 @@ func (conf *Configuration) validatePermissionSet(requestor string, requestorperm
 						continue
 					}
 					if typ == "revoking" {
-						if _, err = sk.RevocationKey(); err != nil {
+						if ok := sk.RevocationSupported(); ok {
 							errs = append(errs, fmt.Sprintf("%s %s permission '%s': private key does not support revocation (add revocation key material to it using \"irma issuer revocation keypair\")", requestor, typ, permission))
 							continue
 						}

--- a/verify.go
+++ b/verify.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/revocation"
 )
 
@@ -49,8 +50,8 @@ var ErrMissingPublicKey = errors.New("Missing public key")
 // ExtractPublicKeys returns the public keys of each proof in the proofList, in the same order,
 // for later use in verification of the proofList. If one of the proofs is not a ProofD
 // an error is returned.
-func (pl ProofList) ExtractPublicKeys(configuration *Configuration) ([]*gabi.PublicKey, error) {
-	var publicKeys = make([]*gabi.PublicKey, 0, len(pl))
+func (pl ProofList) ExtractPublicKeys(configuration *Configuration) ([]*gabikeys.PublicKey, error) {
+	var publicKeys = make([]*gabikeys.PublicKey, 0, len(pl))
 
 	for _, v := range pl {
 		switch v.(type) {
@@ -125,7 +126,7 @@ func (pl ProofList) VerifyProofs(
 	configuration *Configuration,
 	request SessionRequest,
 	context *big.Int, nonce *big.Int,
-	publickeys []*gabi.PublicKey,
+	publickeys []*gabikeys.PublicKey,
 	validAt *time.Time,
 	isSig bool,
 ) (bool, map[int]*time.Time, error) {
@@ -349,7 +350,7 @@ func (d *Disclosure) VerifyAgainstRequest(
 	configuration *Configuration,
 	request SessionRequest,
 	context, nonce *big.Int,
-	publickeys []*gabi.PublicKey,
+	publickeys []*gabikeys.PublicKey,
 	validAt *time.Time,
 	issig bool,
 ) ([][]*DisclosedAttribute, ProofStatus, error) {


### PR DESCRIPTION
Additionally:

* `gabi.PublicKey`, `gabi.PrivateKey` and related methods moved to `gabikeys`
* handle additional errors returned by gabi