### PR TITLE
Bugfix: revocation using JWT authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix requestor JWT PublicKey authentication for Revocation endpoint 
+- Fix requestor JWT authentication for Revocation endpoint 
 
 
 ## [0.10.0] - 2022-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix requestor JWT PublicKey authentication for Revocation endpoint 
+
+
 ## [0.10.0] - 2022-03-09
 
 ### Added

--- a/server/requestorserver/auth.go
+++ b/server/requestorserver/auth.go
@@ -212,23 +212,13 @@ func jwtAuthenticate(
 		return false, nil, "", nil
 	}
 
-	// Verify JWT signature. We do not yet store the JWT contents here, because we need to know the session type first
-	// before we can construct a struct instance of the appropriate type into which to unmarshal the JWT contents.
-	claims := &jwt.StandardClaims{}
-	requestorJwt := string(body)
-	_, err := jwt.ParseWithClaims(requestorJwt, claims, jwtKeyExtractor(keys))
-	if err != nil {
-		return true, nil, "", server.RemoteError(server.ErrorInvalidRequest, err.Error())
-	}
-	if time.Unix(claims.IssuedAt, 0).Add(time.Duration(maxRequestAge) * time.Second).Before(time.Now()) {
-		return true, nil, "", server.RemoteError(server.ErrorUnauthorized, "jwt too old")
-	}
-	if !claims.VerifyIssuedAt(time.Now().Unix(), true) {
-		return true, nil, "", server.RemoteError(server.ErrorUnauthorized, "jwt not yet valid")
+	validatedJwt, claims, validationErr := jwtValidateClaims(body, keys, maxRequestAge)
+	if validationErr != nil {
+		return true, nil, "", validationErr
 	}
 
 	// Read JWT contents
-	parsedJwt, err := irma.ParseRequestorJwt(claims.Subject, requestorJwt)
+	parsedJwt, err := irma.ParseRequestorJwt(claims.Subject, validatedJwt)
 	if err != nil {
 		return true, nil, "", server.RemoteError(server.ErrorInvalidRequest, err.Error())
 	}
@@ -244,27 +234,41 @@ func jwtAutheticateRevocation(
 		return false, nil, "", nil
 	}
 
-	claims := &jwt.StandardClaims{}
-	revocationJwt := string(body)
-	if _, err := jwt.ParseWithClaims(revocationJwt, claims, jwtKeyExtractor(keys)); err != nil {
-		return true, nil, "", server.RemoteError(server.ErrorInvalidRequest, err.Error())
-	}
-	if time.Unix(claims.IssuedAt, 0).Add(time.Duration(maxRequestAge) * time.Second).Before(time.Now()) {
-		return true, nil, "", server.RemoteError(server.ErrorUnauthorized, "jwt too old")
-	}
-	if !claims.VerifyIssuedAt(time.Now().Unix(), true) {
-		return true, nil, "", server.RemoteError(server.ErrorUnauthorized, "jwt not yet valid")
+	validatedJwt, _, validationErr := jwtValidateClaims(body, keys, maxRequestAge)
+	if validationErr != nil {
+		return true, nil, "", validationErr
 	}
 
 	// Read JWT contents
-	s := &irma.RevocationJwt{}
-	if _, _, err := new(jwt.Parser).ParseUnverified(revocationJwt, s); err != nil {
+	revocationJwt := &irma.RevocationJwt{}
+	if _, _, err := new(jwt.Parser).ParseUnverified(validatedJwt, revocationJwt); err != nil {
 		return true, nil, "", server.RemoteError(server.ErrorInvalidRequest, err.Error())
 	}
-	if err := s.Request.Validate(); err != nil {
+	if err := revocationJwt.Request.Validate(); err != nil {
 		return true, nil, "", server.RemoteError(server.ErrorInvalidRequest, "Invalid JWT body")
 	}
-	return true, s.Request, s.ServerName, nil
+	return true, revocationJwt.Request, revocationJwt.ServerName, nil
+}
+
+func jwtValidateClaims(
+	body []byte, keys map[string]interface{}, maxRequestAge int,
+) (string, *jwt.StandardClaims, *irma.RemoteError) {
+	// Verify JWT signature. We do not yet store the JWT contents here, because we need to know the session type first
+	// before we can construct a struct instance of the appropriate type into which to unmarshal the JWT contents.
+	claims := &jwt.StandardClaims{}
+	requestorJwt := string(body)
+	_, err := jwt.ParseWithClaims(requestorJwt, claims, jwtKeyExtractor(keys))
+	if err != nil {
+		return "", nil, server.RemoteError(server.ErrorInvalidRequest, err.Error())
+	}
+	if time.Unix(claims.IssuedAt, 0).Add(time.Duration(maxRequestAge) * time.Second).Before(time.Now()) {
+		return "", nil, server.RemoteError(server.ErrorUnauthorized, "jwt too old")
+	}
+	if !claims.VerifyIssuedAt(time.Now().Unix(), true) {
+		return "", nil, server.RemoteError(server.ErrorUnauthorized, "jwt not yet valid")
+	}
+
+	return requestorJwt, claims, nil
 }
 
 func jwtApplies(headers http.Header, body []byte, signatureAlg string) bool {

--- a/server/requestorserver/auth_test.go
+++ b/server/requestorserver/auth_test.go
@@ -184,7 +184,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 	revocationRequest := &irma.RevocationRequest{}
 	require.NoError(t, json.Unmarshal([]byte(revocationRequestData), revocationRequest))
 
-	j := NewRevocationJwt("my_requestor", revocationRequest)
+	j := newRevocationJwt("my_requestor", revocationRequest)
 	validJwtData, jErr := j.Sign(jwt.SigningMethodHS256, key)
 	require.NoError(t, jErr)
 
@@ -205,7 +205,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 
 	server.Logger.SetLevel(logrus.ErrorLevel)
 	t.Run("invalid jwt requestor", func(t *testing.T) {
-		j := NewRevocationJwt("another_requestor", revocationRequest)
+		j := newRevocationJwt("another_requestor", revocationRequest)
 		invalidJwtData, jErr := j.Sign(jwt.SigningMethodHS256, key)
 		require.NoError(t, jErr)
 
@@ -229,7 +229,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 	})
 
 	t.Run("old jwt data", func(t *testing.T) {
-		j := NewRevocationJwt("my_requestor", revocationRequest)
+		j := newRevocationJwt("my_requestor", revocationRequest)
 		j.IssuedAt = (irma.Timestamp)(time.Unix(0, 0))
 		invalidJwtData, jErr := j.Sign(jwt.SigningMethodHS256, key)
 		require.NoError(t, jErr)
@@ -240,7 +240,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 	})
 
 	t.Run("jwt data not yet valid", func(t *testing.T) {
-		j := NewRevocationJwt("my_requestor", revocationRequest)
+		j := newRevocationJwt("my_requestor", revocationRequest)
 		j.IssuedAt = (irma.Timestamp)(time.Now().AddDate(1, 0, 0))
 		invalidJwtData, jErr := j.Sign(jwt.SigningMethodHS256, key)
 		require.NoError(t, jErr)
@@ -251,7 +251,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 	})
 
 	t.Run("jwt signed using invalid key", func(t *testing.T) {
-		j := NewRevocationJwt("my_requestor", revocationRequest)
+		j := newRevocationJwt("my_requestor", revocationRequest)
 		invalidJwtData, jErr := j.Sign(jwt.SigningMethodHS256, invalidKey)
 		require.NoError(t, jErr)
 		applies, _, _, err := authenticator.AuthenticateRevocation(requestHeaders, []byte(invalidJwtData))
@@ -260,7 +260,7 @@ func TestHmacAuthenticator_AuthenticateRevocation(t *testing.T) {
 	})
 }
 
-func NewRevocationJwt(servername string, rr *irma.RevocationRequest) *irma.RevocationJwt {
+func newRevocationJwt(servername string, rr *irma.RevocationRequest) *irma.RevocationJwt {
 	return &irma.RevocationJwt{
 		ServerJwt: irma.ServerJwt{
 			ServerName: servername,


### PR DESCRIPTION
The `/revocation` endpoint for requestors was not usable using JWT authentication.  
When you tried this an error occured:  
```stacktrace
2022/10/31 13:16:26 http: panic serving 172.18.0.1:61426: interface conversion: jwt.Claims is *irma.RevocationJwt, not *jwt.StandardClaims
goroutine 417 [running]:
net/http.(*conn).serve.func1()
    /usr/local/go/src/net/http/server.go:1850 +0xb8
panic({0x8cb0c0, 0x400040f7d0})
    /usr/local/go/src/runtime/panic.go:890 +0x260
net/http.(*timeoutHandler).ServeHTTP(0x40004eb980, {0xb23168, 0x40000f21c0}, 0x40001aa000)
    /usr/local/go/src/net/http/server.go:3412 +0x6f8
github.com/privacybydesign/irmago/server.TimeoutMiddleware.func1.1({0xb23168?, 0x40000f21c0?}, 0x1?)
    /irmago/server/api.go:491 +0x7c
net/http.HandlerFunc.ServeHTTP(0x4000501480?, {0xb23168?, 0x40000f21c0?}, 0x4a360c?)
    /usr/local/go/src/net/http/server.go:2109 +0x38
github.com/privacybydesign/irmago/server.SizeLimitMiddleware.func1({0xb23168?, 0x40000f21c0}, 0x40001aa000)
    /irmago/server/api.go:477 +0x144
```

The actual problem is in the method `jwtKeyExtractor`, which expects an `jwt.StandardClaims` (deprecated).
For the short term this has been fixed in the method `jwtAutheticateRevocation`.
Tests for `AuthenticationRevocation` have been added, specific for JWT authentication.