### PR TITLE
Test: remove part of the hardcoded network ports

### DIFF
--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -222,7 +222,6 @@ func IrmaServerConfiguration() *server.Configuration {
 			revKeyshareTestCred: {RevocationServerURL: revocationServerURL},
 		},
 		JwtPrivateKeyFile: jwtPrivkeyPath,
-		StaticSessions:    map[string]interface{}{},
 	}
 }
 

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,22 +40,18 @@ var (
 	jwtPrivkeyPath = filepath.Join(testdata, "jwtkeys", "sk.pem")
 )
 
+// Some urls are hardcoded in the test configuration, so we have to hardcode them here too.
 const (
-	irmaServerPort = 48680
-
 	schemeServerURL = "http://localhost:48681"
-
-	requestorServerPort = 48682
-	requestorServerURL  = "http://localhost:48682"
 
 	revocationServerPort = 48683
 	revocationServerURL  = "http://localhost:48683"
+)
 
-	staticSessionServerPort = 48685
-	staticSessionServerURL  = "http://localhost:48685"
-
-	nextSessionServerPort = 48686
-	nextSessionServerURL  = "http://localhost:48686"
+// The doSession helper expects the requestor server URL to be globally defined, to support the optionReuseServer.
+var (
+	requestorServerPort = findFreePort()
+	requestorServerURL  = fmt.Sprintf("http://localhost:%d", requestorServerPort)
 )
 
 type IrmaServer struct {
@@ -87,6 +86,12 @@ func apply(
 	}
 }
 
+func findFreePort() int {
+	s := httptest.NewUnstartedServer(http.NotFoundHandler())
+	defer s.Close()
+	return s.Listener.Addr().(*net.TCPAddr).Port
+}
+
 func StartRequestorServer(t *testing.T, configuration *requestorserver.Configuration) *requestorserver.Server {
 	requestorServer, err := requestorserver.New(configuration)
 	require.NoError(t, err)
@@ -103,19 +108,19 @@ func StartIrmaServer(t *testing.T, conf *server.Configuration) *IrmaServer {
 		conf = IrmaServerConfiguration()
 	}
 
+	mux := http.NewServeMux()
+	httpServer := httptest.NewServer(mux)
+
+	// Make sure domain is used instead of IP address.
+	conf.URL = strings.Replace(httpServer.URL, "127.0.0.1", "localhost", 1)
 	irmaServer, err := irmaserver.New(conf)
 	require.NoError(t, err)
 
-	mux := http.NewServeMux()
 	mux.HandleFunc("/", irmaServer.HandlerFunc())
-	httpServer := &http.Server{Addr: fmt.Sprintf("localhost:%d", irmaServerPort), Handler: mux}
-	go func() {
-		_ = httpServer.ListenAndServe()
-	}()
 	return &IrmaServer{
 		irma: irmaServer,
 		conf: conf,
-		http: httpServer,
+		http: httpServer.Config,
 	}
 }
 
