### PR TITLE
Avoid gocron panics in revocation code during irmaclient startup

### DIFF
--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -547,6 +547,8 @@ func (client *Client) credentialByID(id irma.CredentialIdentifier) (*credential,
 }
 
 // credential returns the requested credential, or nil if we do not have it.
+// FIXME: this function can cause concurrent map writes panics when invoked concurrently simultaneously,
+// in client.Configuration.publicKeys and client.credentialsCache.
 func (client *Client) credential(id irma.CredentialTypeIdentifier, counter int) (cred *credential, err error) {
 	// If the requested credential is not in credential map, we check if its attributes were
 	// deserialized during New(). If so, there should be a corresponding signature file,

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -209,10 +209,6 @@ func New(
 
 	client.sessions = sessions{client: client, sessions: map[string]*session{}}
 
-	client.jobs = make(chan func(), 100)
-	client.initRevocation()
-	client.StartJobs()
-
 	gocron.SetPanicHandler(func(jobName string, recoverData interface{}) {
 		var details string
 		b, err := json.Marshal(recoverData)
@@ -223,6 +219,10 @@ func New(
 		}
 		client.reportError(errors.Errorf("panic during gocron job '%s': %s", jobName, details))
 	})
+
+	client.jobs = make(chan func(), 100)
+	client.initRevocation()
+	client.StartJobs()
 
 	return client, schemeMgrErr
 }

--- a/server/irmaserver/api.go
+++ b/server/irmaserver/api.go
@@ -114,6 +114,7 @@ func New(conf *server.Configuration) (*Server, error) {
 		return nil, err
 	}
 
+	gocron.SetPanicHandler(server.GocronPanicHandler(s.conf.Logger))
 	s.scheduler.StartAsync()
 
 	return s, nil

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -93,6 +93,7 @@ func New(conf *Configuration) (*Server, error) {
 	if _, err := s.scheduler.Every(10).Seconds().Do(s.store.flush); err != nil {
 		return nil, err
 	}
+	gocron.SetPanicHandler(server.GocronPanicHandler(s.conf.Logger))
 	s.scheduler.StartAsync()
 
 	return s, nil

--- a/server/keyshare/myirmaserver/server.go
+++ b/server/keyshare/myirmaserver/server.go
@@ -54,6 +54,7 @@ func New(conf *Configuration) (*Server, error) {
 	if _, err := s.scheduler.Every(10).Seconds().Do(s.store.flush); err != nil {
 		return nil, err
 	}
+	gocron.SetPanicHandler(server.GocronPanicHandler(s.conf.Logger))
 	s.scheduler.StartAsync()
 
 	if s.conf.LogJSON {


### PR DESCRIPTION
If an `irmaclient.Client` has revocable credentials, then during startup of the client the following two functions are started almost simultaneously in `irmaclient.Client.initRevocation()`:

* [a goroutine](https://github.com/privacybydesign/irmago/blob/master/irmaclient/revocation.go#L27) precomputing for each revocable credential a resource-intensive part of the nonrevocation proof that would be required during disclosure of the credential;
* [a gocron job](https://github.com/privacybydesign/irmago/blob/master/irmaclient/revocation.go#L42) that for each revocable credential fetches fresh revocation state from the issuer if the credential's revocation state is too old. This job is set to runs every 10 seconds, but the first time it runs is immediately when adding it to the scheduler.

Both of these two invoke `irmaclient.Client.credential()` to fetch the credential they act upon. It turns out that this function does not like to be called concurrently; it can cause the following two panics:

* `concurrent map writes` in [`irmaclient.Client.credentialsCache`](https://github.com/privacybydesign/irmago/blob/42e9b8d7485fea626c33ff409a00e2006ac10427/irmaclient/client.go#L583)
* `concurrent map writes` in [`irma.Configuration.publicKeys`](https://github.com/privacybydesign/irmago/blob/42e9b8d7485fea626c33ff409a00e2006ac10427/irmaconfig.go#L492)

After being made aware by @ivard that having revocable credentials can make the app crash, I found these issues by obtaining a revocable credential to my IRMA app, running `adb logcat`, and repeatedly starting the IRMA app. The full stack traces for these two can be seen below.

This PR:
* Avoids these panics for now by preventing these two functions from running simultaneously;
* Uses `gocron.SetPanicHandler` to catch any panics, and either report them to Sentry (in the `irmaclient`) or log them (in the IRMA/keyshare servers).

These issues should really be fixed by making the code thread safe using mutexes or thread-safe maps; we'll have to do that in a later PR.

<details>
  <summary>Panic in <code>irmaclient.Client.credential()</code></summary>

  ```
fatal error: concurrent map writes

goroutine 22 [running]:
runtime.throw({0x71217801d3?, 0x6?})
	go/1.18.2/libexec/src/runtime/panic.go:992 +0x50 fp=0x400049d330 sp=0x400049d300 pc=0x71213498b0
runtime.mapassign_fast64(0x71218c1000?, 0x40004000c0?, 0x0)
	go/1.18.2/libexec/src/runtime/map_fast64.go:102 +0x2e0 fp=0x400049d370 sp=0x400049d330 pc=0x7121327000
github.com/privacybydesign/irmago/irmaclient.(*Client).credential(0x4000200e10, {{0x4000582620?, 0x400014e6c0?}}, 0x0)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:580 +0x374 fp=0x400049d410 sp=0x400049d370 pc=0x712174c0a4
github.com/privacybydesign/irmago/irmaclient.(*Client).initRevocation.func2()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:48 +0x140 fp=0x400049d680 sp=0x400049d410 pc=0x7121758ad0
runtime.call16(0x40004de870, 0x40005238d0, 0x0, 0x0, 0x0, 0x0, 0x400049dbc0)
	go/1.18.2/libexec/src/runtime/asm_arm64.s:511 +0x7c fp=0x400049d6a0 sp=0x400049d680 pc=0x7121377c9c
runtime.reflectcall(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	<autogenerated>:1 +0x34 fp=0x400049d6e0 sp=0x400049d6a0 pc=0x712137bb54
reflect.Value.call({0x7121893980?, 0x40005238d0?, 0x13?}, {0x7121775f70, 0x4}, {0x7121c8c778, 0x0, 0x0?})
	go/1.18.2/libexec/src/reflect/value.go:556 +0x5fc fp=0x400049dd50 sp=0x400049d6e0 pc=0x71213b038c
reflect.Value.Call({0x7121893980?, 0x40005238d0?, 0x4000043e48?}, {0x7121c8c778, 0x0, 0x0})
	go/1.18.2/libexec/src/reflect/value.go:339 +0x98 fp=0x400049ddd0 sp=0x400049dd50 pc=0x71213afb88
github.com/go-co-op/gocron.callJobFuncWithParams({0x7121893980?, 0x40005238d0?}, {0x0, 0x0, 0x4000043e88?})
	github.com/go-co-op/gocron@v1.14.0/gocron.go:106 +0x16c fp=0x400049de50 sp=0x400049ddd0 pc=0x71216bbc6c
github.com/go-co-op/gocron.(*executor).start.func1.2()
	github.com/go-co-op/gocron@v1.14.0/executor.go:92 +0x98 fp=0x400049de90 sp=0x400049de50 pc=0x71216bb648
github.com/go-co-op/gocron.(*executor).start.func1()
	github.com/go-co-op/gocron@v1.14.0/executor.go:99 +0x2d4 fp=0x400049dfd0 sp=0x400049de90 pc=0x71216bb284
runtime.goexit()
	go/1.18.2/libexec/src/runtime/asm_arm64.s:1263 +0x4 fp=0x400049dfd0 sp=0x400049dfd0 pc=0x7121379e44
created by github.com/go-co-op/gocron.(*executor).start
	github.com/go-co-op/gocron@v1.14.0/executor.go:49 +0x64

goroutine 36 [select]:
io.(*pipe).read(0x4000132480, {0x4000094000, 0x1000, 0x0?})
	go/1.18.2/libexec/src/io/pipe.go:57 +0x84
io.(*PipeReader).Read(0x0?, {0x4000094000?, 0x0?, 0x0?})
	go/1.18.2/libexec/src/io/pipe.go:136 +0x28
bufio.(*Scanner).Scan(0x4000055f18)
	go/1.18.2/libexec/src/bufio/scan.go:215 +0x908
github.com/sirupsen/logrus.(*Entry).writerScanner(0x0?, 0x4000131220, 0x400031e750)
	github.com/sirupsen/logrus@v1.8.1/writer.go:59 +0x90
created by github.com/sirupsen/logrus.(*Entry).WriterLevel
	github.com/sirupsen/logrus@v1.8.1/writer.go:51 +0x418

goroutine 37 [IO wait]:
internal/poll.runtime_pollWait(0x71774d2bd8, 0x72)
	go/1.18.2/libexec/src/runtime/netpoll.go:302 +0xa4
internal/poll.(*pollDesc).wait(0x40001324e0?, 0x4000198000?, 0x1)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:83 +0x2c
internal/poll.(*pollDesc).waitRead(...)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:88
internal/poll.(*FD).Read(0x40001324e0, {0x4000198000, 0x400, 0x400})
	go/1.18.2/libexec/src/internal/poll/fd_unix.go:167 +0x1e4
os.(*File).read(...)
	go/1.18.2/libexec/src/os/file_posix.go:31
os.(*File).Read(0x4000131230, {0x4000198000?, 0x400031c4e0?, 0x400002cf00?})
	go/1.18.2/libexec/src/os/file.go:119 +0x60
bufio.(*Reader).fill(0x4000139750)
	go/1.18.2/libexec/src/bufio/bufio.go:106 +0x100
bufio.(*Reader).ReadSlice(0x4000139750, 0xbc?)
	go/1.18.2/libexec/src/bufio/bufio.go:371 +0x34
bufio.(*Reader).ReadLine(0x4000139750)
	go/1.18.2/libexec/src/bufio/bufio.go:400 +0x28
golang.org/x/mobile/internal/mobileinit.lineLog(0x4000131230, 0x0?)
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:55 +0xd4
created by golang.org/x/mobile/internal/mobileinit.init.0
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:82 +0x188

goroutine 38 [IO wait]:
internal/poll.runtime_pollWait(0x71774d29f8, 0x72)
	go/1.18.2/libexec/src/runtime/netpoll.go:302 +0xa4
internal/poll.(*pollDesc).wait(0x40001325a0?, 0x4000380000?, 0x1)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:83 +0x2c
internal/poll.(*pollDesc).waitRead(...)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:88
internal/poll.(*FD).Read(0x40001325a0, {0x4000380000, 0x400, 0x400})
	go/1.18.2/libexec/src/internal/poll/fd_unix.go:167 +0x1e4
os.(*File).read(...)
	go/1.18.2/libexec/src/os/file_posix.go:31
os.(*File).Read(0x4000131240, {0x4000380000?, 0x0?, 0x7177807070?})
	go/1.18.2/libexec/src/os/file.go:119 +0x60
bufio.(*Reader).fill(0x4000139f50)
	go/1.18.2/libexec/src/bufio/bufio.go:106 +0x100
bufio.(*Reader).ReadSlice(0x4000139f50, 0x0?)
	go/1.18.2/libexec/src/bufio/bufio.go:371 +0x34
bufio.(*Reader).ReadLine(0x4000139f50)
	go/1.18.2/libexec/src/bufio/bufio.go:400 +0x28
golang.org/x/mobile/internal/mobileinit.lineLog(0x4000131240, 0x0?)
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:55 +0xd4
created by golang.org/x/mobile/internal/mobileinit.init.0
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:92 +0x2a8

goroutine 4 [syscall]:
os/signal.signal_recv()
	go/1.18.2/libexec/src/runtime/sigqueue.go:151 +0x34
os/signal.loop()
	go/1.18.2/libexec/src/os/signal/signal_unix.go:23 +0x20
created by os/signal.Notify.func1.1
	go/1.18.2/libexec/src/os/signal/signal.go:151 +0x30

goroutine 19 [select]:
github.com/go-co-op/gocron.(*executor).start(0x400051a3a0)
	github.com/go-co-op/gocron@v1.14.0/executor.go:46 +0xbc
created by github.com/go-co-op/gocron.(*Scheduler).start
	github.com/go-co-op/gocron@v1.14.0/scheduler.go:80 +0x6c

goroutine 7 [runnable]:
math/big.nat.montgomery({0x40006ee780?, 0x10?, 0x26?}, {0x40006f3200?, 0x10?, 0x24?}, {0x40006f3200?, 0x10?, 0x24?}, {0x400014b1e0?, ...}, ...)
	go/1.18.2/libexec/src/math/big/nat.go:213 +0x434
math/big.nat.expNNMontgomery({0x40006be640, 0x7121767dc0?, 0x14}, {0x40006be3c0?, 0x4000024020?, 0x4e?}, {0x400008f000, 0x4, 0x725663b790?}, {0x400014b1e0?, ...})
	go/1.18.2/libexec/src/math/big/nat.go:1125 +0x8a4
math/big.nat.expNN({0x0?, 0x4000212230?, 0x40000ba120?}, {0x40006be3c0?, 0x10, 0x14}, {0x400008f000?, 0x4, 0x8}, {0x400014b1e0?, ...})
	go/1.18.2/libexec/src/math/big/nat.go:937 +0x318
math/big.(*Int).Exp(0x40006e3a38, 0x40002ac0c0, 0x40006e3a08?, 0x712157343c?)
	go/1.18.2/libexec/src/math/big/int.go:509 +0x118
github.com/privacybydesign/gabi/big.(*Int).Exp(0x712189b6a0?, 0x7121776b16?, 0x40006e3a58?, 0x71216a73b8?)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/big/int.go:143 +0x20
github.com/privacybydesign/gabi/revocation.(*proofStructure).isTrue(0x40003522a0?, {0x71219526b0, 0x400012a040}, 0x1b?, 0x0?)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/revocation/proof.go:452 +0x84
github.com/privacybydesign/gabi/revocation.NewProofCommit(0x400015a9a0, 0x400012a040, 0x4000096b00)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/revocation/proof.go:183 +0x148
github.com/privacybydesign/gabi.(*NonRevocationProofBuilder).Commit(0x4000377d00)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/credential.go:69 +0x3c
github.com/privacybydesign/gabi.(*Credential).NonrevBuildProofBuilder(0x4000377cc0)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/credential.go:256 +0xd0
github.com/privacybydesign/gabi.(*Credential).NonrevPrepareCache(0x4000377cc0)
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/credential.go:229 +0x130
github.com/privacybydesign/irmago/irmaclient.(*Client).nonrevPrepareCache(0x4000212000?, {{0x4000582620?, 0x4000212000?}}, 0x0?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:236 +0x210
github.com/privacybydesign/irmago/irmaclient.(*Client).initRevocation.func1()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:28 +0x34
github.com/privacybydesign/irmago/irmaclient.(*Client).StartJobs.func1()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:275 +0x78
created by github.com/privacybydesign/irmago/irmaclient.(*Client).StartJobs
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:266 +0xf4
  ```
</details>

<details>
  <summary>Panic in <code>irma.Configuration.parseKeysFolder()</code></summary>

  ```
fatal error: concurrent map writes

goroutine 83 [running]:
runtime.throw({0x711eb9a1d3?, 0x0?})
	go/1.18.2/libexec/src/runtime/panic.go:992 +0x50 fp=0x40004e70f0 sp=0x40004e70c0 pc=0x711e7638b0
runtime.mapassign_fast64(0x711ecdb1e0?, 0xe01?, 0x0)
	go/1.18.2/libexec/src/runtime/map_fast64.go:102 +0x2e0 fp=0x40004e7130 sp=0x40004e70f0 pc=0x711e741000
github.com/privacybydesign/irmago.(*Configuration).parseKeysFolder(0x4000001c20, {{0x40001a6eb8?, 0x40001a6eb8?}})
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaconfig.go:492 +0x320 fp=0x40004e7250 sp=0x40004e7130 pc=0x711eb31db0
github.com/privacybydesign/irmago.(*Configuration).PublicKey(0x4000001c20, {{0x40001a6eb8?, 0x711ecdab80?}}, 0x40004e72d8?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaconfig.go:313 +0xb4 fp=0x40004e72a0 sp=0x40004e7250 pc=0x711eb30814
github.com/privacybydesign/irmago.RevocationKeys.PublicKey({0x400051e2e8?}, {{0x40001a6eb8?, 0xea00004000379301?}}, 0x711eb8f746?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/revocation.go:1022 +0x30 fp=0x40004e7310 sp=0x40004e72a0 pc=0x711eb45330
github.com/privacybydesign/irmago/irmaclient.(*storage).LoadSignature(0x40001d6e50, 0x4000766180)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/storage.go:345 +0xe4 fp=0x40004e7370 sp=0x40004e7310 pc=0x711eb7be54
github.com/privacybydesign/irmago/irmaclient.(*Client).credential(0x40001d6e10, {{0x400062c300?, 0x0?}}, 0x0)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:556 +0x1a0 fp=0x40004e7410 sp=0x40004e7370 pc=0x711eb65ed0
github.com/privacybydesign/irmago/irmaclient.(*Client).initRevocation.func2()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:48 +0x140 fp=0x40004e7680 sp=0x40004e7410 pc=0x711eb72ad0
runtime.call16(0x400057c030, 0x4000567180, 0x0, 0x0, 0x0, 0x0, 0x40004e7bc0)
	go/1.18.2/libexec/src/runtime/asm_arm64.s:511 +0x7c fp=0x40004e76a0 sp=0x40004e7680 pc=0x711e791c9c
runtime.reflectcall(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	<autogenerated>:1 +0x34 fp=0x40004e76e0 sp=0x40004e76a0 pc=0x711e795b54
reflect.Value.call({0x711ecad980?, 0x4000567180?, 0x13?}, {0x711eb8ff70, 0x4}, {0x711f0a6778, 0x0, 0x0?})
	go/1.18.2/libexec/src/reflect/value.go:556 +0x5fc fp=0x40004e7d50 sp=0x40004e76e0 pc=0x711e7ca38c
reflect.Value.Call({0x711ecad980?, 0x4000567180?, 0x4000127648?}, {0x711f0a6778, 0x0, 0x0})
	go/1.18.2/libexec/src/reflect/value.go:339 +0x98 fp=0x40004e7dd0 sp=0x40004e7d50 pc=0x711e7c9b88
github.com/go-co-op/gocron.callJobFuncWithParams({0x711ecad980?, 0x4000567180?}, {0x0, 0x0, 0x4000127688?})
	github.com/go-co-op/gocron@v1.14.0/gocron.go:106 +0x16c fp=0x40004e7e50 sp=0x40004e7dd0 pc=0x711ead5c6c
github.com/go-co-op/gocron.(*executor).start.func1.2()
	github.com/go-co-op/gocron@v1.14.0/executor.go:92 +0x98 fp=0x40004e7e90 sp=0x40004e7e50 pc=0x711ead5648
github.com/go-co-op/gocron.(*executor).start.func1()
	github.com/go-co-op/gocron@v1.14.0/executor.go:99 +0x2d4 fp=0x40004e7fd0 sp=0x40004e7e90 pc=0x711ead5284
runtime.goexit()
	go/1.18.2/libexec/src/runtime/asm_arm64.s:1263 +0x4 fp=0x40004e7fd0 sp=0x40004e7fd0 pc=0x711e793e44
created by github.com/go-co-op/gocron.(*executor).start
	github.com/go-co-op/gocron@v1.14.0/executor.go:49 +0x64
goroutine 6 [select]:
io.(*pipe).read(0x40000704e0, {0x400008e000, 0x1000, 0x0?})
	go/1.18.2/libexec/src/io/pipe.go:57 +0x84
io.(*PipeReader).Read(0x0?, {0x400008e000?, 0x0?, 0x0?})
	go/1.18.2/libexec/src/io/pipe.go:136 +0x28
bufio.(*Scanner).Scan(0x4000094f18)
	go/1.18.2/libexec/src/bufio/scan.go:215 +0x908
github.com/sirupsen/logrus.(*Entry).writerScanner(0x0?, 0x4000011228, 0x40002e6790)
	github.com/sirupsen/logrus@v1.8.1/writer.go:59 +0x90
created by github.com/sirupsen/logrus.(*Entry).WriterLevel
	github.com/sirupsen/logrus@v1.8.1/writer.go:51 +0x418
goroutine 7 [IO wait]:
internal/poll.runtime_pollWait(0x7177538c58, 0x72)
	go/1.18.2/libexec/src/runtime/netpoll.go:302 +0xa4
internal/poll.(*pollDesc).wait(0x4000070540?, 0x4000380000?, 0x1)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:83 +0x2c
internal/poll.(*pollDesc).waitRead(...)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:88
internal/poll.(*FD).Read(0x4000070540, {0x4000380000, 0x400, 0x400})
	go/1.18.2/libexec/src/internal/poll/fd_unix.go:167 +0x1e4
os.(*File).read(...)
	go/1.18.2/libexec/src/os/file_posix.go:31
os.(*File).Read(0x4000011238, {0x4000380000?, 0x4000199ba0?, 0x400002aa00?})
	go/1.18.2/libexec/src/os/file.go:119 +0x60
bufio.(*Reader).fill(0x4000048f50)
	go/1.18.2/libexec/src/bufio/bufio.go:106 +0x100
bufio.(*Reader).ReadSlice(0x4000048f50, 0xbc?)
	go/1.18.2/libexec/src/bufio/bufio.go:371 +0x34
bufio.(*Reader).ReadLine(0x4000048f50)
	go/1.18.2/libexec/src/bufio/bufio.go:400 +0x28
golang.org/x/mobile/internal/mobileinit.lineLog(0x4000011238, 0x0?)
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:55 +0xd4
created by golang.org/x/mobile/internal/mobileinit.init.0
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:82 +0x188
goroutine 8 [IO wait]:
internal/poll.runtime_pollWait(0x7177538a78, 0x72)
	go/1.18.2/libexec/src/runtime/netpoll.go:302 +0xa4
internal/poll.(*pollDesc).wait(0x4000070600?, 0x4000120000?, 0x1)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:83 +0x2c
internal/poll.(*pollDesc).waitRead(...)
	go/1.18.2/libexec/src/internal/poll/fd_poll_runtime.go:88
internal/poll.(*FD).Read(0x4000070600, {0x4000120000, 0x400, 0x400})
	go/1.18.2/libexec/src/internal/poll/fd_unix.go:167 +0x1e4
os.(*File).read(...)
	go/1.18.2/libexec/src/os/file_posix.go:31
os.(*File).Read(0x4000011248, {0x4000120000?, 0x0?, 0x71776278f0?})
	go/1.18.2/libexec/src/os/file.go:119 +0x60
bufio.(*Reader).fill(0x4000049750)
	go/1.18.2/libexec/src/bufio/bufio.go:106 +0x100
bufio.(*Reader).ReadSlice(0x4000049750, 0x0?)
	go/1.18.2/libexec/src/bufio/bufio.go:371 +0x34
bufio.(*Reader).ReadLine(0x4000049750)
	go/1.18.2/libexec/src/bufio/bufio.go:400 +0x28
golang.org/x/mobile/internal/mobileinit.lineLog(0x4000011248, 0x0?)
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:55 +0xd4
created by golang.org/x/mobile/internal/mobileinit.init.0
	golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028/internal/mobileinit/mobileinit_android.go:92 +0x2a8
goroutine 10 [syscall]:
os/signal.signal_recv()
	go/1.18.2/libexec/src/runtime/sigqueue.go:151 +0x34
os/signal.loop()
	go/1.18.2/libexec/src/os/signal/signal_unix.go:23 +0x20
created by os/signal.Notify.func1.1
	go/1.18.2/libexec/src/os/signal/signal.go:151 +0x30
goroutine 14 [select]:
github.com/go-co-op/gocron.(*executor).start(0x40005f3580)
	github.com/go-co-op/gocron@v1.14.0/executor.go:46 +0xbc
created by github.com/go-co-op/gocron.(*Scheduler).start
	github.com/go-co-op/gocron@v1.14.0/scheduler.go:80 +0x6c
goroutine 67 [runnable]:
bytes.(*Buffer).WriteByte(0x40004d24e0?, 0x37?)
	go/1.18.2/libexec/src/bytes/buffer.go:263 +0xb4
encoding/xml.(*Decoder).text(0x40004d2480, 0xffffffffffffffff, 0x0)
	go/1.18.2/libexec/src/encoding/xml/xml.go:1120 +0x3ec
encoding/xml.(*Decoder).rawToken(0x40004d2480)
	go/1.18.2/libexec/src/encoding/xml/xml.go:575 +0x60c
encoding/xml.(*Decoder).Token(0x40004d2480)
	go/1.18.2/libexec/src/encoding/xml/xml.go:289 +0xa0
encoding/xml.(*Decoder).unmarshal(0x40004d2480, {0x711ecece80?, 0x400023a240?, 0x711e7d258c?}, 0x4000444ed8?)
	go/1.18.2/libexec/src/encoding/xml/read.go:516 +0xd9c
encoding/xml.(*Decoder).DecodeElement(0x4000444f18?, {0x711eca69a0?, 0x400023a240?}, 0x711ed29800?)
	go/1.18.2/libexec/src/encoding/xml/read.go:151 +0x150
github.com/privacybydesign/gabi/big.(*Int).UnmarshalXML(0x4000750b80, 0x0?, {{{0x4000752360, 0x29}, {0x711f054cd8, 0x1}}, {0x711f0a6778, 0x0, 0x0}})
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/big/int.go:31 +0x6c
encoding/xml.(*Decoder).unmarshalInterface(0x40004d2480, {0x70d0e62600?, 0x4000750b80}, 0x400032b900)
	go/1.18.2/libexec/src/encoding/xml/read.go:206 +0x198
encoding/xml.(*Decoder).unmarshal(0x40004d2480, {0x711ed60f40?, 0x40001b21a0?, 0x711e73cb20?}, 0x400032b901?)
	go/1.18.2/libexec/src/encoding/xml/read.go:348 +0xc1c
encoding/xml.(*Decoder).unmarshalPath(0x40004d2480?, 0x40005f3740, {0x711ed4f460?, 0x40001b2160?, 0x400032b840?}, {0x40005f3760, 0x1, 0xf?}, 0x400032b900)
	go/1.18.2/libexec/src/encoding/xml/read.go:690 +0x32c
encoding/xml.(*Decoder).unmarshalPath(0x40004d2480?, 0x40005f3740, {0x711ed4f460?, 0x40001b2160?, 0x4000750a60?}, {0x0, 0x0, 0x400010b1e0?}, 0x400032b840)
	go/1.18.2/libexec/src/encoding/xml/read.go:719 +0x450
encoding/xml.(*Decoder).unmarshal(0x40004d2480, {0x711ed4f460?, 0x40001b2160?, 0x71778063b0?}, 0x4000445968?)
	go/1.18.2/libexec/src/encoding/xml/read.go:524 +0x1068
encoding/xml.(*Decoder).DecodeElement(0x711ed6a888?, {0x711ed2e480?, 0x40001b2160?}, 0x1d?)
	go/1.18.2/libexec/src/encoding/xml/read.go:151 +0x150
encoding/xml.(*Decoder).Decode(...)
	go/1.18.2/libexec/src/encoding/xml/read.go:139
encoding/xml.Unmarshal({0x40004f9000, 0xe01, 0xe02}, {0x711ed2e480, 0x40001b2160})
	go/1.18.2/libexec/src/encoding/xml/read.go:133 +0xa0
github.com/privacybydesign/gabi/gabikeys.NewPublicKeyFromBytes({0x40004f9000, 0xe01, 0xe02})
	github.com/privacybydesign/gabi@v0.0.0-20220412064428-d1eff7721dca/gabikeys/keys.go:266 +0x54
github.com/privacybydesign/irmago.(*Configuration).parseKeysFolder(0x4000001c20, {{0x40000b6300?, 0x2?}})
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaconfig.go:484 +0x298
github.com/privacybydesign/irmago.(*Configuration).PublicKey(0x4000001c20, {{0x40000b6300?, 0x711ecdab80?}}, 0x4000375ba8?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaconfig.go:313 +0xb4
github.com/privacybydesign/irmago.RevocationKeys.PublicKey({0x400051e2e8?}, {{0x40000b6300?, 0x711ecb4ca0?}}, 0x711eb8f746?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/revocation.go:1022 +0x30
github.com/privacybydesign/irmago/irmaclient.(*storage).LoadSignature(0x40001d6e50, 0x4000766180)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/storage.go:345 +0xe4
github.com/privacybydesign/irmago/irmaclient.(*Client).credential(0x40001d6e10, {{0x400062c300?, 0x400005ad60?}}, 0x0)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:556 +0x1a0
github.com/privacybydesign/irmago/irmaclient.(*Client).nonrevPrepareCache(0x40001f6000?, {{0x400062c300?, 0x40001f6000?}}, 0x0?)
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:232 +0x1d4
github.com/privacybydesign/irmago/irmaclient.(*Client).initRevocation.func1()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/revocation.go:28 +0x34
github.com/privacybydesign/irmago/irmaclient.(*Client).StartJobs.func1()
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:275 +0x78
created by github.com/privacybydesign/irmago/irmaclient.(*Client).StartJobs
	github.com/privacybydesign/irmago@v0.10.1-0.20220803120053-d7fef1c1b59f/irmaclient/client.go:266 +0xf4
  ```
</details>