### PR TITLE
Added docker-compose file to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,28 @@ For the SMTP server you can use [MailHog](https://github.com/mailhog/MailHog) (s
 
 For the unit tests it only matters that the SMTP server itself is running and accepts emails, but MailHog additionally comes with a webinterface showing incoming emails. By default this runs at <http://localhost:8025>.
 
-### Running the tests manually
+### Running the tests
 
-After installing PostgreSQL and MailHog, the tests can be run using:
+In case you chose to start PostgreSQL and MailHog using `docker-compose`, you first need to start these services:
+
+    docker-compose up
+
+When PostgreSQL and MailHog are running, the tests can be run using:
 
     go test -p 1 ./...
 
 * The option `./...` makes sure all tests are run. You can also limit the number of tests by only running the tests from a single directory or even from a single file, for example only running all tests in the directory `./internal/sessiontest`. When you only want to execute one single test, for example the `TestDisclosureSession` test, you can do this by adding the option `-run TestDisclosureSession`.
 * The option `-p 1` is necessary to prevent parallel execution of tests. Most tests use file manipulation and therefore tests can interfere.
 
-### Running the tests using Docker
+### Running without PostgreSQL, MailHog or Docker
 
-You can run the tests using the command below. By default, all tests are run one-by-one without parallel execution.
+If installing PostgreSQL, MailHog or Docker is not an option for you, then you can exclude all tests that use those by additionally passing `--tags=local_tests`:
+
+    go test -p 1 --tags=local_tests ./...
+
+### Running without Go
+
+You can also run the tests fully in Docker using the command below. This is useful when you don't want to install the Go compiler locally. By default, all tests are run one-by-one without parallel execution.
 
     docker-compose run test
 
@@ -63,12 +73,6 @@ You can override the default command by specifying command line options for `go 
 
     docker-compose run test ./internal/sessiontest -run TestDisclosureSession
 
-We always enforce the `-p 1` option to be used (see [above](#running-the-tests-manually)).
-
-### Running without PostgreSQL or MailHog
-
-If installing PostgreSQL or MailHog is not an option for you, then you can exclude all tests that use those by additionally passing `--tags=local_tests`:
-
-    go test -p 1 --tags=local_tests ./...
+We always enforce the `-p 1` option to be used (as explained [above](#running-the-tests)).
 
 <!-- vim: set ts=4 sw=4: -->

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install the `irma` command line tool:
 
 ## Running the unit tests
 
-Some of the unit tests connect to locally running external services, namely PostgreSQL and an SMTP server running at port 1025. These need to be up and running before these tests can be executed. They can be installed as follows.
+Some of the unit tests connect to locally running external services, namely PostgreSQL and an SMTP server running at port 1025. These need to be up and running before these tests can be executed. This can either be done using `docker-compose` or by following the instructions below to install the services manually.
 
 #### PostgreSQL
 
@@ -44,7 +44,7 @@ For the SMTP server you can use [MailHog](https://github.com/mailhog/MailHog) (s
 
 For the unit tests it only matters that the SMTP server itself is running and accepts emails, but MailHog additionally comes with a webinterface showing incoming emails. By default this runs at <http://localhost:8025>.
 
-### Running the tests
+### Running the tests manually
 
 After installing PostgreSQL and MailHog, the tests can be run using:
 
@@ -52,6 +52,18 @@ After installing PostgreSQL and MailHog, the tests can be run using:
 
 * The option `./...` makes sure all tests are run. You can also limit the number of tests by only running the tests from a single directory or even from a single file, for example only running all tests in the directory `./internal/sessiontest`. When you only want to execute one single test, for example the `TestDisclosureSession` test, you can do this by adding the option `-run TestDisclosureSession`.
 * The option `-p 1` is necessary to prevent parallel execution of tests. Most tests use file manipulation and therefore tests can interfere.
+
+### Running the tests using Docker
+
+You can run the tests using the command below. By default, all tests are run one-by-one without parallel execution.
+
+    docker-compose run test
+
+You can override the default command by specifying command line options for `go test` manually, for example:
+
+    docker-compose run test ./internal/sessiontest -run TestDisclosureSession
+
+We always enforce the `-p 1` option to be used (see [above](#running-the-tests-manually)).
 
 ### Running without PostgreSQL or MailHog
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.1'
+
+services:
+  # Dependencies for running unit tests
+  postgres:
+    image: postgres:13-buster
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpassword
+      POSTGRES_DB: test
+    ports:
+      - 5432:5432
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+     - 1025:1025
+
+  # Service to run unit tests
+  test:
+    image: golang:1.16-buster
+    volumes:
+      - .:/irmago
+    depends_on:
+      - postgres
+      - mailhog
+    # The tests assume postgres and mailhog can be accessed on localhost. Therefore, we use host networking for now.
+    network_mode: host
+    working_dir: /irmago
+    entrypoint: go test -p 1
+    command: ./...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,20 @@ services:
   mailhog:
     image: mailhog/mailhog
     ports:
-     - 1025:1025
+      - 1025:1025
 
   # Service to run unit tests
   test:
     image: golang:1.16-buster
+    # Add a test profile to prevent this service to be included when running docker-compose up.
+    profiles:
+      - test
     volumes:
       - .:/irmago
     depends_on:
       - postgres
       - mailhog
-    # The tests assume postgres and mailhog can be accessed on localhost. Therefore, we use host networking for now.
+    # The tests assume postgres and mailhog can be accessed on localhost. Therefore, we use host networking.
     network_mode: host
     working_dir: /irmago
     entrypoint: go test -p 1

--- a/internal/test/postgres.go
+++ b/internal/test/postgres.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const PostgresTestUrl = "postgresql://localhost:5432/test"
+const PostgresTestUrl = "postgresql://testuser:testpassword@localhost:5432/test"
 
 func RunScriptOnDB(t *testing.T, filename string, allowErr bool) {
 	db, err := sql.Open("pgx", PostgresTestUrl)

--- a/server/keyshare/myirmaserver/conf_email_test.go
+++ b/server/keyshare/myirmaserver/conf_email_test.go
@@ -4,6 +4,7 @@ package myirmaserver
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/privacybydesign/irmago/internal/test"
@@ -30,7 +31,7 @@ func TestConfEmailValidation(t *testing.T) {
 
 	conf := validConf(t)
 	conf.DBType = DBTypePostgres
-	conf.DBConnStr = "postgresql://localhost:5432/test"
+	conf.DBConnStr = test.PostgresTestUrl
 	_, err := New(conf)
 	assert.NoError(t, err)
 
@@ -39,7 +40,7 @@ func TestConfEmailValidation(t *testing.T) {
 
 	conf = validConfWithEmail(t)
 	conf.DBType = DBTypePostgres
-	conf.DBConnStr = "postgresql://localhost:54321/test"
+	conf.DBConnStr = strings.Replace(test.PostgresTestUrl, "5432", "54321", 1)
 	_, err = New(conf)
 	assert.Error(t, err)
 


### PR DESCRIPTION
Added a `docker-compose` file such that we can run all unit tests without having to install external packages manually.