### PR TITLE
Fix: Delete fileStorage and storageOld next to current storage in Rem…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use variable base image, such that we can also build for other base images, like alpine.
 ARG BASE_IMAGE=debian:stable-slim
 
-FROM golang:1.16 as build
+FROM golang:1 as build
 
 # Set build environment
 ENV CGO_ENABLED=0

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -453,6 +453,20 @@ func (client *Client) RemoveStorage() error {
 	if err = client.storage.DeleteAll(); err != nil {
 		return err
 	}
+	fileStorage := fileStorage{storagePath: client.storage.storagePath, Configuration: client.Configuration}
+	if err = fileStorage.DeleteAll(); err != nil {
+		return err
+	}
+	storageOld := storageOld{storageOldPath: client.storage.storagePath, Configuration: client.Configuration}
+	if err = storageOld.Open(); err != nil {
+		return err
+	}
+	if err = storageOld.DeleteAll(); err != nil {
+		return err
+	}
+	if err = storageOld.Close(); err != nil {
+		return err
+	}
 
 	// Client assumes there is always a secret key, so we have to load a new one
 	client.secretkey, err = client.storage.LoadSecretKey()


### PR DESCRIPTION
…oveStorage.

Deleting the fileStorage accidently got removed during the implementation of the storage encryption feature. Both the fileStroage and the unencrypted bbolt storage data must be deleted when removing the storage.