### PR TITLE
Upgrade cron library to maintained go-co-op/gocron

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/getsentry/raven-go v0.0.0-20180121060056-563b81fc02b7
 	github.com/go-chi/chi v3.3.3+incompatible
 	github.com/go-chi/cors v1.0.0
+	github.com/go-co-op/gocron v1.13.0 // indirect
 	github.com/go-errors/errors v1.0.1
 	github.com/go-redis/redis/v8 v8.8.0
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
@@ -23,7 +24,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.2
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgx v3.6.2+incompatible
-	github.com/jasonlvhit/gocron v0.0.0-20180312192515-54194c9749d4
 	github.com/jinzhu/gorm v1.9.12
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/mdp/qrterminal v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/go-chi/chi v3.3.3+incompatible h1:KHkmBEMNkwKuK4FdQL7N2wOeB9jnIx7jR5w
 github.com/go-chi/chi v3.3.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/cors v1.0.0 h1:e6x8k7uWbUwYs+aXDoiUzeQFT6l0cygBYyNhD7/1Tg0=
 github.com/go-chi/cors v1.0.0/go.mod h1:K2Yje0VW/SJzxiyMYu6iPQYa7hMjQX2i/F491VChg1I=
+github.com/go-co-op/gocron v1.13.0 h1:BjkuNImPy5NuIPEifhWItFG7pYyr27cyjS6BN9w/D4c=
+github.com/go-co-op/gocron v1.13.0/go.mod h1:GD5EIEly1YNW+LovFVx5dzbYVcIc8544K99D8UVRpGo=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -426,6 +428,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -641,6 +645,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/sessiontest/revocation_test.go
+++ b/internal/sessiontest/revocation_test.go
@@ -200,6 +200,8 @@ func TestRevocationAll(t *testing.T) {
 
 		// run scheduled update of accumulator, triggering a POST to our IRMA server
 		runAllSchedulerJobs(revServer.conf.IrmaConfiguration.Scheduler)
+		// give HTTP request time to be processed
+		time.Sleep(100 * time.Millisecond)
 
 		// check that both the revocation server's and our IRMA server's configuration
 		// agree on the same accumulator which has the same index but updated time
@@ -348,6 +350,8 @@ func TestRevocationAll(t *testing.T) {
 		accindex := sacc.Accumulator.Index
 		sacctime := sacc.Accumulator.Time
 
+		// wait for a moment to assure the accumulator's timestamp will actually differ
+		time.Sleep(time.Second)
 		// trigger time update and update accumulator
 		runAllSchedulerJobs(revServer.conf.IrmaConfiguration.Scheduler)
 

--- a/irmaclient/revocation.go
+++ b/irmaclient/revocation.go
@@ -39,7 +39,7 @@ func (client *Client) initRevocation() {
 	// - Updating happens regularly even if the app is rarely used.
 	// We do this by every 10 seconds updating the credential with a low probability, which
 	// increases over time since the last update.
-	client.Configuration.Scheduler.Every(irma.RevocationParameters.ClientUpdateInterval).Seconds().Do(func() {
+	_, err := client.Configuration.Scheduler.Every(irma.RevocationParameters.ClientUpdateInterval).Seconds().Do(func() {
 		for id, attrsets := range client.attributes {
 			for i, attrs := range attrsets {
 				if attrs.CredentialType() == nil || !attrs.CredentialType().RevocationSupported() {
@@ -79,6 +79,9 @@ func (client *Client) initRevocation() {
 			}
 		}
 	})
+	if err != nil {
+		client.reportError(err)
+	}
 }
 
 // NonrevPrepare updates the revocation state for each credential in the request

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"github.com/go-co-op/gocron"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/jasonlvhit/gocron"
 	"github.com/sirupsen/logrus"
 )
 
@@ -195,8 +195,8 @@ func (conf *Configuration) ParseFolder() (err error) {
 	}
 
 	if conf.Revocation == nil {
-		conf.Scheduler = gocron.NewScheduler()
-		conf.Scheduler.Start()
+		conf.Scheduler = gocron.NewScheduler(time.UTC)
+		conf.Scheduler.StartAsync()
 		conf.Revocation = &RevocationStorage{conf: conf}
 		if err = conf.Revocation.Load(
 			Logger.IsLevelEnabled(logrus.DebugLevel),

--- a/revocation.go
+++ b/revocation.go
@@ -126,7 +126,7 @@ var RevocationParameters = struct {
 
 	// RequestorUpdateInterval is the time period in minutes for requestor servers
 	// updating their revocation state at th RA.
-	RequestorUpdateInterval uint64
+	RequestorUpdateInterval int
 
 	// DefaultTolerance is the default tolerance in seconds: nonrevocation should be proved
 	// by clients up to maximally this amount of seconds ago at verification time. If not, the
@@ -135,15 +135,15 @@ var RevocationParameters = struct {
 
 	// If server mode is enabled for a credential type, then once every so many seconds
 	// the timestamp in each accumulator is updated to now.
-	AccumulatorUpdateInterval uint64
+	AccumulatorUpdateInterval int
 
 	// DELETE issuance records of expired credential every so many minutes
-	DeleteIssuanceRecordsInterval uint64
+	DeleteIssuanceRecordsInterval int
 
 	// ClientUpdateInterval is the time interval with which the irmaclient periodically
 	// retrieves a revocation update from the RA and updates its revocation state with a small but
 	// increasing probability.
-	ClientUpdateInterval uint64
+	ClientUpdateInterval int
 
 	// ClientDefaultUpdateSpeed is the amount of time in hours after which it becomes very likely
 	// that the app will update its witness, quickly after it has been opened.
@@ -751,14 +751,16 @@ func (rs *RevocationStorage) Load(debug bool, dbtype, connstr string, settings R
 		return errors.Errorf("revocation mode for %s requires SQL database but no connection string given", *t)
 	}
 
-	rs.conf.Scheduler.Every(RevocationParameters.AccumulatorUpdateInterval).Seconds().Do(func() {
+	if _, err := rs.conf.Scheduler.Every(RevocationParameters.AccumulatorUpdateInterval).Seconds().Do(func() {
 		if err := rs.updateAccumulatorTimes(); err != nil {
 			err = errors.WrapPrefix(err, "failed to write updated accumulator record", 0)
 			raven.CaptureError(err, nil)
 		}
-	})
+	}); err != nil {
+		return err
+	}
 
-	rs.conf.Scheduler.Every(RevocationParameters.DeleteIssuanceRecordsInterval).Minutes().Do(func() {
+	if _, err := rs.conf.Scheduler.Every(RevocationParameters.DeleteIssuanceRecordsInterval).Minutes().Do(func() {
 		if !rs.sqlMode {
 			return
 		}
@@ -766,7 +768,9 @@ func (rs *RevocationStorage) Load(debug bool, dbtype, connstr string, settings R
 			err = errors.WrapPrefix(err, "failed to delete expired issuance records", 0)
 			raven.CaptureError(err, nil)
 		}
-	})
+	}); err != nil {
+		return err
+	}
 
 	if connstr == "" {
 		Logger.Trace("Using memory revocation database")

--- a/schemes.go
+++ b/schemes.go
@@ -135,7 +135,7 @@ func (conf *Configuration) DangerousTOFUInstallScheme(url string) error {
 	return conf.installScheme(url, nil, "")
 }
 
-func (conf *Configuration) AutoUpdateSchemes(interval uint) {
+func (conf *Configuration) AutoUpdateSchemes(interval int) error {
 	Logger.Infof("Updating schemes every %d minutes", interval)
 	update := func() {
 		if err := conf.UpdateSchemes(); err != nil {
@@ -147,12 +147,16 @@ func (conf *Configuration) AutoUpdateSchemes(interval uint) {
 			}
 		}
 	}
-	conf.Scheduler.Every(uint64(interval)).Minutes().Do(update)
+	_, err := conf.Scheduler.Every(interval).Minutes().Do(update)
+	if err != nil {
+		return err
+	}
 	// Run first update after a small delay
 	go func() {
 		<-time.NewTimer(200 * time.Millisecond).C
 		update()
 	}()
+	return nil
 }
 
 func (conf *Configuration) UpdateSchemes() error {

--- a/server/conf.go
+++ b/server/conf.go
@@ -228,7 +228,9 @@ func (conf *Configuration) verifyIrmaConf() error {
 		conf.SchemesUpdateInterval = 60
 	}
 	if !conf.DisableSchemesUpdate {
-		conf.IrmaConfiguration.AutoUpdateSchemes(uint(conf.SchemesUpdateInterval))
+		if err := conf.IrmaConfiguration.AutoUpdateSchemes(conf.SchemesUpdateInterval); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -85,7 +85,9 @@ func New(conf *Configuration) (*Server, error) {
 	})
 
 	// Setup session cache clearing
-	s.scheduler.Every(10).Seconds().Do(s.store.flush)
+	if _, err := s.scheduler.Every(10).Second().Do(s.store.flush); err != nil {
+		return nil, err
+	}
 	s.scheduler.StartAsync()
 
 	return s, nil

--- a/server/keyshare/myirmaserver/server.go
+++ b/server/keyshare/myirmaserver/server.go
@@ -3,6 +3,7 @@ package myirmaserver
 import (
 	"context"
 	"encoding/json"
+	"github.com/go-co-op/gocron"
 	"net/http"
 	"strconv"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/cors"
 	"github.com/go-errors/errors"
-	"github.com/jasonlvhit/gocron"
 	"github.com/privacybydesign/irmago/internal/common"
 	"github.com/privacybydesign/irmago/server"
 	"github.com/privacybydesign/irmago/server/keyshare"
@@ -27,7 +27,6 @@ type Server struct {
 	store         sessionStore
 	db            db
 	scheduler     *gocron.Scheduler
-	schedulerStop chan<- bool
 }
 
 var (
@@ -49,11 +48,11 @@ func New(conf *Configuration) (*Server, error) {
 		irmaserv:  irmaserv,
 		store:     newMemorySessionStore(time.Duration(conf.SessionLifetime) * time.Second),
 		db:        conf.DB,
-		scheduler: gocron.NewScheduler(),
+		scheduler: gocron.NewScheduler(time.UTC),
 	}
 
 	s.scheduler.Every(10).Seconds().Do(s.store.flush)
-	s.schedulerStop = s.scheduler.Start()
+	s.scheduler.StartAsync()
 
 	if s.conf.LogJSON {
 		s.conf.Logger.WithField("configuration", s.conf).Debug("Configuration")
@@ -67,7 +66,7 @@ func New(conf *Configuration) (*Server, error) {
 
 func (s *Server) Stop() {
 	s.irmaserv.Stop()
-	s.schedulerStop <- true
+	s.scheduler.Stop()
 }
 
 func (s *Server) Handler() http.Handler {

--- a/server/keyshare/myirmaserver/server.go
+++ b/server/keyshare/myirmaserver/server.go
@@ -51,7 +51,9 @@ func New(conf *Configuration) (*Server, error) {
 		scheduler: gocron.NewScheduler(time.UTC),
 	}
 
-	s.scheduler.Every(10).Seconds().Do(s.store.flush)
+	if _, err := s.scheduler.Every(10 * time.Second).Do(s.store.flush); err != nil {
+		return nil, err
+	}
 	s.scheduler.StartAsync()
 
 	if s.conf.LogJSON {


### PR DESCRIPTION
The current scheduler library (https://github.com/jasonlvhit/gocron) has been abandoned and causes race conditions (https://github.com/privacybydesign/irmago/issues/57). There is an active fork from the maintainers that inherited the original project, which is an (almost) drop-in replacement: https://github.com/go-co-op/gocron

This PR replaces jasonlvhit/gocron with go-co-op/gocron