### PR TITLE
chore: Prepare for v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.17.1] - 2025-03-14
 ### Changed
 - Make keyshare pin challenge more resilient by retrying when `pin_challengeresponse` fails due to a server conflict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@ This release contains several large new features. In particular, the shoulder su
 - Combined issuance-disclosure requests with two schemes one of which has a keyshare server now work as expected
 - Various other bugfixes
 
+[0.17.1]: https://github.com/privacybydesign/irmago/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/privacybydesign/irmago/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/privacybydesign/irmago/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/privacybydesign/irmago/compare/v0.15.1...v0.15.2

--- a/version.go
+++ b/version.go
@@ -5,4 +5,4 @@
 package irma
 
 // Version of the IRMA command line and libraries
-const Version = "0.17.0"
+const Version = "0.17.1"


### PR DESCRIPTION
Preparing the changelog for release `v0.17.1`.