### PR TITLE
Ensure wizard items order is always stable

### DIFF
--- a/descriptions.go
+++ b/descriptions.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/privacybydesign/irmago/internal/common"
@@ -262,7 +264,14 @@ func buildDependencyTree(contents []IssueWizardItem, conf *Configuration, credsm
 	var result []IssueWizardItem                         // to return
 	resultMap := map[CredentialTypeIdentifier]struct{}{} // to keep track of credentials already put in the result slice
 	for i := len(depTree) - 1; i >= 0; i-- {
+		var credIDs []CredentialTypeIdentifier
 		for id := range depTree[i] {
+			credIDs = append(credIDs, id)
+		}
+		sort.Slice(credIDs, func(i, j int) bool {
+			return strings.Compare(credIDs[i].String(), credIDs[j].String()) < 0
+		})
+		for _, id := range credIDs {
 			if _, ok := resultMap[id]; ok {
 				continue
 			}

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -968,8 +968,8 @@ func TestWizardConstructed(t *testing.T) {
 		[]IssueWizardItem{
 			credwizarditem("scheme.issuer.a"),
 			credwizarditem("scheme.issuer.b"),
-			credwizarditem("scheme.issuer.d"),
 			credwizarditem("scheme.issuer.c"),
+			credwizarditem("scheme.issuer.d"),
 			wizard.Contents[1][0][0],
 			wizard.Contents[2][0][0],
 		},


### PR DESCRIPTION
The dependency graph of wizard items does not always determine a unique order in which the items are to be executed, and indeed items can switch places within a single wizard across invocations. This is now fixed.