### PR TITLE
Upgrade Docker containers to new Debian stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use variable base image, such that we can also build for other base images, like alpine.
-ARG BASE_IMAGE=debian:buster-slim
+ARG BASE_IMAGE=debian:stable-slim
 
-FROM golang:1.16-buster as build
+FROM golang:1.16 as build
 
 # Set build environment
 ENV CGO_ENABLED=0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install the `irma` command line tool:
 
     go install ./irma
 
-You can also include the `irma` command line tool in a Docker image, using a base image of your choice. The default base image is Debian's `buster-slim`.
+You can also include the `irma` command line tool in a Docker image, using a base image of your choice. The default base image is Debian's `stable-slim`.
 
     docker build --build-arg BASE_IMAGE=alpine -t privacybydesign/irma:edge .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   # Dependencies for running unit tests and for running the 'irma' command line tool using one of the test configurations.
   postgres:
-    image: postgres:13-buster
+    image: postgres:13
     environment:
       POSTGRES_USER: testuser
       POSTGRES_PASSWORD: testpassword
@@ -16,7 +16,7 @@ services:
     ports:
       - 5432:5432
   postgres-init:
-    image: postgres:13-buster
+    image: postgres:13
     environment:
       PGHOST: postgres
       PGUSER: testuser
@@ -45,7 +45,7 @@ services:
 
   # Service to run unit tests
   test:
-    image: golang:1.16-buster
+    image: golang:1.16
     # Add a test profile to prevent this service to be included when running docker-compose up.
     profiles:
       - test


### PR DESCRIPTION
Postgres and golang use Debian stable by default and don't specify a tag to make this explicit.