### PR TITLE
Fix enormous stacktrace in stdout when SSE is disabled and requestor /statusevents endpoint is invoked

### DIFF
--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -412,7 +412,13 @@ func (s *Server) Revoke(credid irma.CredentialTypeIdentifier, key string, issued
 // of the specified IRMA session.
 func (s *Server) SubscribeServerSentEvents(w http.ResponseWriter, r *http.Request, token irma.RequestorToken) (err error) {
 	if !s.conf.EnableSSE {
-		return server.LogError(errors.New("Server sent events disabled"))
+		server.WriteResponse(w, nil, &irma.RemoteError{
+			Status:      500,
+			Description: "Server sent events disabled",
+			ErrorName:   "SSE_DISABLED",
+		})
+		s.conf.Logger.Info("GET /statusevents: endpoint disabled (see --sse in irma server -h)")
+		return nil
 	}
 	session, err := s.sessions.get(token)
 	err = updateAndUnlock(session, err)


### PR DESCRIPTION
This makes the error emitted in this case the same as that of the /statusevents endpoint used by the frontend.