### PR TITLE
Added Github action for linter

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -1,0 +1,74 @@
+# Workflow to check whether changes to master fulfill all requirements.
+name: Status checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Build
+        run: go build -v -o irma-linux-amd64 ./irma
+
+  # We only check the build stage of the Dockerfile, because building the full Dockerfile requires
+  # downloading IRMA schemes. We check the status of the full Dockerfile once every week on master
+  # in the weekly-master-checks.
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run Dockerfile build stage
+      run: docker build -t privacybydesign/irma:build --target build .
+
+    - name: Test Docker image
+      # Because we have only run the build stage, we have to explicitly set irma as entrypoint.
+      run: docker run --entrypoint irma privacybydesign/irma:build version
+      
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Run gofmt
+      run: gofmt -d -e .
+      
+    - name: Run go vet
+      run: go vet ./...
+      
+    - name: Install ineffassign
+      run: go install github.com/gordonklaus/ineffassign@latest
+      
+    - name: Run ineffassign
+      run: ineffassign ./...
+      
+    - name: Install misspell
+      run: go install github.com/client9/misspell/cmd/misspell@latest
+      
+    - name: Run misspell
+      run: misspell -error .
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run all unit tests
+        run: docker-compose run test -v ./...

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -1,0 +1,33 @@
+# Checks to weekly monitor the status of master.
+name: Weekly checks
+
+on:
+  schedule:
+    # Run every monday on 9:00 in the morning (UTC).
+    - cron: "0 9 * * 1"
+
+jobs:
+
+  # Check whether the Dockerfile still builds using the latest Docker base images.
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      # Building the Dockerfile includes downloading the IRMA schemes.
+      # Therefore, we only run one check at the time.
+      max-parallel: 1
+      matrix:
+        # busybox is not working yet.
+        image:
+          - "debian:stable"
+          - "alpine:latest"
+          - "ubuntu:latest"
+          - "centos:latest"
+          - "amazonlinux:latest"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Dockerfile
+        run: docker build -t privacybydesign/irma:edge --build-arg BASE_IMAGE=${{ matrix.image }} .
+
+      - name: Test Docker image
+        run: docker run privacybydesign/irma:edge version


### PR DESCRIPTION
`golint` is not included on purpose, because we have too many issues there still.

For the time being, the status checks also don't run `gocylco` (for code complexity). The configuration of that is a bit more complex, because we have to only check the diff here, and I was not able to get that fully right. In some cases some code complexity might be unavoidable, so it might also be good to add output the `gocyclo` output to a PR review, such that it can be manually judged. This is possible, but requires some additional configuration too.