### PR TITLE
Fix chained session deadlock

### DIFF
--- a/internal/sessiontest/helper_dosession_test.go
+++ b/internal/sessiontest/helper_dosession_test.go
@@ -47,6 +47,7 @@ const (
 	optionClientWait
 	optionWait
 	optionPrePairingClient
+	optionPolling
 )
 
 func processOptions(options ...option) option {
@@ -265,6 +266,10 @@ func doSession(
 
 	if frontendOptionsHandler != nil {
 		frontendOptionsHandler(sessionHandler.(*TestHandler))
+	}
+
+	if opts.enabled(optionPolling) {
+		go func() { waitSessionFinished(t, serv, sesPkg.Token, true) }()
 	}
 
 	clientTransport, dismisser := startSessionAtClient(t, sesPkg, client, sessionHandler)

--- a/internal/sessiontest/helper_dosession_test.go
+++ b/internal/sessiontest/helper_dosession_test.go
@@ -269,6 +269,8 @@ func doSession(
 	}
 
 	if opts.enabled(optionPolling) {
+		// Some tests may want to enable polling. We reuse the waitSessionFinished() function for
+		// this, which does its job by polling the GetSessionResult() function.
 		go func() { waitSessionFinished(t, serv, sesPkg.Token, true) }()
 	}
 

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -185,7 +185,7 @@ func chainedServerHandler(t *testing.T, jwtPubKey *rsa.PublicKey) http.Handler {
 		})
 		require.NoError(t, err)
 
-		// give polling time to land in between
+		// Simulate a slowly responding server
 		time.Sleep(200 * time.Millisecond)
 
 		logger.Trace("2nd request: ", string(bts))

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -185,6 +185,9 @@ func chainedServerHandler(t *testing.T, jwtPubKey *rsa.PublicKey) http.Handler {
 		})
 		require.NoError(t, err)
 
+		// give polling time to land in between
+		time.Sleep(200 * time.Millisecond)
+
 		logger.Trace("2nd request: ", string(bts))
 		_, err = w.Write(bts)
 		require.NoError(t, err)

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -518,6 +518,11 @@ func testChainedSessions(t *testing.T, conf interface{}, opts ...option) {
 
 	var request irma.ServiceProviderRequest
 	require.NoError(t, irma.NewHTTPTransport(nextSessionServerURL, false).Get("1", &request))
+
+	// In case of chained sessions, the server's session store is queried twice in a single
+	// HTTP handler (when processing the irmaclient's response). The mutexes involved have caused
+	// deadlocks in the past when the frontend polls the session status, so we simulate polling in
+	// this test.
 	doSession(t, &request, client, irmaServer, nil, nil, nil, append(opts, optionPolling)...)
 
 	// check that our credential instance is new

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -518,7 +518,7 @@ func testChainedSessions(t *testing.T, conf interface{}, opts ...option) {
 
 	var request irma.ServiceProviderRequest
 	require.NoError(t, irma.NewHTTPTransport(nextSessionServerURL, false).Get("1", &request))
-	doSession(t, &request, client, irmaServer, nil, nil, nil)
+	doSession(t, &request, client, irmaServer, nil, nil, nil, append(opts, optionPolling)...)
 
 	// check that our credential instance is new
 	id := request.SessionRequest().Disclosure().Disclose[0][0][0].Type.CredentialTypeIdentifier()

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -164,10 +164,9 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 
 	r := chi.NewRouter()
 	s.router = r
-	if s.conf.Verbose >= 2 {
-		opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: true}
-		r.Use(server.LogMiddleware("client", opts))
-	}
+
+	opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: true}
+	r.Use(server.LogMiddleware("client", opts))
 
 	r.Use(server.SizeLimitMiddleware)
 	r.Use(server.TimeoutMiddleware([]string{"/statusevents", "/updateevents"}, server.WriteTimeout))

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -130,8 +130,9 @@ var (
 
 func (s *memorySessionStore) get(t irma.RequestorToken) (*session, error) {
 	s.RLock()
-	defer s.RUnlock()
 	ses := s.requestor[t]
+	s.RUnlock()
+
 	if ses != nil {
 		ses.Lock()
 		ses.locked = true
@@ -144,9 +145,9 @@ func (s *memorySessionStore) get(t irma.RequestorToken) (*session, error) {
 
 func (s *memorySessionStore) clientGet(t irma.ClientToken) (*session, error) {
 	s.RLock()
-	defer s.RUnlock()
-
 	ses := s.client[t]
+	s.RUnlock()
+
 	if ses != nil {
 		ses.Lock()
 		ses.locked = true

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -104,10 +104,8 @@ func (s *Server) Handler() http.Handler {
 		router.Use(server.SizeLimitMiddleware)
 		router.Use(server.TimeoutMiddleware(nil, server.WriteTimeout))
 
-		if s.conf.Verbose >= 2 {
-			opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: true}
-			router.Use(server.LogMiddleware("keyshareserver", opts))
-		}
+		opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: true}
+		router.Use(server.LogMiddleware("keyshareserver", opts))
 
 		// Registration
 		router.Post("/client/register", s.handleRegister)

--- a/server/keyshare/myirmaserver/server.go
+++ b/server/keyshare/myirmaserver/server.go
@@ -84,10 +84,8 @@ func (s *Server) Handler() http.Handler {
 		router.Use(server.SizeLimitMiddleware)
 		router.Use(server.TimeoutMiddleware(nil, server.WriteTimeout))
 
-		if s.conf.Verbose >= 2 {
-			opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: false}
-			router.Use(server.LogMiddleware("keyshare-myirma", opts))
-		}
+		opts := server.LogOptions{Response: true, Headers: true, From: false, EncodeBinary: false}
+		router.Use(server.LogMiddleware("keyshare-myirma", opts))
 
 		// Login/logout
 		router.Post("/login/irma", s.handleIrmaLogin)

--- a/server/requestorserver/server.go
+++ b/server/requestorserver/server.go
@@ -195,9 +195,7 @@ func (s *Server) Handler() http.Handler {
 		r.Use(server.SizeLimitMiddleware)
 		r.Use(server.TimeoutMiddleware([]string{"/statusevents"}, server.WriteTimeout))
 		r.Use(cors.New(corsOptions).Handler)
-		if s.conf.Verbose >= 2 {
-			r.Use(server.LogMiddleware("requestor", log))
-		}
+		r.Use(server.LogMiddleware("requestor", log))
 
 		// Server routes
 		r.Route("/session", func(r chi.Router) {
@@ -221,9 +219,7 @@ func (s *Server) Handler() http.Handler {
 		r.Use(server.SizeLimitMiddleware)
 		r.Use(server.TimeoutMiddleware(nil, server.WriteTimeout))
 		r.Use(cors.New(corsOptions).Handler)
-		if s.conf.Verbose >= 2 {
-			r.Use(server.LogMiddleware("revocation", log))
-		}
+		r.Use(server.LogMiddleware("revocation", log))
 		r.Post("/revocation", s.handleRevocation)
 	})
 


### PR DESCRIPTION
If the next session URL responds so slowly that a polling lands in the middle, then:
1) the poll HTTP handler locks the session store, and first tries to lock the session before unlocking the session store;
2) the /proofs HTTP handler has the session locked, and tries locking the session store when the next session URL finally responds. But 1) still has the sessionstore lock, so 2) cannot complete and unlock the session lock, so 1) cannot complete and release the session store lock. Deadlock.

The fix is to make the unlocking of the memory session store in 1) immediate and not conditional on locking the session.

This PR also ensures that 4xx or 5xx responses result in warnings, regardless of the enabled logging level.