### PR TITLE
Chore: make it possible to trigger weekly checks manually

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     # Run every monday on 9:00 in the morning (UTC).
     - cron: "0 9 * * 1"
+  # Make it possible to trigger the checks manually.
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Can be useful when you want to test the `Dockerfile` when making changes.