### PR TITLE
Fix broken retrieval of keyshare server user from postgres database

### DIFF
--- a/server/keyshare/keyshareserver/postgresdb.go
+++ b/server/keyshare/keyshareserver/postgresdb.go
@@ -43,7 +43,7 @@ func (db *postgresDB) AddUser(user *User) error {
 	res, err := db.db.Query("INSERT INTO irma.users (username, language, coredata, last_seen, pin_counter, pin_block_date) VALUES ($1, $2, $3, $4, 0, 0) RETURNING id",
 		user.Username,
 		user.Language,
-		user.Secrets[:],
+		user.Secrets,
 		time.Now().Unix())
 	if err != nil {
 		return err
@@ -66,16 +66,14 @@ func (db *postgresDB) AddUser(user *User) error {
 
 func (db *postgresDB) user(username string) (*User, error) {
 	var result User
-	var secrets []byte
 	err := db.db.QueryUser(
 		"SELECT id, username, language, coredata FROM irma.users WHERE username = $1 AND coredata IS NOT NULL",
-		[]interface{}{&result.id, &result.Username, &result.Language, &secrets},
+		[]interface{}{&result.id, &result.Username, &result.Language, &result.Secrets},
 		username,
 	)
 	if err != nil {
 		return nil, err
 	}
-	copy(result.Secrets[:], secrets)
 	return &result, nil
 }
 
@@ -84,7 +82,7 @@ func (db *postgresDB) updateUser(user *User) error {
 		"UPDATE irma.users SET username = $1, language = $2, coredata = $3 WHERE id=$4",
 		user.Username,
 		user.Language,
-		user.Secrets[:],
+		user.Secrets,
 		user.id,
 	)
 }

--- a/server/keyshare/keyshareserver/postgresdb_test.go
+++ b/server/keyshare/keyshareserver/postgresdb_test.go
@@ -25,7 +25,7 @@ func TestPostgresDBUserManagement(t *testing.T) {
 
 	nuser, err := db.user("testuser")
 	require.NoError(t, err)
-	assert.Equal(t, "testuser", nuser.Username)
+	assert.Equal(t, user, nuser)
 
 	_, err = db.user("notexist")
 	assert.Error(t, err)


### PR DESCRIPTION
Now that `user.Secrets` (of type `keysharecore.UserSecrets`) is a slice instead of an array, passing `user.Secrets[:]` to the database query functions means that when they reslice it to be big enough to receive the data, this is not reflected in `user.Secrets`; so it would stay nil.

Regression of 93f79164.