### PR TITLE
Keyshare server fixes

### DIFF
--- a/irma/cmd/keyshare-server.go
+++ b/irma/cmd/keyshare-server.go
@@ -106,8 +106,8 @@ func configureKeyshareServer(cmd *cobra.Command) (*keyshareserver.Configuration,
 		JwtPrivateKeyFile:       viper.GetString("jwt_privkey_file"),
 		JwtIssuer:               viper.GetString("jwt_issuer"),
 		JwtPinExpiry:            viper.GetInt("jwt_pin_expiry"),
-		StoragePrimaryKeyFile:   viper.GetString("storage_primary_keyfile"),
-		StorageFallbackKeyFiles: viper.GetStringSlice("storage_fallback_keyfile"),
+		StoragePrimaryKeyFile:   viper.GetString("storage_primary_key_file"),
+		StorageFallbackKeyFiles: viper.GetStringSlice("storage_fallback_key_file"),
 
 		KeyshareAttribute: irma.NewAttributeTypeIdentifier(viper.GetString("keyshare_attribute")),
 

--- a/server/keyshare/keyshareserver/postgresdb.go
+++ b/server/keyshare/keyshareserver/postgresdb.go
@@ -24,7 +24,7 @@ const emailTokenValidity = 24 // amount of time user's email validation token is
 
 // Initial amount of time user is forced to back off when having multiple pin failures (in seconds).
 // var so that tests may change it.
-var backoffStart int64 = 30
+var backoffStart int64 = 60
 
 func newPostgresDB(connstring string) (DB, error) {
 	db, err := sql.Open("pgx", connstring)


### PR DESCRIPTION
This PR contains two keyshare server fixes:

* During configuration of the keyshare server `storage_primary_keyfile` was retrieved which should be `storage_primary_key_file`
* When too many wrong PINs are entered, the initial backoff is now set to 60 seconds like the current keyshare server. This is also required by the `irmamobile` integration tests which expect 60 and not 30 seconds.