### PR TITLE
Add backwards compatibilty for older Yivi apps

### DIFF
--- a/server/irmaserver/helpers.go
+++ b/server/irmaserver/helpers.go
@@ -838,6 +838,11 @@ func (session *sessionData) generateSdJwts(
 	if numSdJwtsRequested == 0 {
 		return nil, nil
 	}
+	// when the list of pub keys is empty it's most likely an older Yivi app
+	// that doesn't have SD-JWT support, so don't make any, but also don't return an error
+	if kbPubKeys == nil {
+		return nil, nil
+	}
 
 	if numPubKeys := uint(len(kbPubKeys)); numSdJwtsRequested != numPubKeys {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Older Yivi apps don't understand the sdJwtBatchSize field in session requests and don't send holder pub keys to the irma server, so the irma server should handle that case correctly to ensure backwards compatibility.
We solve this by just not issuing the sdjwts and also not returning an error.

We should probably figure out a way to test this.

Relates to https://github.com/privacybydesign/irmamobile/issues/357
Fixes #483 