### PR TITLE
Feat: ignore directories in irma_configuration directory that don't contain a scheme

### DIFF
--- a/irmaclient/legacy.go
+++ b/irmaclient/legacy.go
@@ -191,7 +191,7 @@ func (s *storageOld) TxStoreUpdates(tx *transaction, updates []update) error {
 func (s *storageOld) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature, *revocation.Witness, error) {
 	credType := attrs.CredentialType()
 	if credType == nil {
-		return nil, nil, errors.Errorf("Credential %s not known in configuration", credType.Identifier())
+		return nil, nil, errors.New("Credential not known in configuration")
 	}
 	if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
 		return nil, nil, errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())

--- a/irmaclient/legacy.go
+++ b/irmaclient/legacy.go
@@ -191,10 +191,10 @@ func (s *storageOld) TxStoreUpdates(tx *transaction, updates []update) error {
 func (s *storageOld) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature, *revocation.Witness, error) {
 	credType := attrs.CredentialType()
 	if credType == nil {
-		return nil, nil, errors.New("Credential not known in configuration")
+		return nil, nil, errors.New("credential not known in configuration")
 	}
 	if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
-		return nil, nil, errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())
+		return nil, nil, errors.Errorf("scheme %s is disabled", credType.SchemeManagerIdentifier())
 	}
 
 	sig := new(clSignatureWitness)
