### PR TITLE
Fix private key issue of issuer if another issuer with a similar name exists

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -153,11 +153,15 @@ func (p *PrivateKeyRingFolder) Latest(id IssuerIdentifier) (*gabikeys.PrivateKey
 }
 
 func (p *PrivateKeyRingFolder) Iterate(id IssuerIdentifier, f func(sk *gabikeys.PrivateKey) error) error {
-	files, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s*", id.String())))
+	files, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s.xml", id.String())))
 	if err != nil {
 		return err
 	}
-	for _, file := range files {
+	filesWithCounter, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s.*.xml", id.String())))
+	if err != nil {
+		return err
+	}
+	for _, file := range append(files, filesWithCounter...) {
 		sk, err := p.readFile(filepath.Base(file), id)
 		if err != nil {
 			return err

--- a/keyring.go
+++ b/keyring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/privacybydesign/gabi/big"
 	"github.com/privacybydesign/gabi/gabikeys"
+	"github.com/privacybydesign/irmago/internal/common"
 )
 
 type (
@@ -153,15 +154,19 @@ func (p *PrivateKeyRingFolder) Latest(id IssuerIdentifier) (*gabikeys.PrivateKey
 }
 
 func (p *PrivateKeyRingFolder) Iterate(id IssuerIdentifier, f func(sk *gabikeys.PrivateKey) error) error {
-	files, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s.xml", id.String())))
+	files, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s.*.xml", id.String())))
 	if err != nil {
 		return err
 	}
-	filesWithCounter, err := filepath.Glob(filepath.Join(p.path, fmt.Sprintf("%s.*.xml", id.String())))
+	fileWithoutCounter := filepath.Join(p.path, fmt.Sprintf("%s.xml", id.String()))
+	exists, err := common.PathExists(fileWithoutCounter)
 	if err != nil {
 		return err
 	}
-	for _, file := range append(files, filesWithCounter...) {
+	if exists {
+		files = append(files, fileWithoutCounter)
+	}
+	for _, file := range files {
 		sk, err := p.readFile(filepath.Base(file), id)
 		if err != nil {
 			return err


### PR DESCRIPTION
This solves the following. If:
- an issuer exists in the scheme whose identifier is of the form $scheme.$issuer$suffix,
  where $scheme.$issuer is another existing issuer in the scheme,
- issuer $scheme.$issuer$suffix has a private key installed in the --privkeys folder,

Then the IRMA server refused to startup with an incorrect error message
("Private key 0 of issuer $scheme.$issuer does not belong to corresponding public key").