### PR TITLE
add mssql (Microsoft SQL Server) as supported db type for revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Support for revocation db type `mssql` (Microsoft SQL Server)
+
 ## [0.12.2] - 2023-03-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ You can override the default command by specifying command line options for `go 
 
 We always enforce the `-p 1` option to be used (as explained [above](#running-the-tests)).
 
+### Testing revocation against SQL Server
+
+* Spin up a docker container:
+
+      docker run --rm -p 1433:1433 -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Say:P4rO0L?' -d mcr.microsoft.com/azure-sql-edge
+
+* Prepare the database and user:
+
+      create database test;
+      create login testuser with password = 'test-Password';
+      use test;
+      create user testuser for login testuser;
+      exec sp_addrolemember 'db_owner', 'testuser';
+
+  This only needs to be done once. No table or rows need to be created; the unit tests do this themselves.
+
+* In the revocation_test activate the mssql datasource instead of the postgres
+
+* Run the revocation unit tests
+
 ## Using a local Redis datastore
 `irmago` can either store session states in memory (default) or in a Redis datastore. For local testing purposes you can use the standard [Redis docker container](https://hub.docker.com/_/redis):
 

--- a/go.mod
+++ b/go.mod
@@ -43,11 +43,13 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.1 // indirect

--- a/internal/sessiontest/revocation_test.go
+++ b/internal/sessiontest/revocation_test.go
@@ -30,6 +30,7 @@ import (
 var (
 	revocationDbType, revocationDbStr = "postgres", "host=127.0.0.1 port=5432 user=testuser dbname=test password='testpassword' sslmode=disable"
 	//revocationDbType, revocationDbStr = "mysql", "testuser:testpassword@tcp(127.0.0.1)/test"
+	//revocationDbType, revocationDbStr = "mssql", "sqlserver://testuser:test-Password@127.0.0.1:1433?database=test"
 
 	revocationPkCounter uint = 2
 )

--- a/revocation.go
+++ b/revocation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/privacybydesign/gabi/signed"
 	sseclient "github.com/sietseringers/go-sse"
 
+	_ "github.com/jinzhu/gorm/dialects/mssql"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -88,13 +89,13 @@ type (
 	AccumulatorRecord struct {
 		CredType  CredentialTypeIdentifier `gorm:"primary_key"`
 		Data      signedMessage
-		PKCounter *uint `gorm:"primary_key;auto_increment:false"`
+		PKCounter *uint `gorm:"primary_key;AUTO_INCREMENT:FALSE"`
 	}
 
 	EventRecord struct {
-		Index      *uint64                  `gorm:"primary_key;column:eventindex;auto_increment:false"`
+		Index      *uint64                  `gorm:"primary_key;column:eventindex;AUTO_INCREMENT:FALSE"`
 		CredType   CredentialTypeIdentifier `gorm:"primary_key"`
-		PKCounter  *uint                    `gorm:"primary_key;auto_increment:false"`
+		PKCounter  *uint                    `gorm:"primary_key;AUTO_INCREMENT:FALSE"`
 		E          *RevocationAttribute
 		ParentHash eventHash
 	}
@@ -103,7 +104,7 @@ type (
 	IssuanceRecord struct {
 		Key        string                   `gorm:"primary_key;column:revocationkey"`
 		CredType   CredentialTypeIdentifier `gorm:"primary_key"`
-		Issued     int64                    `gorm:"primary_key;auto_increment:false"`
+		Issued     int64                    `gorm:"primary_key;AUTO_INCREMENT:FALSE"`
 		PKCounter  *uint
 		Attr       *RevocationAttribute
 		ValidUntil int64
@@ -1075,6 +1076,8 @@ func (signedMessage) GormDataType(dialect gorm.Dialect) string {
 		return "bytea"
 	case "mysql":
 		return "blob"
+	case "mssql":
+		return "varbinary(max)"
 	default:
 		return ""
 	}
@@ -1101,6 +1104,8 @@ func (RevocationAttribute) GormDataType(dialect gorm.Dialect) string {
 		return "bytea"
 	case "mysql":
 		return "blob"
+	case "mssql":
+		return "varbinary(max)"
 	default:
 		return ""
 	}
@@ -1161,6 +1166,8 @@ func (eventHash) GormDataType(dialect gorm.Dialect) string {
 		return "bytea"
 	case "mysql":
 		return "blob"
+	case "mssql":
+		return "varbinary(max)"
 	default:
 		return ""
 	}

--- a/revocation_db.go
+++ b/revocation_db.go
@@ -31,7 +31,7 @@ type (
 
 func newSqlStorage(debug bool, dbtype, connstr string) (sqlRevStorage, error) {
 	switch dbtype {
-	case "postgres", "mysql":
+	case "postgres", "mysql", "mssql":
 	default:
 		return sqlRevStorage{}, errors.New("unsupported database type")
 	}
@@ -39,6 +39,10 @@ func newSqlStorage(debug bool, dbtype, connstr string) (sqlRevStorage, error) {
 	g, err := gorm.Open(dbtype, connstr)
 	if err != nil {
 		return sqlRevStorage{}, err
+	}
+
+	if dbtype == "mssql" {
+		gorm.DefaultCallback.Create().Remove("mssql:set_identity_insert")
 	}
 
 	if debug {


### PR DESCRIPTION
Besides postgres and mysql, support for mssql is preferrable for our environment.
Mostly to prevent yet another database type to be added to our hosting environment.

Support has only been added for the revocation part, since that is the part we need.

Due to a case-sensitivity bug in the GORM mssql package, there was a need to uppercase some of the GORM instructions.

The [README.md](README.md) has been updated with instructions to run the tests against SQL Server.

We have been running with this configuration for a few months in our staging environment, without any problems.