@@ -202,7 +202,7 @@ func (s *storageOld) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature
 	if err != nil {
 		return nil, nil, err
 	} else if !found {
-		return nil, nil, errors.Errorf("Signature of credential with hash %s cannot be found", attrs.Hash())
+		return nil, nil, errors.Errorf("signature of credential with hash %s cannot be found", attrs.Hash())
 	}
 	if sig.Witness != nil {
 		pk, err := s.Configuration.Revocation.Keys.PublicKey(
@@ -256,10 +256,10 @@ func (s *storageOld) LoadAttributes() (list map[irma.CredentialTypeIdentifier][]
 
 			credType := attrlistlist[0].CredentialType()
 			if credType == nil {
-				return errors.Errorf("Credential %s not known in configuration", credTypeID)
+				return errors.Errorf("credential %s not known in configuration", credTypeID)
 			}
 			if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
-				return errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())
+				return errors.Errorf("scheme %s is disabled", credType.SchemeManagerIdentifier())
 			}
 
 			list[credTypeID] = attrlistlist
@@ -276,10 +276,10 @@ func (s *storageOld) LoadKeyshareServers() (ksses map[irma.SchemeManagerIdentifi
 	}
 	for schemeID := range ksses {
 		if _, ok := s.Configuration.DisabledSchemeManagers[schemeID]; ok {
-			return ksses, errors.Errorf("Scheme %s is disabled", schemeID)
+			return ksses, errors.Errorf("scheme %s is disabled", schemeID)
 		}
 		if schemeManager, ok := s.Configuration.SchemeManagers[schemeID]; !ok || !schemeManager.Distributed() {
-			return ksses, errors.Errorf("Scheme %s not known in configuration", schemeManager.Identifier())
+			return ksses, errors.Errorf("scheme %s not known in configuration", schemeManager.Identifier())
 		}
 	}
 	return
@@ -305,10 +305,10 @@ func (s *storageOld) loadLogs() ([]*LogEntry, error) {
 			}
 			for schemeID := range sr.Identifiers().SchemeManagers {
 				if _, ok := s.Configuration.DisabledSchemeManagers[schemeID]; ok {
-					return errors.Errorf("Scheme %s is disabled", schemeID)
+					return errors.Errorf("scheme %s is disabled", schemeID)
 				}
 				if _, ok := s.Configuration.SchemeManagers[schemeID]; !ok {
-					return errors.Errorf("Scheme %s not known in configuration", schemeID)
+					return errors.Errorf("scheme %s not known in configuration", schemeID)
 				}
 			}
 
@@ -446,10 +446,10 @@ func (f *fileStorage) LoadAttributes() (list map[irma.CredentialTypeIdentifier][
 		attrlist.MetadataAttribute = irma.MetadataFromInt(attrlist.Ints[0], f.Configuration)
 		id := attrlist.CredentialType()
 		if id == nil {
-			return nil, errors.Errorf("Unknown credential type in file storage")
+			return nil, errors.Errorf("unknown credential type in file storage")
 		}
 		if _, ok := f.Configuration.DisabledSchemeManagers[id.SchemeManagerIdentifier()]; ok {
-			return nil, errors.Errorf("Scheme %s is disabled", id.SchemeManagerIdentifier())
+			return nil, errors.Errorf("scheme %s is disabled", id.SchemeManagerIdentifier())
 		}
 
 		ct := id.Identifier()

--- a/irmaclient/storage.go
+++ b/irmaclient/storage.go
@@ -336,7 +336,7 @@ func (s *storage) TxStoreUpdates(tx *transaction, updates []update) error {
 func (s *storage) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature, *revocation.Witness, error) {
 	credType := attrs.CredentialType()
 	if credType == nil {
-		return nil, nil, errors.Errorf("Credential %s not known in configuration", credType.Identifier())
+		return nil, nil, errors.New("Credential not known in configuration")
 	}
 	if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
 		return nil, nil, errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())
@@ -412,7 +412,7 @@ func (s *storage) LoadAttributes() (list map[irma.CredentialTypeIdentifier][]*ir
 
 			credType := attrlistlist[0].CredentialType()
 			if credType == nil {
-				return errors.Errorf("Credential %s not known in configuration", credType.Identifier())
+				return errors.New("Credential not known in configuration")
 			}
 			if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
 				return errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())

--- a/irmaclient/storage.go
+++ b/irmaclient/storage.go
@@ -393,6 +393,7 @@ func (s *storage) LoadAttributes() (list map[irma.CredentialTypeIdentifier][]*ir
 			return nil
 		}
 		return b.ForEach(func(key, value []byte) error {
+			credTypeID := irma.NewCredentialTypeIdentifier(string(key))
 			var attrlistlist []*irma.AttributeList
 
 			plaintext, err := s.decrypt(value)
@@ -412,7 +413,7 @@ func (s *storage) LoadAttributes() (list map[irma.CredentialTypeIdentifier][]*ir
 
 			credType := attrlistlist[0].CredentialType()
 			if credType == nil {
-				return errors.New("Credential not known in configuration")
+				return errors.Errorf("Credential %s not known in configuration", credTypeID)
 			}
 			if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
 				return errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())

--- a/irmaclient/storage.go
+++ b/irmaclient/storage.go
@@ -336,10 +336,10 @@ func (s *storage) TxStoreUpdates(tx *transaction, updates []update) error {
 func (s *storage) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature, *revocation.Witness, error) {
 	credType := attrs.CredentialType()
 	if credType == nil {
-		return nil, nil, errors.New("Credential not known in configuration")
+		return nil, nil, errors.New("credential not known in configuration")
 	}
 	if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
-		return nil, nil, errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())
+		return nil, nil, errors.Errorf("scheme %s is disabled", credType.SchemeManagerIdentifier())
 	}
 
 	sig := new(clSignatureWitness)
@@ -347,7 +347,7 @@ func (s *storage) LoadSignature(attrs *irma.AttributeList) (*gabi.CLSignature, *
 	if err != nil {
 		return nil, nil, err
 	} else if !found {
-		return nil, nil, errors.Errorf("Signature of credential with hash %s cannot be found", attrs.Hash())
+		return nil, nil, errors.Errorf("signature of credential with hash %s cannot be found", attrs.Hash())
 	}
 	if sig.Witness != nil {
 		pk, err := s.Configuration.Revocation.Keys.PublicKey(
@@ -413,10 +413,10 @@ func (s *storage) LoadAttributes() (list map[irma.CredentialTypeIdentifier][]*ir
 
 			credType := attrlistlist[0].CredentialType()
 			if credType == nil {
-				return errors.Errorf("Credential %s not known in configuration", credTypeID)
+				return errors.Errorf("credential %s not known in configuration", credTypeID)
 			}
 			if _, ok := s.Configuration.DisabledSchemeManagers[credType.SchemeManagerIdentifier()]; ok {
-				return errors.Errorf("Scheme %s is disabled", credType.SchemeManagerIdentifier())
+				return errors.Errorf("scheme %s is disabled", credType.SchemeManagerIdentifier())
 			}
 
 			list[credType.Identifier()] = attrlistlist
@@ -433,10 +433,10 @@ func (s *storage) LoadKeyshareServers() (ksses map[irma.SchemeManagerIdentifier]
 	}
 	for schemeID := range ksses {
 		if schemeManager, ok := s.Configuration.SchemeManagers[schemeID]; !ok || !schemeManager.Distributed() {
-			return nil, errors.Errorf("Scheme %s not known in configuration", schemeManager.Identifier())
+			return nil, errors.Errorf("scheme %s not known in configuration", schemeManager.Identifier())
 		}
 		if _, ok := s.Configuration.DisabledSchemeManagers[schemeID]; ok {
-			return nil, errors.Errorf("Scheme %s is disabled", schemeID)
+			return nil, errors.Errorf("scheme %s is disabled", schemeID)
 		}
 	}
 	return
@@ -487,10 +487,10 @@ func (s *storage) loadLogs(max int, startAt func(*bbolt.Cursor) (key, value []by
 			}
 			for schemeID := range sr.Identifiers().SchemeManagers {
 				if _, ok := s.Configuration.SchemeManagers[schemeID]; !ok {
-					return errors.Errorf("Scheme %s not known in configuration", schemeID)
+					return errors.Errorf("scheme %s not known in configuration", schemeID)
 				}
 				if _, ok := s.Configuration.DisabledSchemeManagers[schemeID]; ok {
-					return errors.Errorf("Scheme %s is disabled", schemeID)
+					return errors.Errorf("scheme %s is disabled", schemeID)
 				}
 			}
 
@@ -532,10 +532,10 @@ func (s *storage) TxIterateLogs(tx *transaction, handler func(log *LogEntry) err
 		}
 		for schemeID := range sr.Identifiers().SchemeManagers {
 			if _, ok := s.Configuration.SchemeManagers[schemeID]; !ok {
-				return errors.Errorf("Scheme %s not known in configuration", schemeID)
+				return errors.Errorf("scheme %s not known in configuration", schemeID)
 			}
 			if _, ok := s.Configuration.DisabledSchemeManagers[schemeID]; ok {
-				return errors.Errorf("Scheme %s is disabled", schemeID)
+				return errors.Errorf("scheme %s is disabled", schemeID)
 			}
 		}
 

--- a/irmaconfig.go
+++ b/irmaconfig.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -158,7 +157,9 @@ func (conf *Configuration) ParseFolder() (err error) {
 		}
 		scheme, _, err := conf.parseSchemeDescription(dir)
 		if err != nil {
-			return err
+			// Directory does not contain a valid scheme. We log this issue and skip the directory.
+			Logger.Warnf("Directory %s does not contain a valid scheme: %s", dir, err)
+			return nil
 		}
 		switch scheme.typ() {
 		case SchemeTypeIssuer:
@@ -417,7 +418,7 @@ func (conf *Configuration) KeyshareServerPublicKey(schemeid SchemeManagerIdentif
 	}
 	if _, contains := conf.kssPublicKeys[schemeid][i]; !contains {
 		scheme := conf.SchemeManagers[schemeid]
-		pkbts, err := ioutil.ReadFile(filepath.Join(scheme.path(), fmt.Sprintf("kss-%d.pem", i)))
+		pkbts, err := os.ReadFile(filepath.Join(scheme.path(), fmt.Sprintf("kss-%d.pem", i)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This feature prevents apps from starting if the scheme directory is a bit messy. By adding some checks in the storage classes, we prevent the app to start when configuration is missing that was in use.