### PR TITLE
Improve error messages of server.ParseSessionRequest()

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -401,3 +401,25 @@ var SchemeFilenames = []string{"description.xml", "description.json"}
 func Close(o io.Closer) {
 	_ = o.Close()
 }
+
+func ParseLDContext(bts []byte) (string, error) {
+	var v struct {
+		LDContext string `json:"@context"`
+	}
+	if err := json.Unmarshal(bts, &v); err != nil {
+		return "", err
+	}
+	return v.LDContext, nil
+}
+
+func ParseNestedLDContext(bts []byte) (string, error) {
+	var v struct {
+		Request struct {
+			LDContext string `json:"@context"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(bts, &v); err != nil {
+		return "", err
+	}
+	return v.Request.LDContext, nil
+}

--- a/legacy.go
+++ b/legacy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-errors/errors"
+	"github.com/privacybydesign/irmago/internal/common"
 )
 
 // This file contains compatibility code for the legacy, pre-condiscon session requests,
@@ -98,16 +99,6 @@ func convertDisjunctions(disjunctions []LegacyLabeledDisjunction) (
 	return
 }
 
-func parseLDContext(bts []byte) (string, error) {
-	var v struct {
-		LDContext string `json:"@context"`
-	}
-	if err := json.Unmarshal(bts, &v); err != nil {
-		return "", err
-	}
-	return v.LDContext, nil
-}
-
 func checkType(typ, expected Action) error {
 	if typ != expected {
 		return errors.New("not a " + expected + " session request")
@@ -181,7 +172,7 @@ func (dr *DisclosureRequest) Legacy() (SessionRequest, error) {
 
 func (dr *DisclosureRequest) UnmarshalJSON(bts []byte) (err error) {
 	var ldContext string
-	if ldContext, err = parseLDContext(bts); err != nil {
+	if ldContext, err = common.ParseLDContext(bts); err != nil {
 		return err
 	}
 
@@ -228,7 +219,7 @@ func (sr *SignatureRequest) Legacy() (SessionRequest, error) {
 
 func (sr *SignatureRequest) UnmarshalJSON(bts []byte) (err error) {
 	var ldContext string
-	if ldContext, err = parseLDContext(bts); err != nil {
+	if ldContext, err = common.ParseLDContext(bts); err != nil {
 		return err
 	}
 
@@ -285,7 +276,7 @@ func (ir *IssuanceRequest) Legacy() (SessionRequest, error) {
 
 func (ir *IssuanceRequest) UnmarshalJSON(bts []byte) (err error) {
 	var ldContext string
-	if ldContext, err = parseLDContext(bts); err != nil {
+	if ldContext, err = common.ParseLDContext(bts); err != nil {
 		return err
 	}
 

--- a/server/legacy.go
+++ b/server/legacy.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/go-errors/errors"
+	irma "github.com/privacybydesign/irmago"
+)
+
+func parseLegacySessionRequest(r []byte) (irma.RequestorRequest, error) {
+	var attempts = []irma.Validator{&irma.ServiceProviderRequest{}, &irma.SignatureRequestorRequest{}, &irma.IdentityProviderRequest{}}
+	t, err := tryUnmarshalJson(r, attempts)
+	if err == nil {
+		return t.(irma.RequestorRequest), nil
+	}
+	attempts = []irma.Validator{&irma.DisclosureRequest{}, &irma.SignatureRequest{}, &irma.IssuanceRequest{}}
+	t, err = tryUnmarshalJson(r, attempts)
+	if err == nil {
+		return wrapSessionRequest(t.(irma.SessionRequest))
+	}
+	return nil, errors.New("Failed to JSON unmarshal request bytes")
+}
+
+func tryUnmarshalJson(bts []byte, attempts []irma.Validator) (irma.Validator, error) {
+	for _, a := range attempts {
+		if err := irma.UnmarshalValidate(bts, a); err == nil {
+			return a, nil
+		}
+	}
+	return nil, errors.New("")
+}


### PR DESCRIPTION
Instead of attempting to parse the argument as each possible session type, this function now establishes the message type using the JSON-LD @context tag, and then unmarshals the argument as the specified message type. (In case of legacy session requests which don't have JSON-LD tags, the previous unmarshaling mechanism is still used.)