### PR TITLE
Feat: added option for static sessions and session packages to irma session command

### DIFF
--- a/irma/cmd/request.go
+++ b/irma/cmd/request.go
@@ -289,6 +289,10 @@ func printQr(qr *irma.Qr, noqr bool) error {
 }
 
 func printSessionResult(result *server.SessionResult) {
+	if result == nil {
+		fmt.Println("No session result available.")
+		return
+	}
 	fmt.Println("Session result:")
 	fmt.Println(prettyprint(result))
 }

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -182,11 +182,10 @@ func serverRequest(
 		qr              = pkg.SessionPtr
 		frontendRequest = pkg.FrontendRequest
 		transport       = irma.NewHTTPTransport(qr.URL, false)
+		sessionOptions  = &irma.SessionOptions{}
 		err             error
 	)
-	sessionOptions := &irma.SessionOptions{}
 	if pairing {
-		transport = irma.NewHTTPTransport(qr.URL, false)
 		transport.SetHeader(irma.AuthorizationHeader, string(frontendRequest.Authorization))
 		optionsRequest := irma.NewFrontendOptionsRequest()
 		optionsRequest.PairingMethod = irma.PairingMethodPin

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -264,7 +264,7 @@ func serverRequest(
 		}
 		path := fmt.Sprintf("session/%s/result", pkg.Token)
 		if err = irma.NewHTTPTransport(urlParts[0], false).Get(path, result); err == nil {
-			return result, err
+			return result, nil
 		}
 	}
 	return nil, err

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -45,7 +45,7 @@ irma session --sign irma-demo.MijnOverheid.root.BSN --message message
 irma session --issue irma-demo.MijnOverheid.ageLower=yes,yes,yes,no --disclose irma-demo.MijnOverheid.root.BSN
 irma session --request '{"type":"disclosing","content":[{"label":"BSN","attributes":["irma-demo.MijnOverheid.root.BSN"]}]}'
 irma session --server http://localhost:8088 --authmethod token --key mytoken --disclose irma-demo.MijnOverheid.root.BSN
-irma session --server http://localhost:8088 --static mystaticsession
+irma session --url http://localhost:8088 --static mystaticsession
 irma session --from-package '{"sessionPtr": ... , "frontendRequest": ...}'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
@@ -262,8 +262,9 @@ func serverRequest(
 			// Custom URL structure is used, so we cannot determine result endpoint location.
 			return nil, nil
 		}
+		baseURL := strings.Join(urlParts[:len(urlParts)-1], "")
 		path := fmt.Sprintf("session/%s/result", pkg.Token)
