### PR TITLE
Feat: make it possible to increase MaxSessionLifetime without increasing the SessionResult lifetime

### DIFF
--- a/irma/cmd/config.go
+++ b/irma/cmd/config.go
@@ -61,6 +61,7 @@ func configureIRMAServer() *server.Configuration {
 		Logger:                 logger,
 		Production:             viper.GetBool("production"),
 		MaxSessionLifetime:     viper.GetInt("max_session_lifetime"),
+		SessionResultLifetime:  viper.GetInt("session_result_lifetime"),
 		JwtIssuer:              viper.GetString("jwt_issuer"),
 		JwtPrivateKey:          viper.GetString("jwt_privkey"),
 		JwtPrivateKeyFile:      viper.GetString("jwt_privkey_file"),

--- a/irma/cmd/server.go
+++ b/irma/cmd/server.go
@@ -115,7 +115,8 @@ func setFlags(cmd *cobra.Command, production bool) error {
 	flags.StringSlice("revoke-perms", nil, "list of credentials that all requestors may revoke")
 	flags.Bool("skip-private-keys-check", false, "whether or not to skip checking whether the private keys that requestors have permission for using are present in the configuration")
 	flags.String("static-sessions", "", "preconfigured static sessions (in JSON)")
-	flags.Int("max-session-lifetime", 5, "maximum duration of a session once a client connects in minutes")
+	flags.Int("max-session-lifetime", 15, "maximum duration of a session once a client connects in minutes")
+	flags.Int("session-result-lifetime", 5, "determines how long a session result is preserved in minutes")
 
 	flags.String("revocation-settings", "", "revocation settings (in JSON)")
 

--- a/server/conf.go
+++ b/server/conf.go
@@ -57,8 +57,10 @@ type Configuration struct {
 	// Static session requests after parsing
 	StaticSessionRequests map[string]irma.RequestorRequest `json:"-"`
 
-	// Session Timeout in minutes (default value 0 means 5)
+	// Maximum duration of a session once a client connects in minutes (default value 0 means 15)
 	MaxSessionLifetime int `json:"max_session_lifetime" mapstructure:"max_session_lifetime"`
+	// Determines how long a session result is preserved in minutes (default value 0 means 5)
+	SessionResultLifetime int `json:"session_result_lifetime" mapstructure:"session_result_lifetime"`
 
 	// Used in the "iss" field of result JWTs from /result-jwt and /getproof
 	JwtIssuer string `json:"jwt_issuer" mapstructure:"jwt_issuer"`
@@ -112,9 +114,12 @@ func (conf *Configuration) Check() error {
 	Logger = conf.Logger
 	irma.SetLogger(conf.Logger)
 
-	// Use default session lifetime if not specified
+	// Use default session lifetimes if not specified
 	if conf.MaxSessionLifetime == 0 {
-		conf.MaxSessionLifetime = 5
+		conf.MaxSessionLifetime = 15
+	}
+	if conf.SessionResultLifetime == 0 {
+		conf.SessionResultLifetime = 5
 	}
 
 	// loop to avoid repetetive err != nil line triplets


### PR DESCRIPTION
Changed default to 15 minutes, while keeping the SessionResult lifetime to 5 minutes.