### PR TITLE
Chore: make keyshare protocol more resilient by retrying when getResp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use golang version 1.23
+- Make keyshare protocol more resilient by retrying when `getResponse` fails due to a server conflict
 
 ### Fixed
 - Key ID not being set correctly in keyshare JWTs

--- a/internal/sessiontest/keyshare_test.go
+++ b/internal/sessiontest/keyshare_test.go
@@ -282,6 +282,6 @@ func TestKeyshareServerRestart(t *testing.T) {
 	defer test.ClearTestStorage(t, client, handler.storage)
 	irmaServer := StartIrmaServer(t, nil)
 	defer irmaServer.Stop()
-	
+
 	keyshareSessions(t, client, irmaServer)
 }

--- a/internal/testkeyshare/testkeyshare.go
+++ b/internal/testkeyshare/testkeyshare.go
@@ -23,7 +23,7 @@ type KeyshareServer struct {
 	t *testing.T
 }
 
-func StartKeyshareServer(t *testing.T, l *logrus.Logger, schemeID irma.SchemeManagerIdentifier, jwtKeyID uint32) *KeyshareServer {
+func KeyshareServerHandler(t *testing.T, l *logrus.Logger, schemeID irma.SchemeManagerIdentifier, jwtKeyID uint32) (handler http.Handler, host string) {
 	db := keyshareserver.NewMemoryDB()
 	err := db.AddUser(context.Background(), &keyshareserver.User{
 		Username: "",
@@ -70,10 +70,15 @@ func StartKeyshareServer(t *testing.T, l *logrus.Logger, schemeID irma.SchemeMan
 		KeyshareAttribute:     keyshareAttr,
 	})
 	require.NoError(t, err)
+	return s.Handler(), parsedURL.Host
+}
+
+func StartKeyshareServer(t *testing.T, l *logrus.Logger, schemeID irma.SchemeManagerIdentifier, jwtKeyID uint32) *KeyshareServer {
+	handler, host := KeyshareServerHandler(t, l, schemeID, jwtKeyID)
 
 	keyshareServ := &KeyshareServer{http.Server{
-		Addr:    parsedURL.Host,
-		Handler: s.Handler(),
+		Addr:    host,
+		Handler: handler,
 	}, t}
 
 	go func() {

--- a/server/errors.go
+++ b/server/errors.go
@@ -36,12 +36,13 @@ var (
 	ErrorRevocation           Error = Error{Type: "REVOCATION", Status: 500, Description: "Revocation error"}
 	ErrorUnknownRevocationKey Error = Error{Type: "UNKNOWN_REVOCATION_KEY", Status: 404, Description: "No issuance records correspond to the given revocationKey"}
 
-	ErrorUnsupported     Error = Error{Type: "UNSUPPORTED", Status: 501, Description: "Unsupported by this server"}
-	ErrorInvalidRequest  Error = Error{Type: "INVALID_REQUEST", Status: 400, Description: "Invalid HTTP request"}
-	ErrorProtocolVersion Error = Error{Type: "PROTOCOL_VERSION", Status: 400, Description: "Protocol version negotiation failed"}
-	ErrorInvalidToken    Error = Error{Type: "INVALID_TOKEN", Status: 403, Description: "Provided token is unknown or invalid"}
-	ErrorInternal        Error = Error{Type: "INTERNAL_ERROR", Status: 500, Description: "Internal server error"}
-	ErrorRevalidateEmail Error = Error{Type: "REVALIDATE_EMAIL", Status: 500, Description: "Invalid email address is scheduled for revalidation"}
+	ErrorUnsupported       Error = Error{Type: "UNSUPPORTED", Status: 501, Description: "Unsupported by this server"}
+	ErrorInvalidRequest    Error = Error{Type: "INVALID_REQUEST", Status: 400, Description: "Invalid HTTP request"}
+	ErrorProtocolVersion   Error = Error{Type: "PROTOCOL_VERSION", Status: 400, Description: "Protocol version negotiation failed"}
+	ErrorInvalidToken      Error = Error{Type: "INVALID_TOKEN", Status: 403, Description: "Provided token is unknown or invalid"}
+	ErrorMissingCommitment Error = Error{Type: "MISSING_COMMITMENT", Status: 409, Description: "Keyshare response was requested without responding commitment"}
+	ErrorInternal          Error = Error{Type: "INTERNAL_ERROR", Status: 500, Description: "Internal server error"}
+	ErrorRevalidateEmail   Error = Error{Type: "REVALIDATE_EMAIL", Status: 500, Description: "Invalid email address is scheduled for revalidation"}
 )
 
 // Keyshare errors

--- a/server/keyshare/keyshareserver/server.go
+++ b/server/keyshare/keyshareserver/server.go
@@ -389,8 +389,12 @@ func (s *Server) handleResponse(w http.ResponseWriter, r *http.Request) {
 
 	// And do the actual responding
 	proofResponse, err := s.generateResponse(r.Context(), user, authorization, challenge)
-	if err == errMissingCommitment {
+	if err == keysharecore.ErrInvalidChallenge || err == keysharecore.ErrInvalidJWT {
 		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
+		return
+	}
+	if err == errMissingCommitment {
+		server.WriteError(w, server.ErrorMissingCommitment, err.Error())
 		return
 	}
 	if err != nil {
@@ -454,11 +458,12 @@ func (s *Server) keyshareResponse(ctx context.Context, w http.ResponseWriter, r 
 
 	// And do the actual responding
 	proofResponse, err := s.generateResponseV2(ctx, user, authorization, req, linkable)
-	if err != nil &&
-		(err == keysharecore.ErrInvalidChallenge ||
-			err == keysharecore.ErrInvalidJWT ||
-			err == errMissingCommitment) {
+	if err == keysharecore.ErrInvalidChallenge || err == keysharecore.ErrInvalidJWT {
 		server.WriteError(w, server.ErrorInvalidRequest, err.Error())
+		return
+	}
+	if err == errMissingCommitment {
+		server.WriteError(w, server.ErrorMissingCommitment, err.Error())
 		return
 	}
 	if err != nil {

--- a/server/keyshare/keyshareserver/server_test.go
+++ b/server/keyshare/keyshareserver/server_test.go
@@ -416,7 +416,7 @@ func TestKeyshareSessions(t *testing.T) {
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
-			400, nil,
+			409, nil,
 		)
 
 		// can't retrieve commitments with fake authorization

--- a/server/keyshare/keyshareserver/server_unversioned_test.go
+++ b/server/keyshare/keyshareserver/server_unversioned_test.go
@@ -388,7 +388,7 @@ func TestUnversionedKeyshareSessions(t *testing.T) {
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
-			400, nil,
+			409, nil,
 		)
 
 		// can't retrieve commitments with fake authorization

--- a/server/keyshare/keyshareserver/server_v2_test.go
+++ b/server/keyshare/keyshareserver/server_v2_test.go
@@ -2,6 +2,10 @@ package keyshareserver
 
 import (
 	"crypto/sha256"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/fxamacker/cbor"
 	"github.com/privacybydesign/gabi"
 	"github.com/privacybydesign/gabi/big"
@@ -10,9 +14,6 @@ import (
 	"github.com/privacybydesign/irmago/internal/test"
 	"github.com/privacybydesign/irmago/server"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
-	"time"
 )
 
 func TestServerInvalidMessageV2(t *testing.T) {
@@ -112,7 +113,7 @@ func TestKeyshareSessionsV2(t *testing.T) {
 
 		// no active session, can't retrieve result
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponse",
-		server.ToJson(responseReq), http.Header{
+			server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
@@ -120,7 +121,7 @@ func TestKeyshareSessionsV2(t *testing.T) {
 		)
 
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponseLinkable",
-		server.ToJson(responseReq), http.Header{
+			server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
@@ -165,7 +166,7 @@ func TestKeyshareSessionsV2(t *testing.T) {
 
 		// can't retrieve result with fake authorization
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponse",
-		server.ToJson(responseReq), http.Header{
+			server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{"fakeauthorization"},
 			},

--- a/server/keyshare/keyshareserver/server_v2_test.go
+++ b/server/keyshare/keyshareserver/server_v2_test.go
@@ -108,21 +108,23 @@ func TestKeyshareSessionsV2(t *testing.T) {
 	for _, user := range []struct {
 		username, auth string
 	}{{"testusername", auth1}, {"legacyuser", auth2}} {
+		commitmentReq, responseReq := prepareRequests(t)
+
 		// no active session, can't retrieve result
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponse",
-			"12345678", http.Header{
+		server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
-			400, nil,
+			409, nil,
 		)
 
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponseLinkable",
-			"12345678", http.Header{
+		server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{user.auth},
 			},
-			400, nil,
+			409, nil,
 		)
 
 		// can't retrieve commitments with fake authorization
@@ -163,7 +165,7 @@ func TestKeyshareSessionsV2(t *testing.T) {
 
 		// can't retrieve result with fake authorization
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getResponse",
-			"12345678", http.Header{
+		server.ToJson(responseReq), http.Header{
 				"X-IRMA-Keyshare-Username": []string{user.username},
 				"Authorization":            []string{"fakeauthorization"},
 			},
@@ -177,8 +179,6 @@ func TestKeyshareSessionsV2(t *testing.T) {
 			},
 			400, nil,
 		)
-
-		commitmentReq, responseReq := prepareRequests(t)
 
 		// can start session while another is already active
 		test.HTTPPost(t, nil, "http://localhost:8080/api/v2/prove/getCommitments",


### PR DESCRIPTION
…onse fails due to a server conflict