### PR TITLE
Support gabi with updated keyshare protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jinzhu/gorm v1.9.16
 	github.com/mdp/qrterminal v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/privacybydesign/gabi v0.0.0-20221109103539-8e9ce1f4eb2c
+	github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750
 	github.com/sietseringers/go-sse v0.0.0-20200801161811-e2cf2c63ca50
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/privacybydesign/gabi v0.0.0-20221109103539-8e9ce1f4eb2c h1:Ffb+ORxS/DiG7crVSV0Zf0WXCrk6VHDbBFU92lRe2pI=
-github.com/privacybydesign/gabi v0.0.0-20221109103539-8e9ce1f4eb2c/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
+github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750 h1:3RuYOQTlArQ6Uw2TgySusmZGluP+18WdQL56YSfkM3Q=
+github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -981,7 +981,7 @@ func (client *Client) IssuanceProofBuilders(
 		if distributed {
 			keyshareP, present = keysharePs[schemeID].Ps[keyID]
 			if distributed && !present {
-				return nil, nil, nil, errors.Errorf("missing keyshareP for %s", keyID)
+				return nil, nil, nil, errors.Errorf("missing keyshareP for %s-%d", keyID.Issuer, keyID.Counter)
 			}
 		}
 

--- a/irmaclient/client.go
+++ b/irmaclient/client.go
@@ -954,22 +954,44 @@ func generateIssuerProofNonce() (*big.Int, error) {
 // IssuanceProofBuilders constructs a list of proof builders in the issuance protocol
 // for the future credentials as well as possibly any disclosed attributes, and generates
 // a nonce against which the issuer's proof of knowledge must verify.
-func (client *Client) IssuanceProofBuilders(request *irma.IssuanceRequest, choice *irma.DisclosureChoice,
+func (client *Client) IssuanceProofBuilders(
+	request *irma.IssuanceRequest, choice *irma.DisclosureChoice, keyshareSession *keyshareSession,
 ) (gabi.ProofBuilderList, irma.DisclosedAttributeIndices, *big.Int, error) {
 	issuerProofNonce, err := generateIssuerProofNonce()
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	builders := gabi.ProofBuilderList([]gabi.ProofBuilder{})
+
+	var keysharePs = map[irma.SchemeManagerIdentifier]*irma.PMap{}
+	if keyshareSession != nil {
+		keysharePs, err = keyshareSession.getKeysharePs(request)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
 	for _, futurecred := range request.Credentials {
 		var pk *gabikeys.PublicKey
+		keyID := futurecred.PublicKeyIdentifier()
+		schemeID := keyID.Issuer.SchemeManagerIdentifier()
+		distributed := client.Configuration.SchemeManagers[schemeID].Distributed()
+		var keyshareP *big.Int
+		var present bool
+		if distributed {
+			keyshareP, present = keysharePs[schemeID].Ps[keyID]
+			if distributed && !present {
+				return nil, nil, nil, errors.Errorf("missing keyshareP for %s", keyID)
+			}
+		}
+
 		pk, err = client.Configuration.PublicKey(futurecred.CredentialTypeID.IssuerIdentifier(), futurecred.KeyCounter)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		credtype := client.Configuration.CredentialTypes[futurecred.CredentialTypeID]
 		credBuilder, err := gabi.NewCredentialBuilder(pk, request.GetContext(),
-			client.secretkey.Key, issuerProofNonce, nil, credtype.RandomBlindAttributeIndices())
+			client.secretkey.Key, issuerProofNonce, keyshareP, credtype.RandomBlindAttributeIndices())
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -988,7 +1010,7 @@ func (client *Client) IssuanceProofBuilders(request *irma.IssuanceRequest, choic
 // and also returns the credential builders which will become the new credentials upon combination with the issuer's signature.
 func (client *Client) IssueCommitments(request *irma.IssuanceRequest, choice *irma.DisclosureChoice,
 ) (*irma.IssueCommitmentMessage, gabi.ProofBuilderList, error) {
-	builders, choices, issuerProofNonce, err := client.IssuanceProofBuilders(request, choice)
+	builders, choices, issuerProofNonce, err := client.IssuanceProofBuilders(request, choice, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/irmaclient/keyshare.go
+++ b/irmaclient/keyshare.go
@@ -214,7 +214,7 @@ func (ks *keyshareSession) fail(manager irma.SchemeManagerIdentifier, err error)
 }
 
 // VerifyPin asks for a pin, repeatedly if necessary, informing the handler of success or failure.
-// It returns whether or not the authentication was succesful.
+// It returns whether the authentication was successful or not.
 func (ks *keyshareSession) VerifyPin(attempts int) bool {
 	ks.pinRequestor.RequestPin(attempts, PinHandler(func(proceed bool, pin string) {
 		if !proceed {

--- a/irmaclient/legacy.go
+++ b/irmaclient/legacy.go
@@ -503,3 +503,17 @@ func (kss *keyshareServer) registerPublicKey(client *Client, transport *irma.HTT
 
 	return result, nil
 }
+
+// removeKeysharePsFromProofUs fixes a difference in gabi between the old keyshare protocol and
+// the new one. In the old one, during issuance the client sends a proof of knowledge only of its
+// own keyshare to the issuer. In the new one, it sends a proof of knowledge of the full secret.
+// Therefore, the proofU contains a PoK over the full secret, while in case of the old keyshare
+// protocol, the issuer expects a PoK only of the user's keyshare. This method removes the
+// keyshare server's contribution for use in the old keyshare protocol.
+func (ks *keyshareSession) removeKeysharePsFromProofUs(proofs gabi.ProofList) {
+	for i, proof := range proofs {
+		if proofU, ok := proof.(*gabi.ProofU); ok {
+			proofU.RemoveKeyshareP(ks.builders[i].(*gabi.CredentialBuilder))
+		}
+	}
+}

--- a/irmaclient/session.go
+++ b/irmaclient/session.go
@@ -113,6 +113,7 @@ var supportedVersions = map[int][]int{
 		6, // introduces nonrevocation proofs
 		7, // introduces chained sessions
 		8, // introduces session binding
+		9, // new keyshare protocol version
 	},
 }
 
@@ -488,20 +489,26 @@ func (session *session) doSession(proceed bool, choice *irma.DisclosureChoice) {
 		session.finish(false)
 	} else {
 		var err error
-		session.builders, session.attrIndices, session.issuerProofNonce, err = session.getBuilders()
-		if err != nil {
-			session.fail(&irma.SessionError{ErrorType: irma.ErrorCrypto, Err: err})
-		}
-		startKeyshareSession(
+		keyshareSession, auth := newKeyshareSession(
 			session,
 			session.client,
 			session.Handler,
-			session.builders,
 			session.request,
 			session.implicitDisclosure,
-			session.issuerProofNonce,
-			session.timestamp,
+			session.Version,
 		)
+		if !auth {
+			// newKeyshareSession() calls session.fail() in case of failure, no need to do that here
+			return
+		}
+		session.builders, session.attrIndices, session.issuerProofNonce, err = session.getBuilders(keyshareSession)
+		if err != nil {
+			session.fail(&irma.SessionError{ErrorType: irma.ErrorCrypto, Err: err})
+		}
+		keyshareSession.builders = session.builders
+		keyshareSession.issuerProofNonce = session.issuerProofNonce
+		keyshareSession.timestamp = session.timestamp
+		keyshareSession.GetCommitments()
 	}
 }
 
@@ -584,7 +591,7 @@ func (session *session) sendResponse(message interface{}) {
 
 // getBuilders computes the builders for disclosure proofs or secretkey-knowledge proof (in case of disclosure/signing
 // and issuing respectively).
-func (session *session) getBuilders() (gabi.ProofBuilderList, irma.DisclosedAttributeIndices, *big.Int, error) {
+func (session *session) getBuilders(keyshareSession *keyshareSession) (gabi.ProofBuilderList, irma.DisclosedAttributeIndices, *big.Int, error) {
 	var builders gabi.ProofBuilderList
 	var err error
 	var issuerProofNonce *big.Int
@@ -594,7 +601,7 @@ func (session *session) getBuilders() (gabi.ProofBuilderList, irma.DisclosedAttr
 	case irma.ActionSigning, irma.ActionDisclosing:
 		builders, choices, session.timestamp, err = session.client.ProofBuilders(session.choice, session.request)
 	case irma.ActionIssuing:
-		builders, choices, issuerProofNonce, err = session.client.IssuanceProofBuilders(session.request.(*irma.IssuanceRequest), session.choice)
+		builders, choices, issuerProofNonce, err = session.client.IssuanceProofBuilders(session.request.(*irma.IssuanceRequest), session.choice, keyshareSession)
 	}
 
 	return builders, choices, issuerProofNonce, err

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -211,7 +211,7 @@ func (conf *Configuration) ParseFolder() (err error) {
 // Any error encountered during parsing is considered recoverable only if it is of type *SchemeManagerError;
 // In this case the scheme in which it occurred is downloaded from its remote and re-parsed.
 // If any other error is encountered at any time, it is returned immediately.
-// If no error is returned, parsing and possibly restoring has been succesfull, and there should be no
+// If no error is returned, parsing and possibly restoring has been successful, and there should be no
 // disabled schemes.
 func (conf *Configuration) ParseOrRestoreFolder() (rerr error) {
 	err := conf.ParseFolder()

--- a/requests.go
+++ b/requests.go
@@ -615,6 +615,13 @@ func (dr *DisclosureRequest) Validate() error {
 	return nil
 }
 
+func (cr *CredentialRequest) PublicKeyIdentifier() PublicKeyIdentifier {
+	return PublicKeyIdentifier{
+		Issuer:  cr.CredentialTypeID.IssuerIdentifier(),
+		Counter: cr.KeyCounter,
+	}
+}
+
 func (cr *CredentialRequest) Info(conf *Configuration, metadataVersion byte, issuedAt time.Time) (*CredentialInfo, error) {
 	list, err := cr.AttributeList(conf, metadataVersion, nil, issuedAt)
 	if err != nil {

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -120,7 +120,7 @@ const (
 
 var (
 	minProtocolVersion = irma.NewVersion(2, 4)
-	maxProtocolVersion = irma.NewVersion(2, 8)
+	maxProtocolVersion = irma.NewVersion(2, 8) // TODO support 2.9
 
 	minFrontendProtocolVersion = irma.NewVersion(1, 0)
 	maxFrontendProtocolVersion = irma.NewVersion(1, 1)


### PR DESCRIPTION
This version of `gabi` produces a `proofU` that proves knowledge of both keyshares. To take that into account, this commit changes the following:

- `irmaclient.Client.startKeyshareSession()` is now called `newKeyshareSession`, because it does not actually immediately start the session. Instead, it returns after checking the user's PIN. This is necessary because what happens next now differs per session type, see next point.
- In case of disclosure/ABS, the session proceeds as before. In case of issuance, `/api/v2/prove/getPs` at the keyshare server is first invoked to retrieve the `P` values (`R_0^{keyshare server secret}`), after which the session is started.
- In case of the old keyshare protocol, the keyshare's `P` is divided out from the `U` of the `proofU` because that is what the issuer expects in the old keyshare protocol.

Note: this commit uses the new function in `gabi` added by privacybydesign/gabi#38. Once that is merged, `gabi` should be bumped in `go.mod`.