### PR TITLE
Log the amount of replica's Redis wrote to

### DIFF
--- a/server/keyshare/myirmaserver/session.go
+++ b/server/keyshare/myirmaserver/session.go
@@ -104,9 +104,11 @@ func (s *redisSessionStore) add(ctx context.Context, ses session) error {
 			return err
 		}
 		if s.client.FailoverMode {
-			if err := tx.Wait(ctx, 1, time.Second).Err(); err != nil {
+			replicas, err := s.client.Wait(ctx, 1, time.Second).Result()
+			if err != nil {
 				return err
 			}
+			s.logger.WithFields(logrus.Fields{"replicas": replicas}).Debug("Redis datastore acknowledged write")
 		}
 		return nil
 	}); err != nil {
@@ -150,9 +152,11 @@ func (s *redisSessionStore) update(ctx context.Context, token string, handler fu
 		}
 
 		if s.client.FailoverMode {
-			if err := tx.Wait(ctx, 1, time.Second).Err(); err != nil {
+			replicas, err := s.client.Wait(ctx, 1, time.Second).Result()
+			if err != nil {
 				return err
 			}
+			s.logger.WithFields(logrus.Fields{"replicas": replicas}).Debug("Redis datastore acknowledged write")
 		}
 		return nil
 	})


### PR DESCRIPTION
This pull request includes several changes to improve logging in the `redisSessionStore` methods across different files. The main focus is on enhancing the visibility of Redis datastore acknowledgments by logging the number of replicas that acknowledged the write.

Deploying this change should contribute to fixing #394 