### PR TITLE
Prevent possible mutex deadlock when using chained sessions

### DIFF
--- a/server/irmaserver/sessions_test.go
+++ b/server/irmaserver/sessions_test.go
@@ -1,0 +1,51 @@
+package irmaserver
+
+import (
+	irma "github.com/privacybydesign/irmago"
+	"github.com/privacybydesign/irmago/server"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreNoDeadlock(t *testing.T) {
+	logger := logrus.New()
+	logger.Level = logrus.FatalLevel
+	s, err := New(&server.Configuration{Logger: logger})
+	require.NoError(t, err)
+	defer s.Stop()
+
+	req, err := server.ParseSessionRequest(`{"request":{"@context":"https://irma.app/ld/request/disclosure/v2","context":"AQ==","nonce":"MtILupG0g0J23GNR1YtupQ==","devMode":true,"disclose":[[[{"type":"test.test.email.email","value":"example@example.com"}]]]}}`)
+	require.NoError(t, err)
+	session := s.newSession(irma.ActionDisclosing, req)
+
+	session.Lock()
+	deletingCompleted := false
+	addingCompleted := false
+	// Make sure the deleting continues on completion such that the test itself will not hang.
+	defer func() {
+		session.Unlock()
+		time.Sleep(100 * time.Millisecond)
+		require.True(t, deletingCompleted)
+	}()
+
+	go func() {
+		s.sessions.deleteExpired()
+		deletingCompleted = true
+	}()
+
+	// Make sure the goroutine above is running
+	time.Sleep(100 * time.Millisecond)
+
+	// Make a new session; this involves adding it to the memory session store.
+	go func() {
+		_ = s.newSession(irma.ActionDisclosing, req)
+		addingCompleted = true
+	}()
+
+	// Check whether the IRMA server doesn't hang
+	time.Sleep(100 * time.Millisecond)
+	require.True(t, addingCompleted)
+	require.False(t, deletingCompleted)
+}


### PR DESCRIPTION
When periodically iterating over sessions to see if they need to be expired,
the `memorySessionStore.deleteExpired()` method of the IRMA server locks the
session store mutex, and while that is locked it additionally locks each
session mutex when handling it. If a session is currently being handled by an
endpoint which also locks the session mutex, `deleteExpired()` therefore has to
wait for the handler to finish dealing with the session. However, when that
session attempts to starts a new session (as part of a session chain), it tries
to lock the session store mutex again, which was already locked: a deadlock.

We solve this by making `deleteExired()` not request a session lock while the
entire store is also locked: the store and session locking are now done
sequentially. That way, even when a session is locked by an endpoint in the
loop over the sessions in `deleteExpired()`, that session is free to write new
sessions to the session store.