### PR TITLE
Fix: go-sse cannot be used in combination with go-chi middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/privacybydesign/irmago
 go 1.15
 
 require (
-	github.com/alexandrevicenzi/go-sse v1.3.1-0.20200117161408-7b23d5ff7420
+	github.com/alexandrevicenzi/go-sse v1.6.0
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/bsm/redislock v0.7.1
 	github.com/bwesterb/go-atum v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexandrevicenzi/go-sse v1.3.1-0.20200117161408-7b23d5ff7420 h1:lDpHFBMtUtgk2zfPEMVO2s03D0nmuuy7A2/s++2+t4c=
-github.com/alexandrevicenzi/go-sse v1.3.1-0.20200117161408-7b23d5ff7420/go.mod h1:BLBuvd1uY9dCX660zu1fzsmr0Cqt3VPqK1e5fPfV6wc=
+github.com/alexandrevicenzi/go-sse v1.6.0 h1:3KvOzpuY7UrbqZgAtOEmub9/V5ykr7Myudw+PA+H1Ik=
+github.com/alexandrevicenzi/go-sse v1.6.0/go.mod h1:jdrNAhMgVqP7OfcUuM8eJx0sOY17wc+girs5utpFZUU=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.17.0 h1:EwLdrIS50uczw71Jc7iVSxZluTKj5nfSP8n7ARRnJy0=


### PR DESCRIPTION
Apply fix https://github.com/alexandrevicenzi/go-sse/issues/8

Causes issues at the UniqueID-issuer where the IRMA server library is used in combination with `go-chi` middleware.