### PR TITLE
Implement signature verification api

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -19,14 +19,15 @@ import (
 )
 
 const (
-	LDContextDisclosureRequest      = "https://irma.app/ld/request/disclosure/v2"
-	LDContextSignatureRequest       = "https://irma.app/ld/request/signature/v2"
-	LDContextIssuanceRequest        = "https://irma.app/ld/request/issuance/v2"
-	LDContextRevocationRequest      = "https://irma.app/ld/request/revocation/v1"
-	LDContextFrontendOptionsRequest = "https://irma.app/ld/request/frontendoptions/v1"
-	LDContextClientSessionRequest   = "https://irma.app/ld/request/client/v1"
-	LDContextSessionOptions         = "https://irma.app/ld/options/v1"
-	DefaultJwtValidity              = 120
+	LDContextDisclosureRequest            = "https://irma.app/ld/request/disclosure/v2"
+	LDContextSignatureRequest             = "https://irma.app/ld/request/signature/v2"
+	LDContextIssuanceRequest              = "https://irma.app/ld/request/issuance/v2"
+	LDContextRevocationRequest            = "https://irma.app/ld/request/revocation/v1"
+	LDContextSignatureVerificationRequest = "https://irma.app/ld/request/signatureverification/v1"
+	LDContextFrontendOptionsRequest       = "https://irma.app/ld/request/frontendoptions/v1"
+	LDContextClientSessionRequest         = "https://irma.app/ld/request/client/v1"
+	LDContextSessionOptions               = "https://irma.app/ld/options/v1"
+	DefaultJwtValidity                    = 120
 )
 
 // BaseRequest contains information used by all IRMA session types, such the context and nonce,
@@ -269,6 +270,27 @@ type ClientSessionRequest struct {
 	ProtocolVersion *ProtocolVersion `json:"protocolVersion,omitempty"`
 	Options         *SessionOptions  `json:"options,omitempty"`
 	Request         SessionRequest   `json:"request,omitempty"`
+}
+
+// A SignatureVerificationRequest is a request to verify a SignedMessage.
+type SignatureVerificationRequest struct {
+	LDContext string        `json:"@context,omitempty"`
+	Signature SignedMessage `json:"signature"`
+
+	// Optionally, the SignedMessage can be verified against a SignatureRequest
+	Request *SignatureRequest `json:"request,omitempty"`
+}
+
+func (r *SignatureVerificationRequest) Validate() error {
+	if r.LDContext != LDContextSignatureVerificationRequest {
+		return errors.New("not a signature verification request")
+	}
+	if r.Request != nil {
+		if err := r.Request.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (choice *DisclosureChoice) Validate() error {

--- a/server/api.go
+++ b/server/api.go
@@ -67,6 +67,12 @@ type LegacySessionResult struct {
 	Err         *irma.RemoteError          `json:"error,omitempty"`
 }
 
+type SignatureVerificationResult struct {
+	ProofStatus irma.ProofStatus             `json:"proofStatus,omitempty"`
+	Disclosed   [][]*irma.DisclosedAttribute `json:"disclosed,omitempty"`
+	Err         *irma.RemoteError            `json:"error,omitempty"`
+}
+
 const (
 	ComponentRevocation      = "revocation"
 	ComponentSession         = "session"
@@ -266,6 +272,24 @@ func wrapSessionRequest(request irma.SessionRequest) (irma.RequestorRequest, err
 		return &irma.IdentityProviderRequest{Request: r}, nil
 	default:
 		return nil, errors.New("Invalid session type")
+	}
+}
+
+func ParseSignatureVerificationRequest(request interface{}) (*irma.SignatureVerificationRequest, error) {
+	switch r := request.(type) {
+	case irma.SignatureVerificationRequest:
+		return &r, nil
+	case string:
+		return ParseSignatureVerificationRequest([]byte(r))
+	case []byte:
+		msg := irma.SignatureVerificationRequest{}
+		if err := irma.UnmarshalValidate(r, &msg); err != nil {
+			return nil, err
+		}
+
+		return &msg, nil
+	default:
+		return nil, errors.New("Invalid request type")
 	}
 }
 

--- a/server/requestorserver/server.go
+++ b/server/requestorserver/server.go
@@ -218,6 +218,7 @@ func (s *Server) Handler() http.Handler {
 		})
 
 		r.Get("/publickey", s.handlePublicKey)
+		r.Post("/verifysignature", s.handleVerifySignature)
 	})
 
 	router.Group(func(r chi.Router) {
@@ -490,6 +491,33 @@ func (s *Server) handlePublicKey(w http.ResponseWriter, r *http.Request) {
 		Bytes: bts,
 	})
 	_, _ = w.Write(pubBytes)
+}
+
+func (s *Server) handleVerifySignature(w http.ResponseWriter, r *http.Request) {
+	defer common.Close(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.conf.Logger.Error("Could not read signature verification request HTTP POST body")
+		_ = server.LogError(err)
+		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
+		return
+	}
+
+	verreq, err := server.ParseSignatureVerificationRequest(body)
+	if err != nil {
+		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
+		return
+	}
+
+	disclosed, proofStatus, err := verreq.Signature.Verify(s.conf.IrmaConfiguration, verreq.Request)
+	var rerr *irma.RemoteError
+	if err != nil && err == irma.ErrMissingPublicKey {
+		rerr = server.RemoteError(server.ErrorUnknownPublicKey, err.Error())
+	} else if err != nil {
+		rerr = server.RemoteError(server.ErrorUnknown, err.Error())
+	}
+	res := server.SignatureVerificationResult{ProofStatus: proofStatus, Disclosed: disclosed, Err: rerr}
+	server.WriteJson(w, res)
 }
 
 func (s *Server) createSession(w http.ResponseWriter, requestor string, rrequest irma.RequestorRequest) {


### PR DESCRIPTION
Based on a discussion from a long time ago (https://yiviapp.slack.com/archives/C0KCTQ0BC/p1713794023128249) I decided to implement an API endpoint for verifying signatures in the irma server.

Currently, there's no authorization: as the user already has a signature, and authenticator does not prevent doing disclosures with excessive personal data. 

However, maybe it should still be implement to prevent freeloading on a public irma server. I'm not sure about that, nor about how that would look. Alternatively, it could also be made configurable whether the endpoint should be available at all. That way, it can be disabled by default, and hosting parties who are afraid of people using it without authentication can still turn it on when reachable only from a private network.

I haven't made docs or implemented implemented any tests (yet). The verification logic is already tested though, and I'm using this without any issues so far in my project. 

Let me know if you have any ideas or requests! If you guys are interested in merging this, I can probably take a look at unittests and docs some time.