-		if err = irma.NewHTTPTransport(urlParts[0], false).Get(path, result); err == nil {
+		if err = irma.NewHTTPTransport(baseURL, false).Get(path, result); err == nil {
 			return result, nil
 		}
 	}

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -94,8 +94,9 @@ irma session --server http://localhost:8088 --static mystaticsession`,
 		} else {
 			err = serverRequest(pkg, noqr, pairing)
 			if pkg.Token != "" {
-				result := &server.SessionResult{}
-				err = irma.NewHTTPTransport(serverURL, false).Get("result", result)
+				result = &server.SessionResult{}
+				path := fmt.Sprintf("session/%s/result", pkg.Token)
+				err = irma.NewHTTPTransport(serverURL, false).Get(path, result)
 				if err != nil {
 					die("Result could not be retrieved", err)
 				}

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -272,7 +272,7 @@ func staticRequest(serverURL, name string, noqr bool) error {
 	return printQr(qr, noqr)
 }
 
-func postRequest(serverURL, path string, request interface{}, name, authMethod, key string) (
+func postRequest(serverURL, path string, request irma.RequestorRequest, name, authMethod, key string) (
 	*server.SessionPackage, error) {
 	var (
 		err       error
@@ -287,12 +287,8 @@ func postRequest(serverURL, path string, request interface{}, name, authMethod, 
 	case "none":
 		err = transport.Post(path, pkg, request)
 	case "hmac", "rsa":
-		rr, ok := request.(irma.RequestorRequest)
-		if !ok {
-			return nil, errors.New("Authentication methods hmac and rsa cannot be used for static sessions")
-		}
 		var jwtstr string
-		jwtstr, err = signRequest(rr, name, authMethod, key)
+		jwtstr, err = signRequest(request, name, authMethod, key)
 		if err != nil {
 			return nil, err
 		}

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -88,7 +88,7 @@ irma session --from-package '{"sessionPtr": ... , "frontendRequest": ...}'`,
 				authMethod, _ := flags.GetString("authmethod")
 				key, _ := flags.GetString("key")
 				name, _ := flags.GetString("name")
-				pkg, err = postRequest(serverURL, "session", request, name, authMethod, key)
+				pkg, err = postRequest(serverURL, request, name, authMethod, key)
 				if err != nil {
 					die("Session could not be started", err)
 				}
@@ -280,7 +280,7 @@ func staticRequest(url string, port int, name string, noqr bool) error {
 	return printQr(qr, noqr)
 }
 
-func postRequest(serverURL, path string, request irma.RequestorRequest, name, authMethod, key string) (
+func postRequest(serverURL string, request irma.RequestorRequest, name, authMethod, key string) (
 	*server.SessionPackage, error) {
 	var (
 		err       error
@@ -293,7 +293,7 @@ func postRequest(serverURL, path string, request irma.RequestorRequest, name, au
 		transport.SetHeader("Authorization", key)
 		fallthrough
 	case "none":
-		err = transport.Post(path, pkg, request)
+		err = transport.Post("session", pkg, request)
 	case "hmac", "rsa":
 		var jwtstr string
 		jwtstr, err = signRequest(request, name, authMethod, key)
@@ -301,7 +301,7 @@ func postRequest(serverURL, path string, request irma.RequestorRequest, name, au
 			return nil, err
 		}
 		logger.Debug("Session request JWT: ", jwtstr)
-		err = transport.Post(path, pkg, jwtstr)
+		err = transport.Post("session", pkg, jwtstr)
 	default:
 		return nil, errors.New("Invalid authentication method (must be none, token, hmac or rsa)")
 	}

--- a/irma/cmd/session.go
+++ b/irma/cmd/session.go
@@ -257,12 +257,12 @@ func serverRequest(
 
 	if err == nil && pkg.Token != "" {
 		result := &server.SessionResult{}
-		urlParts := strings.Split(pkg.SessionPtr.URL, "/irma/session/")
-		if len(urlParts) <= 1 {
+		prefixIndex := strings.LastIndex(pkg.SessionPtr.URL, "/irma/session/")
+		if prefixIndex < 0 {
 			// Custom URL structure is used, so we cannot determine result endpoint location.
 			return nil, nil
 		}
-		baseURL := strings.Join(urlParts[:len(urlParts)-1], "")
+		baseURL := pkg.SessionPtr.URL[:prefixIndex]
 		path := fmt.Sprintf("session/%s/result", pkg.Token)
 		if err = irma.NewHTTPTransport(baseURL, false).Get(path, result); err == nil {
 			return result, nil

--- a/wait_status.go
+++ b/wait_status.go
@@ -28,13 +28,18 @@ func subscribeSSE(transport *HTTPTransport, statuschan chan ServerStatus, errorc
 
 	events := make(chan *sseclient.Event)
 	cancelled := false
+	var status ServerStatus
 	go func() {
 		for {
 			e := <-events
 			if e == nil || e.Type == "open" {
 				continue
 			}
-			status := ServerStatus(strings.Trim(string(e.Data), `"`))
+			newStatus := ServerStatus(strings.Trim(string(e.Data), `"`))
+			if newStatus == status {
+				continue
+			}
+			status = newStatus
 			statuschan <- status
 			if untilNextOnly || status.Finished() {
 				errorchan <- nil

--- a/wait_status.go
+++ b/wait_status.go
@@ -28,8 +28,8 @@ func subscribeSSE(transport *HTTPTransport, statuschan chan ServerStatus, errorc
 
 	events := make(chan *sseclient.Event)
 	cancelled := false
-	var status ServerStatus
 	go func() {
+		var status ServerStatus
 		for {
 			e := <-events
 			if e == nil || e.Type == "open" {

--- a/wait_status.go
+++ b/wait_status.go
@@ -29,17 +29,12 @@ func subscribeSSE(transport *HTTPTransport, statuschan chan ServerStatus, errorc
 	events := make(chan *sseclient.Event)
 	cancelled := false
 	go func() {
-		var status ServerStatus
 		for {
 			e := <-events
 			if e == nil || e.Type == "open" {
 				continue
 			}
-			newStatus := ServerStatus(strings.Trim(string(e.Data), `"`))
-			if newStatus == status {
-				continue
-			}
-			status = newStatus
+			status := ServerStatus(strings.Trim(string(e.Data), `"`))
 			statuschan <- status
 			if untilNextOnly || status.Finished() {
 				errorchan <- nil


### PR DESCRIPTION
Useful for testing [static QRs](https://irma.app/docs/irma-server/#static-irma-qrs) and to handle sessions for the UniqueID issuer.

## Usage
    irma session --url $URL --static mystaticsession
    irma session --from-package $(curl "https://angrygames.nl/start_session.php?type=18plus") --pairing