### PR TITLE
Feat: use new keyshare protocol in irmaclient

### DIFF
--- a/identifiers.go
+++ b/identifiers.go
@@ -281,7 +281,11 @@ func (pki *PublicKeyIdentifier) UnmarshalText(text []byte) error {
 }
 
 func (pki *PublicKeyIdentifier) MarshalText() (text []byte, err error) {
-	return []byte(fmt.Sprintf("%s-%d", pki.Issuer, pki.Counter)), nil
+	return []byte(pki.String()), nil
+}
+
+func (pki *PublicKeyIdentifier) String() string {
+	return fmt.Sprintf("%s-%d", pki.Issuer, pki.Counter)
 }
 
 // MarshalText implements encoding.TextMarshaler.

--- a/internal/sessiontest/helper_dosession_test.go
+++ b/internal/sessiontest/helper_dosession_test.go
@@ -49,6 +49,7 @@ const (
 	optionClientWait
 	optionWait
 	optionPrePairingClient
+	optionLinkableKeyshareResponse
 	optionPolling
 	optionNoSchemeAssets
 )

--- a/internal/sessiontest/helper_main_test.go
+++ b/internal/sessiontest/helper_main_test.go
@@ -71,10 +71,14 @@ func parseExistingStorage(t *testing.T, storage string, options ...option) (*irm
 		err = client.Configuration.ParseFolder()
 		require.NoError(t, err)
 	}
+
+	version := extractClientMaxVersion(client)
 	if opts.enabled(optionPrePairingClient) {
-		version := extractClientMaxVersion(client)
-		// set to largest protocol version that dos not support pairing
+		// Set to largest protocol version that does not support pairing
 		*version = irma.ProtocolVersion{Major: 2, Minor: 7}
+	} else if opts.enabled(optionLinkableKeyshareResponse) {
+		// Set to largest protocol version that uses linkable keyshare responses
+		*version = irma.ProtocolVersion{Major: 2, Minor: 8}
 	}
 
 	client.SetPreferences(irmaclient.Preferences{DeveloperMode: true})

--- a/internal/sessiontest/legacy_test.go
+++ b/internal/sessiontest/legacy_test.go
@@ -5,6 +5,7 @@ import (
 
 	irma "github.com/privacybydesign/irmago"
 	"github.com/privacybydesign/irmago/internal/test"
+	"github.com/privacybydesign/irmago/internal/testkeyshare"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,4 +68,14 @@ func TestWithoutPairingSupport(t *testing.T) {
 	t.Run("DisclosureNewAttributeUpdateSchemeManager", apply(testDisclosureNewAttributeUpdateSchemeManager, IrmaServerConfiguration, optionPrePairingClient))
 
 	t.Run("StaticQRSession", apply(testStaticQRSession, nil, optionPrePairingClient))
+}
+
+func TestLinkableKeyshareResponse(t *testing.T) {
+	keyshareServer := testkeyshare.StartKeyshareServer(t, logger, irma.NewSchemeManagerIdentifier("test"))
+	defer keyshareServer.Stop()
+	client, handler := parseStorage(t, optionLinkableKeyshareResponse)
+	defer test.ClearTestStorage(t, client, handler.storage)
+	irmaServer := StartIrmaServer(t, nil)
+	defer irmaServer.Stop()
+	keyshareSessions(t, client, irmaServer)
 }

--- a/irmaclient/legacy.go
+++ b/irmaclient/legacy.go
@@ -540,7 +540,7 @@ func (kss *keyshareServer) registerPublicKey(client *Client, transport *irma.HTT
 	}
 
 	result := &irma.KeysharePinStatus{}
-	err = transport.Post("users/register_publickey", result, irma.KeyshareKeyRegistration{PublicKeyRegistrationJWT: jwtt})
+	err = transport.Post("api/v1/users/register_publickey", result, irma.KeyshareKeyRegistration{PublicKeyRegistrationJWT: jwtt})
 	if err != nil {
 		err = irma.WrapErrorPrefix(err, "failed to register public key")
 		return nil, err

--- a/messages.go
+++ b/messages.go
@@ -456,6 +456,10 @@ func (e *SessionError) Error() string {
 
 	buffer.WriteString("Error type: ")
 	buffer.WriteString(string(typ))
+	if len(e.Info) > 0 {
+		buffer.WriteString("\nInfo: ")
+		buffer.WriteString(e.Info)
+	}
 	if e.Err != nil {
 		buffer.WriteString("\nDescription: ")
 		buffer.WriteString(e.Err.Error())
@@ -465,7 +469,7 @@ func (e *SessionError) Error() string {
 		buffer.WriteString(strconv.Itoa(e.RemoteStatus))
 	}
 	if e.RemoteError != nil {
-		buffer.WriteString("\nIRMA server error: ")
+		buffer.WriteString("\nServer error: ")
 		buffer.WriteString(e.RemoteError.Error())
 	}
 

--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -330,6 +330,18 @@ func (session *session) getProofP(commitments *irma.IssueCommitmentMessage, sche
 		if !token.Valid {
 			return nil, errors.Errorf("invalid keyshare proof included for scheme %s", scheme.Name())
 		}
+
+		// Validate whether proofP has the expected values given the chosen protocol version.
+		if session.Version.Below(2, 9) {
+			if claims.ProofP.P == nil {
+				return nil, errors.Errorf("p value missing in keyshare server proofP for scheme %s", scheme.Name())
+			}
+		} else {
+			if claims.ProofP.P != nil {
+				return nil, errors.Errorf("p value unexpectedly set in keyshare server proofP for scheme %s", scheme.Name())
+			}
+		}
+
 		session.KssProofs[scheme] = claims.ProofP
 	}
 

--- a/server/irmaserver/sessions.go
+++ b/server/irmaserver/sessions.go
@@ -120,7 +120,7 @@ const (
 
 var (
 	minProtocolVersion = irma.NewVersion(2, 4)
-	maxProtocolVersion = irma.NewVersion(2, 8) // TODO support 2.9
+	maxProtocolVersion = irma.NewVersion(2, 9)
 
 	minFrontendProtocolVersion = irma.NewVersion(1, 0)
 	maxFrontendProtocolVersion = irma.NewVersion(1, 1)

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -499,7 +499,7 @@ func (s *Server) generateResponseV2(ctx context.Context, user *User, authorizati
 	return proofResponse, nil
 }
 
-// /prove/getLinkableResponse
+// /api/v2/prove/getLinkableResponse
 func (s *Server) handleResponseV2Linkable(w http.ResponseWriter, r *http.Request) {
 	s.keyshareResponse(r.Context(), w, r, true)
 }


### PR DESCRIPTION
In this PR I implemented the clientside parts of the new keyshare protocol. The server endpoints were already introduced in #267, #273, #274 and #278.

This PR does not include introducing a new JWT type for verifiers. This will be done later in a separate PR because it needs some thinking first. There is no API design yet about how we post the JWT to verifiers and we must decide whether we want to keep the difference between the message format in signing sessions and disclosure sessions. The JWT handling for verifiers is not mandatory for using the new keyshare protocol, so this issue is not blocking.