### PR TITLE
Add support for development on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.sig binary
+*.png binary

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -90,20 +90,22 @@ func ensureSymlinks(tb testing.TB) func(tb testing.TB) {
 	var symlinkError error
 
 	for symlinkLocation, target := range symlinks {
-		if _, err := os.Stat(symlinkLocation); os.IsNotExist(err) {
-			// Create the symbolic link
-			switch runtime.GOOS {
-			case "windows":
+		// Create the symbolic link
+		switch runtime.GOOS {
+		case "windows":
+			if _, err := os.Stat(symlinkLocation); os.IsNotExist(err) {
 				c = exec.Command("cmd", "/c", "mklink", "/J", symlinkLocation, target)
 				symlinkError = c.Run()
+			}
 
-			default: //Mac & Linux
+		default: //Mac & Linux
+			if _, err := os.Lstat(symlinkLocation); os.IsNotExist(err) {
 				symlinkError = os.Symlink(symlinkLocation, target)
 			}
+		}
 
-			if symlinkError != nil {
-				fmt.Println("Error creating symbolic links: ", symlinkError)
-			}
+		if symlinkError != nil {
+			fmt.Println("Error creating symbolic links: ", symlinkError)
 		}
 	}
 

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -82,8 +82,8 @@ func ensureSymlinks(tb testing.TB) func(tb testing.TB) {
 	// Some tests expect symbolic links to be present
 	// Notation is <symlink location> : <target>
 	symlinks := map[string]string{
-		"..\\..\\testdata\\irma_configuration_updated\\test":  "..\\..\\testdata\\irma_configuration\\test",
-		"..\\..\\testdata\\irma_configuration_updated\\test2": "..\\..\\testdata\\irma_configuration\\test2",
+		filepath.Join("..", "..", "testdata", "irma_configuration_updated", "test"):  filepath.Join("..", "..", "testdata", "irma_configuration", "test"),
+		filepath.Join("..", "..", "testdata", "irma_configuration_updated", "test2"): filepath.Join("..", "..", "testdata", "irma_configuration", "test2"),
 	}
 
 	var c *exec.Cmd
@@ -100,7 +100,7 @@ func ensureSymlinks(tb testing.TB) func(tb testing.TB) {
 
 		default: //Mac & Linux
 			if _, err := os.Lstat(symlinkLocation); os.IsNotExist(err) {
-				symlinkError = os.Symlink(symlinkLocation, target)
+				symlinkError = os.Symlink(target, symlinkLocation)
 			}
 		}
 

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -78,7 +78,7 @@ func init() {
 }
 
 // Setup symbolic links for tests that require them
-func ensureSymlinks(tb testing.TB) func(tb testing.TB) {
+func ensureSymlinks(tb testing.TB) {
 	// Some tests expect symbolic links to be present
 	// Notation is <symlink location> : <target>
 	symlinks := map[string]string{
@@ -107,11 +107,6 @@ func ensureSymlinks(tb testing.TB) func(tb testing.TB) {
 		if symlinkError != nil {
 			fmt.Println("Error creating symbolic links: ", symlinkError)
 		}
-	}
-
-	// Return a function to teardown the test
-	return func(tb testing.TB) {
-
 	}
 }
 

--- a/internal/sessiontest/legacy_test.go
+++ b/internal/sessiontest/legacy_test.go
@@ -39,6 +39,7 @@ func testSessionUsingLegacyStorage(t *testing.T, dir string) {
 	// Re-open client
 	require.NoError(t, client.Close())
 	client, _ = parseExistingStorage(t, handler.storage)
+	defer client.Close()
 
 	// Test whether credential is still there after the storage has been reloaded
 	doSession(t, getDisclosureRequest(idRoot), client, nil, nil, nil, nil)

--- a/internal/sessiontest/logs_test.go
+++ b/internal/sessiontest/logs_test.go
@@ -100,4 +100,5 @@ func TestLogging(t *testing.T) {
 	require.Equal(t, irma.ProofStatusValid, status)
 	require.NotEmpty(t, attrs)
 	require.Equal(t, attrid, attrs[0][0].Identifier)
+	require.NoError(t, client.Close())
 }

--- a/internal/sessiontest/redis_test.go
+++ b/internal/sessiontest/redis_test.go
@@ -177,6 +177,7 @@ func TestRedisWithTLSCertFile(t *testing.T) {
 	require.NoError(t, err)
 	certfile := file.Name()
 	defer func() {
+		file.Close()
 		require.NoError(t, os.Remove(certfile))
 	}()
 

--- a/internal/sessiontest/session_test.go
+++ b/internal/sessiontest/session_test.go
@@ -169,6 +169,8 @@ func testIssuanceSameAttributesNotSingleton(t *testing.T, conf interface{}, opts
 	// Also check whether this is actually stored
 	require.NoError(t, client.Close())
 	client, _ = parseExistingStorage(t, handler.storage)
+	defer client.Close()
+
 	require.Equal(t, prevLen+1, len(client.CredentialInfoList()))
 }
 
@@ -275,6 +277,8 @@ func testIssuanceSingletonCredential(t *testing.T, conf interface{}, opts ...opt
 	// Also check whether this is actually stored
 	require.NoError(t, client.Close())
 	client, _ = parseExistingStorage(t, handler.storage)
+	defer client.Close()
+
 	require.NotNil(t, client.Attributes(credid, 0))
 	require.Nil(t, client.Attributes(credid, 1))
 }
@@ -350,6 +354,7 @@ func testOutdatedClientIrmaConfiguration(t *testing.T, conf interface{}, opts ..
 
 	client, handler := parseStorage(t, opts...)
 	defer test.ClearTestStorage(t, client, handler.storage)
+	defer client.Close()
 
 	// Remove old studentCard credential from before support for optional attributes, and issue a new one
 	require.NoError(t, client.RemoveStorage())
@@ -369,6 +374,7 @@ func testDisclosureNewAttributeUpdateSchemeManager(t *testing.T, conf interface{
 
 	client, handler := parseStorage(t, opts...)
 	defer test.ClearTestStorage(t, client, handler.storage)
+	defer client.Close()
 
 	schemeid := irma.NewSchemeManagerIdentifier("irma-demo")
 	credid := irma.NewCredentialTypeIdentifier("irma-demo.RU.studentCard")
@@ -450,6 +456,8 @@ func testIssuedCredentialIsStored(t *testing.T, conf interface{}, opts ...option
 	require.NoError(t, client.Close())
 
 	client, _ = parseExistingStorage(t, handler.storage)
+	defer client.Close()
+
 	id := irma.NewAttributeTypeIdentifier("irma-demo.MijnOverheid.fullName.familyname")
 	doSession(t, getDisclosureRequest(id), client, nil, nil, nil, conf, opts...)
 }

--- a/irmaclient/irmaclient_test.go
+++ b/irmaclient/irmaclient_test.go
@@ -294,6 +294,7 @@ func TestCredentialRemoval(t *testing.T) {
 	err = client.storage.db.Close()
 	require.NoError(t, err)
 	client, _ = parseExistingStorage(t, handler.storage)
+	defer client.storage.db.Close()
 	cred, err = client.credential(id2, 0)
 	require.NoError(t, err)
 	require.Nil(t, cred)
@@ -393,6 +394,7 @@ func TestFreshStorage(t *testing.T) {
 	storage := test.CreateTestStorage(t)
 	client, handler := parseExistingStorage(t, storage)
 	defer test.ClearTestStorage(t, client, handler.storage)
+	defer client.Close()
 	require.NotNil(t, client)
 }
 
@@ -403,9 +405,11 @@ func TestKeyshareEnrollmentRemoval(t *testing.T) {
 	err := client.KeyshareRemove(irma.NewSchemeManagerIdentifier("test"))
 	require.NoError(t, err)
 
-	err = client.storage.db.Close()
+	err = client.storage.Close()
 	require.NoError(t, err)
 	client, _ = parseExistingStorage(t, handler.storage)
+	err = client.storage.Close()
+	require.NoError(t, err)
 
 	require.NotContains(t, client.keyshareServers, "test")
 }
@@ -413,6 +417,7 @@ func TestKeyshareEnrollmentRemoval(t *testing.T) {
 func TestUpdatingStorage(t *testing.T) {
 	client, handler := parseStorage(t)
 	defer test.ClearTestStorage(t, client, handler.storage)
+	defer client.Close()
 	require.NotNil(t, client)
 
 	// Check whether all update functions succeeded
@@ -424,6 +429,7 @@ func TestUpdatingStorage(t *testing.T) {
 func TestRemoveStorage(t *testing.T) {
 	client, handler := parseStorage(t)
 	defer test.ClearTestStorage(t, client, handler.storage)
+	defer client.Close()
 
 	// Check whether we have logs in storage to know whether the logs bucket is there
 	logs, err := client.LoadNewestLogs(1)
@@ -452,6 +458,7 @@ func TestRemoveStorage(t *testing.T) {
 
 func TestCredentialsConcurrency(t *testing.T) {
 	client, _ := parseStorage(t)
+	defer client.Close()
 	grp := sync.WaitGroup{}
 
 	for j := 0; j < 1000; j++ {

--- a/schemes.go
+++ b/schemes.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -773,9 +774,15 @@ func (conf *Configuration) checkUnsignedFiles(dir string, index SchemeManagerInd
 		if err != nil {
 			return err
 		}
+
 		schemepath := filepath.Join(index.Scheme(), relpath)
+
+		// On Linux and MacOS, filepath.Rel returns a path with forward slashes, on Windows with backslashes.
+		// However, scheme index is always stored with forward slashes, so we need to convert the path to forward slashes.
+		schemepath = filepath.ToSlash(schemepath)
+
 		for _, ex := range sigExceptions {
-			if ex.MatchString(filepath.ToSlash(schemepath)) {
+			if ex.MatchString(schemepath) {
 				return nil
 			}
 		}
@@ -1497,7 +1504,12 @@ func (scheme *RequestorScheme) handleUpdateFile(conf *Configuration, path, filen
 		if err != nil {
 			return err
 		}
-		if _, err = downloadSignedFile(transport, path, filepath.Join("assets", filename), hash); err != nil {
+		//if _, err = downloadSignedFile(transport, path, filepath.Join("assets", filename), hash); err != nil {
+		urlPath, err := url.JoinPath("assets", filename)
+		if err != nil {
+			return err
+		}
+		if _, err = downloadSignedFile(transport, path, urlPath, hash); err != nil {
 			return err
 		}
 	}

--- a/schemes.go
+++ b/schemes.go
@@ -1504,7 +1504,7 @@ func (scheme *RequestorScheme) handleUpdateFile(conf *Configuration, path, filen
 		if err != nil {
 			return err
 		}
-		//if _, err = downloadSignedFile(transport, path, filepath.Join("assets", filename), hash); err != nil {
+
 		urlPath, err := url.JoinPath("assets", filename)
 		if err != nil {
 			return err

--- a/testdata/irma_configuration_updated/.gitignore
+++ b/testdata/irma_configuration_updated/.gitignore
@@ -1,0 +1,2 @@
+test
+test2

--- a/testdata/irma_configuration_updated/test
+++ b/testdata/irma_configuration_updated/test
@@ -1,1 +1,0 @@
-../irma_configuration/test

--- a/testdata/irma_configuration_updated/test2
+++ b/testdata/irma_configuration_updated/test2
@@ -1,1 +1,0 @@
-../irma_configuration/test2


### PR DESCRIPTION
This pull request introduces several changes aimed at improving test reliability, enhancing cross-platform compatibility, and ensuring proper resource cleanup in the codebase. The most significant changes include the addition of symbolic link setup for tests, proper closing of resources in test cases, and updates to path handling for better compatibility across operating systems.

### Test reliability and resource cleanup:
* Added a new `ensureSymlinks` function in `internal/sessiontest/helper_servers_test.go` to create symbolic links required for certain tests, with cross-platform support for Windows, macOS, and Linux. This function is invoked in `StartIrmaServer` to ensure the necessary setup is in place. [[1]](diffhunk://#diff-68ffaae070a6bbe0623df8506dbf61f5e735898da6762f2c49f987e86f9b35cdR80-R117) [[2]](diffhunk://#diff-68ffaae070a6bbe0623df8506dbf61f5e735898da6762f2c49f987e86f9b35cdR144-R145)
* Added `defer client.Close()` in multiple test cases across files like `internal/sessiontest/session_test.go` and `irmaclient/irmaclient_test.go` to ensure proper cleanup of client resources after tests complete. [[1]](diffhunk://#diff-88353f9abc6d47ac6d66317e0df456e5631c52681d49ab6e4b0e8c58ac7890b8R172-R173) [[2]](diffhunk://#diff-88353f9abc6d47ac6d66317e0df456e5631c52681d49ab6e4b0e8c58ac7890b8R280-R281) [[3]](diffhunk://#diff-b62dc2e06c13f87d9ad344a5bcccbd2557a3aefa481b5e80aa19cb8d69859dbfR397) [[4]](diffhunk://#diff-b62dc2e06c13f87d9ad344a5bcccbd2557a3aefa481b5e80aa19cb8d69859dbfR461)

### Cross-platform compatibility:
* Updated path handling in `schemes.go` to ensure consistency across operating systems by converting paths to forward slashes before comparison. This change affects the `checkUnsignedFiles` and `handleUpdateFile` functions. [[1]](diffhunk://#diff-d9a0f717b4668b699fae9ed83cd3c40b204b233359281a673934659068d53fa8R777-R785) [[2]](diffhunk://#diff-d9a0f717b4668b699fae9ed83cd3c40b204b233359281a673934659068d53fa8L1500-R1512)

### Binary file handling:
* Added `.gitattributes` to enforce consistent line endings (`eol=lf`) and mark certain file types (e.g., `.png`, `.sig`) as binary to prevent modifications.

### Test data updates:
* Updated the `.gitignore` file and test data files (`testdata/irma_configuration_updated/test` and `test2`) to reflect changes in symbolic link handling. [[1]](diffhunk://#diff-8d8d0f71dc4f166759a6bf5ea818d3dadc6e7b52cbb93a972d1355363a6f1dccR1-R2) [[2]](diffhunk://#diff-d21b41f15ea46b9f331a05ff9ebb1bbfc1d182173c76788d3fcc2c07b1a1a50cL1) [[3]](diffhunk://#diff-8ad560c8598fa330a483f7c53e0945e6ba000756195f03d818f25f50a5e55682L1)