### PR TITLE
Rename path to dir for sdjwtvc issuance config

### DIFF
--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -798,8 +798,8 @@ func irmaServerConfWithSdJwtEnabled(t *testing.T) *server.Configuration {
 
 	conf := IrmaServerConfigurationWithTempStorage(t)
 	conf.SdJwtIssuanceSettings = &server.SdJwtIssuanceSettings{
-		SdJwtIssuerPrivKeysPath:     privKeyDir,
-		SdJwtIssuerCertificatesPath: certDir,
+		SdJwtIssuerPrivKeysDir:     privKeyDir,
+		SdJwtIssuerCertificatesDir: certDir,
 	}
 	return conf
 }

--- a/internal/sessiontest/helper_servers_test.go
+++ b/internal/sessiontest/helper_servers_test.go
@@ -41,8 +41,8 @@ var (
 
 	jwtPrivkeyPath = filepath.Join(testdataFolder, "jwtkeys", "sk.pem")
 
-	sdJwtIssuerPrivKeysPath = filepath.Join(testdataFolder, "eudi", "irma_server_config", "sdjwt_priv_keys")
-	sdJwtIssuerCertsPath    = filepath.Join(testdataFolder, "eudi", "irma_server_config", "sdjwt_certs")
+	sdJwtIssuerPrivKeysDir = filepath.Join(testdataFolder, "eudi", "irma_server_config", "sdjwt_priv_keys")
+	sdJwtIssuerCertsDir    = filepath.Join(testdataFolder, "eudi", "irma_server_config", "sdjwt_certs")
 )
 
 const (
@@ -345,8 +345,8 @@ func RequestorServerConfiguration() *requestorserver.Configuration {
 	irmaServerConf.URL = requestorServerURL + "/irma"
 	irmaServerConf.DisableTLS = true
 	irmaServerConf.SdJwtIssuanceSettings = &server.SdJwtIssuanceSettings{
-		SdJwtIssuerCertificatesPath: sdJwtIssuerCertsPath,
-		SdJwtIssuerPrivKeysPath:     sdJwtIssuerPrivKeysPath,
+		SdJwtIssuerCertificatesDir: sdJwtIssuerCertsDir,
+		SdJwtIssuerPrivKeysDir:     sdJwtIssuerPrivKeysDir,
 	}
 	return &requestorserver.Configuration{
 		Configuration:                  irmaServerConf,

--- a/irma/cmd/config.go
+++ b/irma/cmd/config.go
@@ -43,16 +43,16 @@ func configureEmail() keyshare.EmailConfiguration {
 }
 
 func getSdJwtIssuanceConfigFromCli() *server.SdJwtIssuanceSettings {
-	certChainsPath := viper.GetString("sdjwtvc_issuer_certificates_path")
-	privKeysPath := viper.GetString("sdjwtvc_issuer_priv_keys_path")
+	certChainsDir := viper.GetString("sdjwtvc_issuer_certificates_dir")
+	privKeysDir := viper.GetString("sdjwtvc_issuer_private_keys_dir")
 
-	if certChainsPath == "" && privKeysPath == "" {
+	if certChainsDir == "" && privKeysDir == "" {
 		return nil
 	}
 
 	return &server.SdJwtIssuanceSettings{
-		SdJwtIssuerCertificatesPath: certChainsPath,
-		SdJwtIssuerPrivKeysPath:     privKeysPath,
+		SdJwtIssuerCertificatesDir: certChainsDir,
+		SdJwtIssuerPrivKeysDir:     privKeysDir,
 	}
 }
 
@@ -204,6 +204,15 @@ func readConfig(cmd *cobra.Command, name, logname string, configpaths []string, 
 	} else {
 		logger.Info("Config file: ", viper.ConfigFileUsed())
 	}
+}
+
+func wasProvidedInAnyWay(key string) bool {
+	if val, flagOrEnv := viper.Get(key).(string); !flagOrEnv || val != "" {
+		if _, err := cast.ToStringMapE(viper.Get(key)); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func handleMapOrString(key string, dest interface{}) error {

--- a/irma/cmd/server.go
+++ b/irma/cmd/server.go
@@ -121,12 +121,9 @@ func setFlags(cmd *cobra.Command, production bool) error {
 
 	flags.String("revocation-settings", "", "revocation settings (in JSON)")
 
-	headers["sdjwtvc-issuer"] = "SD-JWT VC issuance configuration"
-	flags.String("sdjwtvc-issuer", "", "SD-JWT VC issuer ('iss') field")
-	flags.String("sdjwtvc-privkey", "", "SD-JWT VC issuance private key")
-	flags.String("sdjwtvc-privkey-file", "", "SD-JWT VC issuance private key file")
-	flags.String("sdjwtvc-cert-chain", "", "SD-JWT VC issuance certificate chain (PEM)")
-	flags.String("sdjwtvc-cert-chain-file", "", "SD-JWT VC issuance certificate chain file (PEM)")
+	headers["sdjwtvc-issuer-certificates-dir"] = "SD-JWT VC issuance configuration"
+	flags.String("sdjwtvc-issuer-certificates-dir", "", "SD-JWT VC issuer certificates directory dir")
+	flags.String("sdjwtvc-issuer-private-keys-dir", "", "SD-JWT VC issuer private keys directory dir")
 
 	headers["store-type"] = "Session store configuration"
 	flags.String("store-type", "", "specifies how session state will be saved on the server (default \"memory\")")
@@ -234,6 +231,13 @@ func configureServer(cmd *cobra.Command) (*requestorserver.Configuration, error)
 		}
 		if viper.GetBool("no_email") && conf.Email != "" {
 			return nil, errors.New("--no-email cannot be combined with --email")
+		}
+	}
+
+	// no error handling for this one, as it can be left empty
+	if wasProvidedInAnyWay("sdjwtvc") {
+		if err := handleMapOrString("sdjwtvc", &conf.SdJwtIssuanceSettings); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Now allows for three ways of configuring sdjwtvc issuance

### `--config` flag
  ```json
  {
    "sdjwtvc": {
      "issuer_certificates_dir": "<path_to_certs>",
      "issuer_private_keys_dir": "<path_to_keys>"
    }
  }
  ```

### Command line params
```bash
irma server --sdjwtvc-issuer-certificates-dir="<path_to_certs>" \
            --sdjwtvc-issuer-private-keys-dir="<path_to_keys>"
```

### Environment variables
```bash
export IRMASERVER_SDJWTVC_ISSUER_CERTIFICATES_DIR="<path_to_certs>"
export IRMASERVER_SDJWTVC_ISSUER_PRIVATE_KEYS_DIR="<path_to_keys>"
irma server
```
