### PR TITLE
Fix VerifyMXRecord to handle implicit MX per RFC 5321

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fix
+- Bug that keyshare regisration failed when users email domain had no MX records.
 
 ## [0.19.2] - 2026-02-26
 ### Fix
 - Bug that caused HTTP request body to not be sent upon retransmission
 
-## Changed
+### Changed
 - Add wildcard support for authorized credentials and attributes in relying party and attestation provider certificates
 
 ## [0.19.1] - 2025-10-13

--- a/server/keyshare/email.go
+++ b/server/keyshare/email.go
@@ -15,6 +15,26 @@ import (
 	"github.com/privacybydesign/irmago/server"
 )
 
+// DNSResolver is an interface for DNS lookups, allowing injection of test doubles.
+type DNSResolver interface {
+	LookupMX(host string) ([]*net.MX, error)
+	LookupIP(host string) ([]net.IP, error)
+}
+
+// netDNSResolver is the default implementation using the net package.
+type netDNSResolver struct{}
+
+func (netDNSResolver) LookupMX(host string) ([]*net.MX, error) {
+	return net.LookupMX(host)
+}
+
+func (netDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// DefaultDNSResolver is the default DNS resolver used by VerifyMXRecord.
+var DefaultDNSResolver DNSResolver = netDNSResolver{}
+
 type EmailConfiguration struct {
 	EmailServer     string `json:"email_server" mapstructure:"email_server"`
 	EmailHostname   string `json:"email_hostname" mapstructure:"email_hostname"`
@@ -171,7 +191,7 @@ func VerifyMXRecord(email string) error {
 
 	host := email[strings.LastIndex(email, "@")+1:]
 
-	records, err := net.LookupMX(host)
+	records, err := DefaultDNSResolver.LookupMX(host)
 
 	if err != nil || len(records) == 0 {
 		if derr, ok := err.(*net.DNSError); ok && (derr.IsTemporary || derr.IsTimeout) {
@@ -181,10 +201,11 @@ func VerifyMXRecord(email string) error {
 		}
 
 		// Check if there is a valid A or AAAA record which is used as fallback by mailservers
-		// when there are no MX records present
-		if records, err := net.LookupIP(host); err != nil || len(records) == 0 {
+		// when there are no MX records present (implicit MX per RFC 5321 Section 5.1)
+		if records, err := DefaultDNSResolver.LookupIP(host); err != nil || len(records) == 0 {
 			return ErrInvalidEmailDomain
 		}
+		return nil
 	}
 
 	hasValidHost := false

--- a/server/keyshare/email_test.go
+++ b/server/keyshare/email_test.go
@@ -2,6 +2,7 @@ package keyshare
 
 import (
 	"bytes"
+	"net"
 	"path/filepath"
 	"testing"
 
@@ -45,4 +46,39 @@ func TestParseEmailTemplates(t *testing.T) {
 	var msg bytes.Buffer
 	require.NoError(t, templ[lang].Execute(&msg, map[string]string{"VerificationURL": "123"}))
 	require.Equal(t, "This is a test template 123", msg.String())
+}
+
+// mockDNSResolver implements DNSResolver for testing
+type mockDNSResolver struct {
+	mxRecords []*net.MX
+	mxErr     error
+	ipRecords []net.IP
+	ipErr     error
+}
+
+func (m mockDNSResolver) LookupMX(host string) ([]*net.MX, error) {
+	return m.mxRecords, m.mxErr
+}
+
+func (m mockDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	return m.ipRecords, m.ipErr
+}
+
+func TestVerifyMXRecordImplicitMX(t *testing.T) {
+	// Save original resolver
+	origResolver := DefaultDNSResolver
+	defer func() {
+		DefaultDNSResolver = origResolver
+	}()
+
+	// Mock: no MX records, but valid A record (implicit MX per RFC 5321 Section 5.1)
+	DefaultDNSResolver = mockDNSResolver{
+		mxRecords: nil,
+		mxErr:     nil,
+		ipRecords: []net.IP{net.ParseIP("192.0.2.1")},
+		ipErr:     nil,
+	}
+
+	err := VerifyMXRecord("user@example.com")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Fix `VerifyMXRecord` to correctly handle domains with A/AAAA records but no MX records
- Refactor DNS lookups to use interface-based dependency injection for testability

## Problem

Per RFC 5321 Section 5.1, when no MX records exist for a domain, mail servers should apply the "implicit MX" rule - treating the domain as if it had an MX record pointing to itself and using A/AAAA records for delivery.

The previous implementation checked for A/AAAA records as a fallback but didn't return success, causing valid email domains to be incorrectly rejected.

Fixes #524