### PR TITLE
Fix: ParseFolder cannot handle legacy oldscheme and tempscheme directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2023-02-13
+
+### Fixed
+ - ParseFolder cannot handle legacy oldscheme and tempscheme directories
+
 ## [0.11.1] - 2023-01-19
 
 ### Added
@@ -284,6 +289,7 @@ This release contains several large new features. In particular, the shoulder su
 - Combined issuance-disclosure requests with two schemes one of which has a keyshare server now work as expected
 - Various other bugfixes
 
+[0.11.2]: https://github.com/privacybydesign/irmago/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/privacybydesign/irmago/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/privacybydesign/irmago/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/privacybydesign/irmago/compare/v0.9.0...v0.10.0

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 var Logger *logrus.Logger
@@ -330,6 +331,31 @@ filenameloop:
 	return false, nil
 }
 
+func ValidateSchemeID(id string) error {
+	// We use the format 'schemeManager.issuer.credential.attribute' in full identifiers,
+	// so dots can never be in a valid scheme id.
+	if strings.Contains(id, ".") {
+		return errors.New("scheme id contains a dot")
+	}
+	if IsTempSchemeDir(id) {
+		return errors.New("scheme id uses forbidden prefix")
+	}
+	return nil
+}
+
+func IsTempSchemeDir(dirname string) bool {
+	if strings.HasPrefix(dirname, ".tempscheme") || strings.HasPrefix(dirname, ".oldscheme") {
+		return true
+	}
+	// In irmago version 0.11.0 and below, temporary directories were not marked as hidden yet. So, there
+	// might be directories starting with 'tempscheme' or 'oldscheme' that should not be considered as a scheme.
+	// To prevent directory name clashes, we forbid scheme IDs starting with these prefixes.
+	if strings.HasPrefix(dirname, "tempscheme") || strings.HasPrefix(dirname, "oldscheme") {
+		return true
+	}
+	return false
+}
+
 func containsSchemes(dir string) (bool, error) {
 	var (
 		hasSubdirs     bool
@@ -368,6 +394,9 @@ func SchemeInfo(filename string, bts []byte) (string, string, error) {
 
 	if temp.Type != "issuer" && temp.Type != "requestor" {
 		return "", "", errors.New("unsupported scheme type")
+	}
+	if err := ValidateSchemeID(temp.ID); err != nil {
+		return "", "", errors.WrapPrefix(err, fmt.Sprintf("invalid scheme id %s", temp.ID), 0)
 	}
 	return temp.ID, temp.Type, nil
 }

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -422,7 +422,7 @@ func SchemeFilename(dir string) (string, error) {
 			return filename, nil
 		}
 	}
-	return "", errors.New("no scheme file found")
+	return "", errors.Errorf("no scheme file found in directory %s", dir)
 }
 
 var SchemeFilenames = []string{"description.xml", "description.json"}

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -144,15 +144,16 @@ func (conf *Configuration) ParseFolder() (err error) {
 	var issuerschemes, requestorschemes []Scheme
 	err = common.IterateSubfolders(conf.Path, func(dir string, _ os.FileInfo) error {
 		dirname := filepath.Base(dir)
-		if strings.HasPrefix(dirname, ".tempscheme") || strings.HasPrefix(dirname, ".oldscheme") {
-			// Leftover dirs made by tempSchemeCopy(), from interrupted scheme updates. Remove them
+		if common.IsTempSchemeDir(dirname) {
+			Logger.Infof("Removing leftover temporary scheme directory %s", dirname)
 			if err := os.RemoveAll(dir); err != nil {
 				// warn the error but continue, dotted dirs are ignored below anyway
 				Logger.Warn(err)
 			}
+			return nil
 		}
 		if strings.HasPrefix(filepath.Base(dir), ".") {
-			// No scheme can have a dot in its name, so we can ignore dotted dirs
+			// Ignore other hidden directories
 			return nil
 		}
 		scheme, _, err := conf.parseSchemeDescription(dir)

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -1608,7 +1608,3 @@ func TestInstallSchemeUnstableRemote(t *testing.T) {
 	err = conf.ParseFolder()
 	require.NoError(t, err)
 }
-
-func TestLeftoverTempSchemeDir(t *testing.T) {
-
-}

--- a/irmago_test.go
+++ b/irmago_test.go
@@ -128,6 +128,8 @@ func TestParseIrmaConfigurationLeftoverTempDir(t *testing.T) {
 	confpath := filepath.Join(storage, "client")
 	require.NoError(t, common.EnsureDirectoryExists(filepath.Join(confpath, ".tempscheme")))
 	require.NoError(t, common.EnsureDirectoryExists(filepath.Join(confpath, ".oldscheme")))
+	require.NoError(t, common.EnsureDirectoryExists(filepath.Join(confpath, "tempscheme")))
+	require.NoError(t, common.EnsureDirectoryExists(filepath.Join(confpath, "oldscheme")))
 	require.NoError(t, common.EnsureDirectoryExists(filepath.Join(confpath, ".foobar")))
 
 	// Parse configuration, the above folders are ignored
@@ -138,6 +140,8 @@ func TestParseIrmaConfigurationLeftoverTempDir(t *testing.T) {
 	// These are removed by ParseFolder()
 	require.NoError(t, common.AssertPathNotExists(filepath.Join(confpath, ".tempscheme")))
 	require.NoError(t, common.AssertPathNotExists(filepath.Join(confpath, ".oldscheme")))
+	require.NoError(t, common.AssertPathNotExists(filepath.Join(confpath, "tempscheme")))
+	require.NoError(t, common.AssertPathNotExists(filepath.Join(confpath, "oldscheme")))
 
 	// Other dotted dirs are left in place by ParseFolder()
 	require.NoError(t, common.AssertPathExists(filepath.Join(confpath, ".foobar")))
@@ -1603,4 +1607,8 @@ func TestInstallSchemeUnstableRemote(t *testing.T) {
 
 	err = conf.ParseFolder()
 	require.NoError(t, err)
+}
+
+func TestLeftoverTempSchemeDir(t *testing.T) {
+
 }

--- a/version.go
+++ b/version.go
@@ -5,4 +5,4 @@
 package irma
 
 // Version of the IRMA command line and libraries
-const Version = "0.11.1"
+const Version = "0.11.2"


### PR DESCRIPTION
Fixes #284 