@@ -137,7 +142,7 @@ func chainedServerHandler(t *testing.T, jwtPubKey *rsa.PublicKey) http.Handler {
 		request := &irma.ServiceProviderRequest{
 			Request: getDisclosureRequest(id),
 			RequestorBaseRequest: irma.RequestorBaseRequest{
-				NextSession: &irma.NextSessionData{URL: nextSessionServerURL + "/2"},
+				NextSession: &irma.NextSessionData{URL: fmt.Sprintf("http://%s/2", r.Host)},
 			},
 		}
 		bts, err := json.Marshal(request)
@@ -180,7 +185,7 @@ func chainedServerHandler(t *testing.T, jwtPubKey *rsa.PublicKey) http.Handler {
 		bts, err = json.Marshal(irma.IdentityProviderRequest{
 			Request: irma.NewIssuanceRequest([]*irma.CredentialRequest{cred}),
 			RequestorBaseRequest: irma.RequestorBaseRequest{
-				NextSession: &irma.NextSessionData{URL: nextSessionServerURL + "/3"},
+				NextSession: &irma.NextSessionData{URL: fmt.Sprintf("http://%s/3", r.Host)},
 			},
 		})
 		require.NoError(t, err)
@@ -206,20 +211,8 @@ func chainedServerHandler(t *testing.T, jwtPubKey *rsa.PublicKey) http.Handler {
 	return mux
 }
 
-func StartNextRequestServer(t *testing.T, jwtPubKey *rsa.PublicKey) *http.Server {
-	s := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", nextSessionServerPort),
-		Handler: chainedServerHandler(t, jwtPubKey),
-	}
-	go func() {
-		_ = s.ListenAndServe()
-	}()
-	return s
-}
-
 func IrmaServerConfiguration() *server.Configuration {
 	return &server.Configuration{
-		URL:                   fmt.Sprintf("http://localhost:%d", irmaServerPort),
 		Logger:                logger,
 		DisableSchemesUpdate:  true,
 		SchemesPath:           filepath.Join(testdata, "irma_configuration"),
@@ -229,19 +222,7 @@ func IrmaServerConfiguration() *server.Configuration {
 			revKeyshareTestCred: {RevocationServerURL: revocationServerURL},
 		},
 		JwtPrivateKeyFile: jwtPrivkeyPath,
-		StaticSessions: map[string]interface{}{
-			"staticsession": irma.ServiceProviderRequest{
-				RequestorBaseRequest: irma.RequestorBaseRequest{
-					CallbackURL: staticSessionServerURL,
-				},
-				Request: &irma.DisclosureRequest{
-					BaseRequest: irma.BaseRequest{LDContext: irma.LDContextDisclosureRequest},
-					Disclose: irma.AttributeConDisCon{
-						{{irma.NewAttributeRequest("irma-demo.RU.studentCard.level")}},
-					},
-				},
-			},
-		},
+		StaticSessions:    map[string]interface{}{},
 	}
 }
 

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -392,14 +392,16 @@ func testStaticQRSession(t *testing.T, _ interface{}, opts ...option) {
 	defer staticSessionServer.Close()
 
 	config := RequestorServerAuthConfiguration()
-	config.StaticSessions["staticsession"] = irma.ServiceProviderRequest{
-		RequestorBaseRequest: irma.RequestorBaseRequest{
-			CallbackURL: staticSessionServer.URL,
-		},
-		Request: &irma.DisclosureRequest{
-			BaseRequest: irma.BaseRequest{LDContext: irma.LDContextDisclosureRequest},
-			Disclose: irma.AttributeConDisCon{
-				{{irma.NewAttributeRequest("irma-demo.RU.studentCard.level")}},
+	config.StaticSessions = map[string]interface{}{
+		"staticsession": irma.ServiceProviderRequest{
+			RequestorBaseRequest: irma.RequestorBaseRequest{
+				CallbackURL: staticSessionServer.URL,
+			},
+			Request: &irma.DisclosureRequest{
+				BaseRequest: irma.BaseRequest{LDContext: irma.LDContextDisclosureRequest},
+				Disclose: irma.AttributeConDisCon{
+					{{irma.NewAttributeRequest("irma-demo.RU.studentCard.level")}},
+				},
 			},
 		},
 	}

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -380,8 +381,6 @@ func testDisclosureNewAttributeUpdateSchemeManager(t *testing.T, conf interface{
 func testStaticQRSession(t *testing.T, _ interface{}, opts ...option) {
 	client, handler := parseStorage(t, opts...)
 	defer test.ClearTestStorage(t, handler.storage)
-	rs := StartRequestorServer(t, RequestorServerAuthConfiguration())
-	defer rs.Stop()
 
 	// start server to receive session result callback after the session
 	var received bool
@@ -389,8 +388,24 @@ func testStaticQRSession(t *testing.T, _ interface{}, opts ...option) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		received = true
 	})
-	s := &http.Server{Addr: fmt.Sprintf("localhost:%d", staticSessionServerPort), Handler: mux}
-	go func() { _ = s.ListenAndServe() }()
+	staticSessionServer := httptest.NewServer(mux)
+	defer staticSessionServer.Close()
+
+	config := RequestorServerAuthConfiguration()
+	config.StaticSessions["staticsession"] = irma.ServiceProviderRequest{
+		RequestorBaseRequest: irma.RequestorBaseRequest{
+			CallbackURL: staticSessionServer.URL,
+		},
+		Request: &irma.DisclosureRequest{
+			BaseRequest: irma.BaseRequest{LDContext: irma.LDContextDisclosureRequest},
+			Disclose: irma.AttributeConDisCon{
+				{{irma.NewAttributeRequest("irma-demo.RU.studentCard.level")}},
+			},
+		},
+	}
+
+	rs := StartRequestorServer(t, config)
+	defer rs.Stop()
 
 	// setup static QR and other variables
 	qr := &irma.Qr{
@@ -410,7 +425,6 @@ func testStaticQRSession(t *testing.T, _ interface{}, opts ...option) {
 
 	// give irma server time to post session result to the server started above, and check the call was received
 	time.Sleep(200 * time.Millisecond)
-	require.NoError(t, s.Shutdown(context.Background()))
 	require.True(t, received)
 }
 
@@ -511,13 +525,11 @@ func testChainedSessions(t *testing.T, conf interface{}, opts ...option) {
 	require.IsType(t, IrmaServerConfiguration, conf)
 	irmaServer := StartIrmaServer(t, conf.(func() *server.Configuration)())
 	defer irmaServer.Stop()
-	nextServer := StartNextRequestServer(t, &irmaServer.conf.JwtRSAPrivateKey.PublicKey)
-	defer func() {
-		_ = nextServer.Close()
-	}()
+	nextServer := httptest.NewServer(chainedServerHandler(t, &irmaServer.conf.JwtRSAPrivateKey.PublicKey))
+	defer nextServer.Close()
 
 	var request irma.ServiceProviderRequest
-	require.NoError(t, irma.NewHTTPTransport(nextSessionServerURL, false).Get("1", &request))
+	require.NoError(t, irma.NewHTTPTransport(nextServer.URL, false).Get("1", &request))
 	doSession(t, &request, client, irmaServer, nil, nil, nil)
 
 	// check that our credential instance is new
@@ -947,7 +959,8 @@ func TestDisclosureNonexistingCredTypeUpdateSchemeManager(t *testing.T) {
 }
 
 func TestPOSTSizeLimit(t *testing.T) {
-	rs := StartRequestorServer(t, RequestorServerConfiguration())
+	config := RequestorServerConfiguration()
+	rs := StartRequestorServer(t, config)
 	defer rs.Stop()
 
 	server.PostSizeLimit = 1 << 10
@@ -957,7 +970,7 @@ func TestPOSTSizeLimit(t *testing.T) {
 
 	req, err := http.NewRequest(
 		http.MethodPost,
-		requestorServerURL+"/session/",
+		fmt.Sprintf("http://localhost:%d/session/", config.Port),
 		bytes.NewReader(make([]byte, server.PostSizeLimit+1, server.PostSizeLimit+1)),
 	)
 	require.NoError(t, err)

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -51,7 +51,7 @@ type BadServer struct {
 }
 
 func (s *BadServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	if s.count > 0 {
+	if s.count <= 0 {
 		_, _ = fmt.Fprintln(w, s.success)
 		return
 	} else {

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -117,10 +117,10 @@ func TestParseInvalidIrmaConfiguration(t *testing.T) {
 }
 
 func TestRetryHTTPRequest(t *testing.T) {
-	test.StartBadHttpServer(2, 1*time.Second, "42")
-	defer test.StopBadHttpServer()
+	badServer := test.StartBadHttpServer(2, 1*time.Second, "42")
+	defer badServer.Close()
 
-	transport := NewHTTPTransport("http://localhost:48682", false)
+	transport := NewHTTPTransport(badServer.URL, false)
 	transport.client.HTTPClient.Timeout = 500 * time.Millisecond
 	bts, err := transport.GetBytes("")
 	require.NoError(t, err)

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -117,11 +117,18 @@ func TestParseInvalidIrmaConfiguration(t *testing.T) {
 }
 
 func TestRetryHTTPRequest(t *testing.T) {
-	badServer := test.StartBadHttpServer(2, 1*time.Second, "42")
+	// Make sure that first 5 requests fail.
+	badServer := test.StartBadHttpServer(5, 1*time.Second, "42")
 	defer badServer.Close()
 
 	transport := NewHTTPTransport(badServer.URL, false)
 	transport.client.HTTPClient.Timeout = 500 * time.Millisecond
+
+	// Retryable HTTP tries 3 times, so this attempt should fail.
+	_, err := transport.GetBytes("")
+	require.Error(t, err)
+
+	// The 6th request should succeed.
 	bts, err := transport.GetBytes("")
 	require.NoError(t, err)
 	require.Equal(t, "42\n", string(bts))


### PR DESCRIPTION
The test sometimes fail because one of the hardcoded ports is not available. This PR removes most of these hardcoded ports.

The ones I did not remove where reliant on hardcoded URLs in the test configuration:
- Revocation server
- Keyshare server
- MyIRMA server
- Test server that hosts the schemes

I did also not remove the global variables for the URL of the requestor server, because the `optionReuseServer` of the `doSession` helper relies on a globally specified URL. I managed to make the URL being generated dynamically, but an improvement would still be to refactor `doSession` such that also the hardcoded `requestorServerPort` and `requestorServerURL` can be removed.