### PR TITLE
Fix/use subject value instead of file path value as subject in account removed mail

### DIFF
--- a/server/keyshare/myirmaserver/server.go
+++ b/server/keyshare/myirmaserver/server.go
@@ -167,7 +167,7 @@ func (s *Server) sendDeleteEmails(session *session) error {
 		// the user account, even if one or more notification mails could not be sent.
 		_ = s.conf.SendEmail(
 			s.conf.deleteAccountTemplates,
-			s.conf.DeleteAccountFiles,
+			s.conf.DeleteAccountSubjects,
 			map[string]string{"Username": user.Username, "Email": email.Email, "Delay": strconv.Itoa(s.conf.DeleteDelay)},
 			email.Email,
 			user.language,


### PR DESCRIPTION
    From: [noreply@sidn.nl](mailto:noreply@sidn.nl)
    To: [yivi2@humilis.net](mailto:yivi2@humilis.net)
    Subject: /sidn/myirma/mail/account_removed.en.html

    Dear IRMA user,

    We have received a request to delete your IRMA account (app ID