### PR TITLE
Fix leftover temp folder in scheme folder if scheme updating is aborted

### DIFF
--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -152,7 +152,7 @@ func (conf *Configuration) ParseFolder() (err error) {
 			}
 		}
 		if strings.HasPrefix(filepath.Base(dir), ".") {
-			// No scheme can have a dot in its name, so we can ignore dotted dirs.
+			// No scheme can have a dot in its name, so we can ignore dotted dirs
 			return nil
 		}
 		scheme, _, err := conf.parseSchemeDescription(dir)

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -143,6 +143,18 @@ func (conf *Configuration) ParseFolder() (err error) {
 	var mgrerr *SchemeManagerError
 	var issuerschemes, requestorschemes []Scheme
 	err = common.IterateSubfolders(conf.Path, func(dir string, _ os.FileInfo) error {
+		dirname := filepath.Base(dir)
+		if strings.HasPrefix(dirname, ".tempscheme") || strings.HasPrefix(dirname, ".oldscheme") {
+			// Leftover dirs made by tempSchemeCopy(), from interrupted scheme updates. Remove them
+			if err := os.RemoveAll(dir); err != nil {
+				// warn the error but continue, dotted dirs are ignored below anyway
+				Logger.Warn(err)
+			}
+		}
+		if strings.HasPrefix(filepath.Base(dir), ".") {
+			// No scheme can have a dot in its name, so we can ignore dotted dirs.
+			return nil
+		}
 		scheme, _, err := conf.parseSchemeDescription(dir)
 		if err != nil {
 			return err

--- a/schemes.go
+++ b/schemes.go
@@ -823,7 +823,7 @@ func downloadScheme(url string) (Scheme, error) {
 }
 
 func (conf *Configuration) tempSchemeCopy(scheme Scheme) (string, string, error) {
-	dir, err := ioutil.TempDir(filepath.Dir(scheme.path()), "tempscheme")
+	dir, err := ioutil.TempDir(filepath.Dir(scheme.path()), ".tempscheme")
 	if err != nil {
 		return "", "", err
 	}
@@ -844,7 +844,7 @@ func (conf *Configuration) tempSchemeCopy(scheme Scheme) (string, string, error)
 func (conf *Configuration) updateSchemeDir(scheme Scheme, oldscheme, newscheme string) error {
 	// Create a directory in the same directory as oldscheme,
 	// this is to make sure os.Rename does not fail with an "invalid cross-device link" error.
-	tmp, err := ioutil.TempDir(filepath.Dir(oldscheme), "oldscheme")
+	tmp, err := ioutil.TempDir(filepath.Dir(oldscheme), ".oldscheme")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR solves issue #139 issue by:

* Include a dot in the tempdirs made by the scheme updating function, i.e. `/path/to/schemes/.tempscheme3581524345`.
* Just before iterating over the schemes within the scheme folder, try to remove any existing `.tempschemeXXXXXXXXXX` folders from `/path/to/schemes`.
* When iterating over the schemes within the scheme folder, skip folders beginning with a dot. (Note that no scheme name can ever contain a dot.)

Fixes #139 