### PR TITLE
Update transport.go to allow usage of http proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- `irma.HTTPTransport` now honours the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables, so irmago can run where outgoing traffic must pass through a proxy; it was the only outbound transport in irmago that ignored them. Operators with a system-wide proxy can keep internal traffic (requestor callbacks, keyshare and revocation servers) off it with `NO_PROXY`; loopback addresses are never proxied ([#423](https://github.com/privacybydesign/irmago/issues/423))
 
 ## [1.3.0] - 2026-08-12
 ### Added

--- a/irma/transport.go
+++ b/irma/transport.go
@@ -90,6 +90,7 @@ func NewHTTPTransport(serverURL string, forceHTTPS bool) *HTTPTransport {
 	innerTransport := &http.Transport{
 		TLSClientConfig:       tlsClientConfig,
 		ForceAttemptHTTP2:     true,
+		Proxy:                 http.ProxyFromEnvironment, //  Proxy support via env vars
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,

--- a/irma/transport.go
+++ b/irma/transport.go
@@ -86,11 +86,13 @@ func NewHTTPTransport(serverURL string, forceHTTPS bool) *HTTPTransport {
 	}
 
 	// Create a transport that dials with a SIGPIPE handler (which is only active on iOS).
-	// The settings are inspired on the defaults of http.DefaultTransport.
+	// The settings are inspired on the defaults of http.DefaultTransport, including its
+	// Proxy: outbound requests honour the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment
+	// variables, as the rest of irmago already does through http.DefaultTransport.
 	innerTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
 		TLSClientConfig:       tlsClientConfig,
 		ForceAttemptHTTP2:     true,
-		Proxy:                 http.ProxyFromEnvironment, //  Proxy support via env vars
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,

--- a/irma/transport_test.go
+++ b/irma/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -144,5 +145,30 @@ func TestJsonRequest_RemoteErrorBodyIsPreserved(t *testing.T) {
 			require.Equal(t, http.StatusNotFound, serr.RemoteStatus)
 			require.Equal(t, apierr, serr.RemoteError)
 		})
+	}
+}
+
+// TestNewHTTPTransport_UsesEnvironmentProxy covers issue #423: HTTPTransport was the
+// only outbound transport in irmago that left http.Transport.Proxy unset, so it ignored
+// the HTTP_PROXY/HTTPS_PROXY environment variables that everything routed through
+// http.DefaultTransport already honours.
+//
+// The proxy function is inspected directly rather than exercised against a real proxy,
+// because net/http reads the environment once behind a sync.Once: a test setting
+// HTTP_PROXY would only take effect if it happened to run before any other code in the
+// process resolved a proxy.
+func TestNewHTTPTransport_UsesEnvironmentProxy(t *testing.T) {
+	inner, ok := NewHTTPTransport("https://example.com", true).client.HTTPClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, inner.Proxy, "outbound transport must honour HTTP_PROXY/HTTPS_PROXY")
+
+	// Loopback destinations are never proxied, whatever the environment says, so local
+	// servers (including the ones in these tests) keep being dialled directly.
+	for _, dest := range []string{"http://localhost:8080/foo", "http://127.0.0.1:8080/foo"} {
+		u, err := url.Parse(dest)
+		require.NoError(t, err)
+		proxy, err := inner.Proxy(&http.Request{URL: u})
+		require.NoError(t, err)
+		require.Nil(t, proxy, "loopback destination %s must not be proxied", dest)
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -88,7 +88,7 @@ func NewHTTPTransport(serverURL string, forceHTTPS bool) *HTTPTransport {
 	innerTransport := &http.Transport{
 		TLSClientConfig:       tlsClientConfig,
 		ForceAttemptHTTP2:     true,
-		Proxy: http.ProxyFromEnvironment, //  Enables proxy support via env vars
+		Proxy:                 http.ProxyFromEnvironment, //  Proxy support via env vars
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,

--- a/transport.go
+++ b/transport.go
@@ -88,6 +88,7 @@ func NewHTTPTransport(serverURL string, forceHTTPS bool) *HTTPTransport {
 	innerTransport := &http.Transport{
 		TLSClientConfig:       tlsClientConfig,
 		ForceAttemptHTTP2:     true,
+		Proxy: http.ProxyFromEnvironment, //  Enables proxy support via env vars
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
By setting `http.Transport.Proxy = http.ProxyFromEnvironment`, irmago will respect system proxy settings.
This allows use in secured or firewalled environments requiring a proxy server for outgoing HTTP(S) traffic.

This code compiles, and seems to use a proxy when setting HTTPS_PROXY

```
May 14 21:49:29 t480 tinyproxy[331565]: Request (file descriptor 12): CONNECT schemes.yivi.app:443 HTTP/1.1
May 14 21:49:29 t480 tinyproxy[331565]: No upstream proxy for schemes.yivi.app
May 14 21:49:29 t480 tinyproxy[331565]: opensock: opening connection to schemes.yivi.app:443
```

```
./irma.bin scheme download
No irma_configuration path specified, using /home/sigio/.local/share/irma/irma_configuration
[21:48:53.597714]  INFO downloading default schemes (may take a while)
[21:48:53.829394]  INFO checking for updates scheme=irma-demo type=issuer
[21:48:54.055701]  INFO scheme is outdated, updating scheme=irma-demo type=issuer
[21:49:32.966370]  INFO checking for updates scheme=pbdf type=issuer
[21:49:33.208570]  INFO scheme is outdated, updating scheme=pbdf type=issuer
[21:49:49.904658]  INFO Finished downloading schemes

```
Fixes #423