### PR TITLE
feat: Custom session nonce in request

### DIFF
--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -421,10 +421,15 @@ func (s *Server) newSession(action irma.Action, request irma.RequestorRequest, d
 		request:     request.SessionRequest(),
 	}
 
-	s.conf.Logger.WithFields(logrus.Fields{"session": ses.RequestorToken}).Debug("New session started")
-	nonce, _ := gabi.GenerateNonce()
-	base.Nonce = nonce
+	if base.Nonce == nil {
+		nonce, _ := gabi.GenerateNonce()
+		base.Nonce = nonce
+	}
 	base.Context = one
+
+	// Debug
+	myNonce, _ := base.Nonce.MarshalText()
+	s.conf.Logger.WithFields(logrus.Fields{"session": ses.RequestorToken, "nonce": string(myNonce)}).Debug("New session started")
 
 	err := s.sessions.add(ses)
 	if err != nil {


### PR DESCRIPTION
Following the discussion on slack, this feature allows a relying party to set the nonce of the session directly in a signed request.

In a possible scenario:
- A javascript client that talks directly to the IRMA session server (Single-Page Application use-case)
- A relying party that obtains disclosed attributes from the end-user through the Single-Page Application

To prevent replay attacks by the SPA, the relying party must be able to set the nonce in a signed session request, such that the session result cannot be replayed by the javascript client.