### PR TITLE
Chore: remove leftover TODOs (new keyshare protocol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
-## Added
-- Keyshare server /api/v2/prove/... endpoints for the new keyshare protocol
-
 ### Added
 - E-mail address revalidation, addressing issues where user's e-mail addresses can be (temporary) invalid
+- Keyshare server /api/v2/prove/... endpoints for the new keyshare protocol
 
 ### Changed
 - Use separate application user in Dockerfile for entrypoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+- Keyshare server /api/v2/prove/... endpoints for the new keyshare protocol
+
 ### Added
 - E-mail address revalidation, addressing issues where user's e-mail addresses can be (temporary) invalid
 

--- a/internal/keysharecore/operations_test.go
+++ b/internal/keysharecore/operations_test.go
@@ -183,7 +183,6 @@ func TestProofFunctionality(t *testing.T) {
 		require.NoError(t, err)
 
 		// For issuance, initially get P_t
-		// TODO: The result ps will be used in the generate commitment step and checked when the response is made.
 		_, err = c.GeneratePs(secrets, jwtt, []irma.PublicKeyIdentifier{irma.PublicKeyIdentifier{Issuer: irma.NewIssuerIdentifier("test"), Counter: 1}})
 		require.NoError(t, err)
 

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -315,7 +315,6 @@ func (s *Server) handleCommitmentsV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	commitments, err := s.generateCommitmentsV2(user, authorization, req)
-	// TODO: can ErrInvalidChallenge be removed?
 	if err != nil && (err == keysharecore.ErrInvalidChallenge || err == keysharecore.ErrInvalidJWT) {
 		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
 		return
@@ -338,7 +337,6 @@ func (s *Server) generateCommitmentsV2(user *User, authorization string, req irm
 	}
 
 	// Prepare output message format
-	// TODO: move logic to gabi?
 	mappedCommitments := map[irma.PublicKeyIdentifier]*big.Int{}
 	for i, keyID := range req.Keys {
 		mappedCommitments[keyID] = commitments[i].Pcommit


### PR DESCRIPTION
The missing tests are #327 and #334. If all PRs are being merged together, then everything is properly tested.

Furthermore, I removed two other TODOs that were merely cosmetic.  It does not really need a follow-up.