### PR TITLE
Fix: legacy endpoints of keyshare server return 403 status codes when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Legacy endpoints of keyshare server return 403 status codes when database is down
 
 ## [0.12.5] - 2023-05-25
 

--- a/server/keyshare/keyshareserver/legacy.go
+++ b/server/keyshare/keyshareserver/legacy.go
@@ -12,6 +12,7 @@ import (
 	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/keysharecore"
 	"github.com/privacybydesign/irmago/server"
+	"github.com/privacybydesign/irmago/server/keyshare"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,7 +34,7 @@ func (s *Server) handleRegisterPublicKey(w http.ResponseWriter, r *http.Request)
 		return pk, err
 	})
 	if err != nil {
-		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
+		keyshare.WriteError(w, err)
 		return
 	}
 
@@ -41,14 +42,14 @@ func (s *Server) handleRegisterPublicKey(w http.ResponseWriter, r *http.Request)
 	user, err := s.db.user(r.Context(), claims.Username)
 	if err != nil {
 		s.conf.Logger.WithFields(logrus.Fields{"username": claims.Username, "error": err}).Warn("Could not find user in db")
-		server.WriteError(w, server.ErrorUserNotRegistered, "")
+		keyshare.WriteError(w, err)
 		return
 	}
 
 	result, err := s.registerPublicKey(r.Context(), user, claims.Pin, pk)
 	if err != nil {
 		// already logged
-		server.WriteError(w, server.ErrorInternal, err.Error())
+		keyshare.WriteError(w, err)
 		return
 	}
 	server.WriteJson(w, result)
@@ -146,7 +147,7 @@ func (s *Server) handleChangePinLegacy(ctx context.Context, w http.ResponseWrite
 	user, err := s.db.user(ctx, username)
 	if err != nil {
 		s.conf.Logger.WithFields(logrus.Fields{"username": username, "error": err}).Warn("Could not find user in db")
-		server.WriteError(w, server.ErrorUserNotRegistered, "")
+		keyshare.WriteError(w, err)
 		return
 	}
 
@@ -154,7 +155,7 @@ func (s *Server) handleChangePinLegacy(ctx context.Context, w http.ResponseWrite
 
 	if err != nil {
 		// already logged
-		server.WriteError(w, server.ErrorInternal, err.Error())
+		keyshare.WriteError(w, err)
 		return
 	}
 	server.WriteJson(w, result)

--- a/server/keyshare/keyshareserver/legacy.go
+++ b/server/keyshare/keyshareserver/legacy.go
@@ -34,7 +34,7 @@ func (s *Server) handleRegisterPublicKey(w http.ResponseWriter, r *http.Request)
 		return pk, err
 	})
 	if err != nil {
-		keyshare.WriteError(w, err)
+		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
 		return
 	}
 


### PR DESCRIPTION
… database is down