### PR TITLE
Refactor Attribute model: Id → ClaimPath

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -556,7 +556,7 @@ func (client *Client) rawLogEntryToLogInfo(entry *irmaclient.LogEntry) (clientmo
 				rawVal := irma.TranslatedString(attributeValues[atType.Index])
 				description := clientmodels.TranslatedString(atType.Description)
 				attributes = append(attributes, clientmodels.Attribute{
-					Id:          atType.ID,
+					ClaimPath:   []any{atType.ID},
 					DisplayName: clientmodels.TranslatedString(atType.Name),
 					Description: &description,
 					Value:       buildAttributeValue(atType.DisplayHint, &rawVal),
@@ -625,7 +625,7 @@ func disclosedAttributesToLogCredentials(irmaConfig *irma.Configuration, attribu
 			rawVal := irma.TranslatedString(attr.Value)
 			description := clientmodels.TranslatedString(atType.Description)
 			attributes = append(attributes, clientmodels.Attribute{
-				Id:          atType.ID,
+				ClaimPath:   []any{atType.ID},
 				DisplayName: clientmodels.TranslatedString(atType.Name),
 				Description: &description,
 				Value:       buildAttributeValue(atType.DisplayHint, &rawVal),
@@ -671,7 +671,7 @@ func issuedCredentialsToLogCredentials(irmaConfig *irma.Configuration, creds irm
 			rawVal := irma.TranslatedString(cred.Attributes[atType.GetAttributeTypeIdentifier()])
 			description := clientmodels.TranslatedString(atType.Description)
 			attributes = append(attributes, clientmodels.Attribute{
-				Id:          atType.ID,
+				ClaimPath:   []any{atType.ID},
 				DisplayName: clientmodels.TranslatedString(atType.Name),
 				Description: &description,
 				Value:       buildAttributeValue(atType.DisplayHint, &rawVal),
@@ -722,7 +722,7 @@ func openid4vpCredentialLogsToLogCredentials(irmaConfig *irma.Configuration, log
 			irmaVal := irma.NewTranslatedString(&v)
 			description := clientmodels.TranslatedString(atType.Description)
 			attributes = append(attributes, clientmodels.Attribute{
-				Id:          atType.ID,
+				ClaimPath:   []any{atType.ID},
 				DisplayName: clientmodels.TranslatedString(atType.Name),
 				Description: &description,
 				Value:       buildAttributeValue(atType.DisplayHint, &irmaVal),

--- a/client/openid4vp_adapters.go
+++ b/client/openid4vp_adapters.go
@@ -151,18 +151,18 @@ func checkWrongCredential(cred *clientmodels.Credential, option *clientmodels.Cr
 	var mismatched []clientmodels.Attribute
 	requestedByID := make(map[string]*clientmodels.Attribute)
 	for i := range option.Attributes {
-		requestedByID[option.Attributes[i].Id] = &option.Attributes[i]
+		requestedByID[clientmodels.ClaimPathKey(option.Attributes[i].ClaimPath)] = &option.Attributes[i]
 	}
 
 	for _, attr := range cred.Attributes {
-		req, ok := requestedByID[attr.Id]
+		req, ok := requestedByID[clientmodels.ClaimPathKey(attr.ClaimPath)]
 		if !ok || req.RequestedValue == nil || !req.RequestedValue.HasValue() {
 			continue
 		}
 		satisfied, _ := SatisfiesRequestedAttributes([]clientmodels.Attribute{attr}, []clientmodels.Attribute{*req})
 		if !satisfied {
 			mismatched = append(mismatched, clientmodels.Attribute{
-				Id:             attr.Id,
+				ClaimPath:      attr.ClaimPath,
 				DisplayName:    attr.DisplayName,
 				Description:    attr.Description,
 				Value:          attr.Value,
@@ -193,7 +193,7 @@ func openid4vpCredentialLogsToIrmaclientLogEntry(
 		attrs := make(map[string]string)
 		for _, a := range cl.Attributes {
 			if a.Value != nil && a.Value.String != nil {
-				attrs[a.Id] = *a.Value.String
+				attrs[clientmodels.ClaimPathKey(a.ClaimPath)] = *a.Value.String
 			}
 		}
 		disclosed = append(disclosed, irmaclient.CredentialLog{

--- a/client/schemaless.go
+++ b/client/schemaless.go
@@ -39,7 +39,7 @@ func (client *Client) GetCredentialStore() ([]*clientmodels.CredentialStoreItem,
 				continue
 			}
 			attributes = append(attributes, clientmodels.Attribute{
-				Id:          attr.ID,
+				ClaimPath:   []any{attr.ID},
 				DisplayName: clientmodels.TranslatedString(attr.Name),
 				Value: &clientmodels.AttributeValue{
 					Type: displayHintToAttributeType(attr.DisplayHint),
@@ -133,7 +133,7 @@ func createCredentialDescriptor(
 					requestedValue.String = &s
 				}
 				attributes = append(attributes, clientmodels.Attribute{
-					Id:             a.ID,
+					ClaimPath:      []any{a.ID},
 					DisplayName:    clientmodels.TranslatedString(a.Name),
 					RequestedValue: requestedValue,
 				})
@@ -168,7 +168,7 @@ func getCredentialDescriptor(irmaConfig *irma.Configuration, id irma.CredentialT
 			continue
 		}
 		attributes = append(attributes, clientmodels.Attribute{
-			Id:          at.ID,
+			ClaimPath:   []any{at.ID},
 			DisplayName: clientmodels.TranslatedString(at.Name),
 			Value: &clientmodels.AttributeValue{
 				Type: clientmodels.AttributeType_String,
@@ -232,7 +232,7 @@ func credentialInfoListToSchemaless(irmaConfig *irma.Configuration, creds irma.C
 					continue
 				}
 				attributes = append(attributes, clientmodels.Attribute{
-					Id:          at.ID,
+					ClaimPath:   []any{at.ID},
 					DisplayName: clientmodels.TranslatedString(at.Name),
 					Description: &description,
 					Value:       buildAttributeValue(at.DisplayHint, &attrValue),
@@ -356,13 +356,14 @@ func SatisfiesRequestedAttributes(given, requested []clientmodels.Attribute) (bo
 func checkAttributeList(issues *[]string, path string, given, requested []clientmodels.Attribute) {
 	givenByID := make(map[string]clientmodels.Attribute, len(given))
 	for _, g := range given {
-		givenByID[g.Id] = g
+		givenByID[clientmodels.ClaimPathKey(g.ClaimPath)] = g
 	}
 
 	for _, r := range requested {
-		p := joinPath(path, r.Id)
+		key := clientmodels.ClaimPathKey(r.ClaimPath)
+		p := joinPath(path, key)
 
-		g, ok := givenByID[r.Id]
+		g, ok := givenByID[key]
 		if !ok {
 			*issues = append(*issues, fmt.Sprintf("missing attribute: %s", p))
 			continue
@@ -391,13 +392,6 @@ func checkValueSatisfies(issues *[]string, path string, given clientmodels.Attri
 	}
 
 	switch req.Type {
-	case clientmodels.AttributeType_Object:
-		// Nested attributes must satisfy nested requested constraints.
-		checkAttributeList(issues, path, given.Object, req.Object)
-
-	case clientmodels.AttributeType_Array:
-		checkArrayAllOfUnordered(issues, path, given.Array, req.Array)
-
 	case clientmodels.AttributeType_Int:
 		if req.Int == nil {
 			return
@@ -447,51 +441,6 @@ func checkValueSatisfies(issues *[]string, path string, given clientmodels.Attri
 	}
 }
 
-// Unordered "all-of":
-// Every requested element must be satisfied by some *distinct* element in given.
-// Uses backtracking to avoid greedy mismatches.
-func checkArrayAllOfUnordered(issues *[]string, path string, given, req []clientmodels.AttributeValue) {
-	// If nothing requested, array type is enough.
-	if len(req) == 0 {
-		return
-	}
-	if len(given) < len(req) {
-		*issues = append(*issues, fmt.Sprintf("array too short at %s: have %d want >= %d", path, len(given), len(req)))
-		return
-	}
-
-	used := make([]bool, len(given))
-
-	var dfs func(i int) bool
-	dfs = func(i int) bool {
-		if i == len(req) {
-			return true
-		}
-
-		// Try to match req[i] with any unused given[j]
-		for j := range given {
-			if used[j] {
-				continue
-			}
-			if valueSatisfiesNoReport(given[j], req[i]) {
-				used[j] = true
-				if dfs(i + 1) {
-					return true
-				}
-				used[j] = false
-			}
-		}
-		return false
-	}
-
-	if dfs(0) {
-		return
-	}
-
-	// If it doesn't match, add a helpful (though not minimal) error.
-	*issues = append(*issues, fmt.Sprintf("array mismatch at %s: could not satisfy all requested elements (unordered all-of)", path))
-}
-
 // valueSatisfiesNoReport mirrors checkValueSatisfies but returns bool only (no side-effects).
 // This is used for array matching/backtracking.
 func valueSatisfiesNoReport(given clientmodels.AttributeValue, req clientmodels.AttributeValue) bool {
@@ -500,13 +449,6 @@ func valueSatisfiesNoReport(given clientmodels.AttributeValue, req clientmodels.
 	}
 
 	switch req.Type {
-	case clientmodels.AttributeType_Object:
-		return attributeListSatisfiesNoReport(given.Object, req.Object)
-
-	case clientmodels.AttributeType_Array:
-		// Recurse into unordered all-of arrays as well.
-		return arrayAllOfUnorderedNoReport(given.Array, req.Array)
-
 	case clientmodels.AttributeType_Int:
 		if req.Int == nil {
 			return true
@@ -542,44 +484,13 @@ func valueSatisfiesNoReport(given clientmodels.AttributeValue, req clientmodels.
 	}
 }
 
-func arrayAllOfUnorderedNoReport(given, req []clientmodels.AttributeValue) bool {
-	if len(req) == 0 {
-		return true
-	}
-	if len(given) < len(req) {
-		return false
-	}
-
-	used := make([]bool, len(given))
-	var dfs func(i int) bool
-	dfs = func(i int) bool {
-		if i == len(req) {
-			return true
-		}
-		for j := range given {
-			if used[j] {
-				continue
-			}
-			if valueSatisfiesNoReport(given[j], req[i]) {
-				used[j] = true
-				if dfs(i + 1) {
-					return true
-				}
-				used[j] = false
-			}
-		}
-		return false
-	}
-	return dfs(0)
-}
-
 func attributeListSatisfiesNoReport(given, requested []clientmodels.Attribute) bool {
 	givenByID := make(map[string]clientmodels.Attribute, len(given))
 	for _, g := range given {
-		givenByID[g.Id] = g
+		givenByID[clientmodels.ClaimPathKey(g.ClaimPath)] = g
 	}
 	for _, r := range requested {
-		g, ok := givenByID[r.Id]
+		g, ok := givenByID[clientmodels.ClaimPathKey(r.ClaimPath)]
 		if !ok {
 			return false
 		}

--- a/client/session_handler.go
+++ b/client/session_handler.go
@@ -143,7 +143,7 @@ func filterRandomBlindAttributes(irmaConfig *irma.Configuration, credentials []*
 		randomBlindIDs := make(map[string]struct{})
 		for _, at := range credType.AttributeTypes {
 			if at.RandomBlind {
-				randomBlindIDs[at.ID] = struct{}{}
+				randomBlindIDs[clientmodels.ClaimPathKey([]any{at.ID})] = struct{}{}
 			}
 		}
 		if len(randomBlindIDs) == 0 {
@@ -151,7 +151,7 @@ func filterRandomBlindAttributes(irmaConfig *irma.Configuration, credentials []*
 		}
 		filtered := make([]clientmodels.Attribute, 0, len(cred.Attributes))
 		for _, attr := range cred.Attributes {
-			if _, isBlind := randomBlindIDs[attr.Id]; !isBlind {
+			if _, isBlind := randomBlindIDs[clientmodels.ClaimPathKey(attr.ClaimPath)]; !isBlind {
 				filtered = append(filtered, attr)
 			}
 		}
@@ -272,7 +272,7 @@ func createDisclosureChoicesOverview(
 					// Populate RequestedValue for the requested attribute
 					attrName := attr.AttributeIdentifier.Type.Name()
 					for i := range choiceTemplates[id].Attributes {
-						if choiceTemplates[id].Attributes[i].Id == attrName {
+						if clientmodels.ClaimPathKey(choiceTemplates[id].Attributes[i].ClaimPath) == clientmodels.ClaimPathKey([]any{attrName}) {
 							requestedValue := &clientmodels.AttributeValue{
 								Type: clientmodels.AttributeType_String,
 							}
@@ -394,12 +394,12 @@ func getIssuedSinceOriginalPlan(
 func filterCredentialToMismatchedAttributes(cred *clientmodels.Credential, requestedAttrs []clientmodels.Attribute) *clientmodels.Credential {
 	requestedByID := make(map[string]*clientmodels.Attribute, len(requestedAttrs))
 	for i := range requestedAttrs {
-		requestedByID[requestedAttrs[i].Id] = &requestedAttrs[i]
+		requestedByID[clientmodels.ClaimPathKey(requestedAttrs[i].ClaimPath)] = &requestedAttrs[i]
 	}
 
 	var filtered []clientmodels.Attribute
 	for _, attr := range cred.Attributes {
-		req, ok := requestedByID[attr.Id]
+		req, ok := requestedByID[clientmodels.ClaimPathKey(attr.ClaimPath)]
 		if !ok || req.RequestedValue == nil || !req.RequestedValue.HasValue() {
 			continue
 		}
@@ -410,7 +410,7 @@ func filterCredentialToMismatchedAttributes(cred *clientmodels.Credential, reque
 		)
 		if !satisfied {
 			filtered = append(filtered, clientmodels.Attribute{
-				Id:             attr.Id,
+				ClaimPath:      attr.ClaimPath,
 				DisplayName:    attr.DisplayName,
 				Description:    attr.Description,
 				Value:          attr.Value,
@@ -484,7 +484,7 @@ func createDisclosurePlan(
 
 func lookupAttrValue(orig *clientmodels.SelectableCredentialInstance, id *irma.AttributeIdentifier) (clientmodels.Attribute, bool) {
 	index := slices.IndexFunc(orig.Attributes, func(att clientmodels.Attribute) bool {
-		return att.Id == id.Type.Name()
+		return clientmodels.ClaimPathKey(att.ClaimPath) == clientmodels.ClaimPathKey([]any{id.Type.Name()})
 	})
 	if index >= 0 {
 		return orig.Attributes[index], true

--- a/common/clientmodels/helpers.go
+++ b/common/clientmodels/helpers.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SatisfiesRequestedAttributes checks that `given` contains everything needed to satisfy `requested`.
-// Returns ok + list of issues with paths (e.g. "address.street", "roles[2]").
+// Returns ok + list of issues with paths (e.g. "address.street").
 func SatisfiesRequestedAttributes(given, requested []Attribute) (bool, []string) {
 	var issues []string
 	checkAttributeList(&issues, "", given, requested)
@@ -14,15 +14,16 @@ func SatisfiesRequestedAttributes(given, requested []Attribute) (bool, []string)
 }
 
 func checkAttributeList(issues *[]string, path string, given, requested []Attribute) {
-	givenByID := make(map[string]Attribute, len(given))
+	givenByPath := make(map[string]Attribute, len(given))
 	for _, g := range given {
-		givenByID[g.Id] = g
+		givenByPath[ClaimPathKey(g.ClaimPath)] = g
 	}
 
 	for _, r := range requested {
-		p := joinPath(path, r.Id)
+		key := ClaimPathKey(r.ClaimPath)
+		p := joinPath(path, key)
 
-		g, ok := givenByID[r.Id]
+		g, ok := givenByPath[key]
 		if !ok {
 			*issues = append(*issues, fmt.Sprintf("missing attribute: %s", p))
 			continue
@@ -48,12 +49,6 @@ func checkValueSatisfies(issues *[]string, path string, given AttributeValue, re
 	}
 
 	switch req.Type {
-	case AttributeType_Object:
-		checkAttributeList(issues, path, given.Object, req.Object)
-
-	case AttributeType_Array:
-		checkArrayAllOfUnordered(issues, path, given.Array, req.Array)
-
 	case AttributeType_Int:
 		if req.Int == nil {
 			return
@@ -100,51 +95,11 @@ func checkValueSatisfies(issues *[]string, path string, given AttributeValue, re
 	}
 }
 
-func checkArrayAllOfUnordered(issues *[]string, path string, given, req []AttributeValue) {
-	if len(req) == 0 {
-		return
-	}
-	if len(given) < len(req) {
-		*issues = append(*issues, fmt.Sprintf("array too short at %s: have %d want >= %d", path, len(given), len(req)))
-		return
-	}
-
-	used := make([]bool, len(given))
-	var dfs func(i int) bool
-	dfs = func(i int) bool {
-		if i == len(req) {
-			return true
-		}
-		for j := range given {
-			if used[j] {
-				continue
-			}
-			if valueSatisfiesNoReport(given[j], req[i]) {
-				used[j] = true
-				if dfs(i + 1) {
-					return true
-				}
-				used[j] = false
-			}
-		}
-		return false
-	}
-
-	if dfs(0) {
-		return
-	}
-	*issues = append(*issues, fmt.Sprintf("array mismatch at %s: could not satisfy all requested elements (unordered all-of)", path))
-}
-
 func valueSatisfiesNoReport(given AttributeValue, req AttributeValue) bool {
 	if req.Type != "" && given.Type != req.Type {
 		return false
 	}
 	switch req.Type {
-	case AttributeType_Object:
-		return attributeListSatisfiesNoReport(given.Object, req.Object)
-	case AttributeType_Array:
-		return arrayAllOfUnorderedNoReport(given.Array, req.Array)
 	case AttributeType_Int:
 		if req.Int == nil {
 			return true
@@ -175,43 +130,13 @@ func valueSatisfiesNoReport(given AttributeValue, req AttributeValue) bool {
 	}
 }
 
-func arrayAllOfUnorderedNoReport(given, req []AttributeValue) bool {
-	if len(req) == 0 {
-		return true
-	}
-	if len(given) < len(req) {
-		return false
-	}
-	used := make([]bool, len(given))
-	var dfs func(i int) bool
-	dfs = func(i int) bool {
-		if i == len(req) {
-			return true
-		}
-		for j := range given {
-			if used[j] {
-				continue
-			}
-			if valueSatisfiesNoReport(given[j], req[i]) {
-				used[j] = true
-				if dfs(i + 1) {
-					return true
-				}
-				used[j] = false
-			}
-		}
-		return false
-	}
-	return dfs(0)
-}
-
 func attributeListSatisfiesNoReport(given, requested []Attribute) bool {
-	givenByID := make(map[string]Attribute, len(given))
+	givenByPath := make(map[string]Attribute, len(given))
 	for _, g := range given {
-		givenByID[g.Id] = g
+		givenByPath[ClaimPathKey(g.ClaimPath)] = g
 	}
 	for _, r := range requested {
-		g, ok := givenByID[r.Id]
+		g, ok := givenByPath[ClaimPathKey(r.ClaimPath)]
 		if !ok {
 			return false
 		}
@@ -228,9 +153,9 @@ func attributeListSatisfiesNoReport(given, requested []Attribute) bool {
 	return true
 }
 
-func joinPath(prefix, id string) string {
-	if prefix == "" {
-		return id
+func joinPath(parent, child string) string {
+	if parent == "" {
+		return child
 	}
-	return strings.Join([]string{prefix, id}, ".")
+	return parent + "." + strings.TrimPrefix(child, ".")
 }

--- a/common/clientmodels/types.go
+++ b/common/clientmodels/types.go
@@ -26,8 +26,6 @@ type TrustedParty struct {
 type AttributeType string
 
 const (
-	AttributeType_Object      AttributeType = "object"
-	AttributeType_Array       AttributeType = "array"
 	AttributeType_String      AttributeType = "string"
 	AttributeType_Bool        AttributeType = "boolean"
 	AttributeType_Int         AttributeType = "integer"
@@ -35,22 +33,22 @@ const (
 	AttributeType_Base64Image AttributeType = "base64_image"
 )
 
-// AttributeValue holds a typed attribute value.
+// AttributeValue holds a single scalar attribute value. Compound types (arrays,
+// objects) are represented as multiple Attribute entries with nested claim paths
+// instead.
 type AttributeValue struct {
 	Type AttributeType `json:"type"`
 
-	Int         *int64           `json:"int,omitempty"`
-	Bool        *bool            `json:"bool,omitempty"`
-	String      *string          `json:"string,omitempty"`
-	Array       []AttributeValue `json:"array,omitempty"`
-	Object      []Attribute      `json:"object,omitempty"`
-	ImagePath   *string          `json:"image_path,omitempty"`
-	Base64Image *string          `json:"base64_image,omitempty"`
+	Int         *int64  `json:"int,omitempty"`
+	Bool        *bool   `json:"bool,omitempty"`
+	String      *string `json:"string,omitempty"`
+	ImagePath   *string `json:"image_path,omitempty"`
+	Base64Image *string `json:"base64_image,omitempty"`
 }
 
-// NewAttributeValue converts a Go value (typically from JSON unmarshalling) into
-// an AttributeValue. Supported types: string, bool, float64, int64, []any,
-// map[string]any. Returns nil for nil input.
+// NewAttributeValue converts a scalar Go value into an AttributeValue.
+// Only handles scalar types (string, bool, int64, float64). Returns nil for nil
+// input. Callers must flatten arrays and objects into separate Attribute entries.
 func NewAttributeValue(val any) *AttributeValue {
 	if val == nil {
 		return nil
@@ -69,23 +67,6 @@ func NewAttributeValue(val any) *AttributeValue {
 		}
 		s := fmt.Sprintf("%g", v)
 		return &AttributeValue{Type: AttributeType_String, String: &s}
-	case []any:
-		arr := make([]AttributeValue, len(v))
-		for i, elem := range v {
-			if av := NewAttributeValue(elem); av != nil {
-				arr[i] = *av
-			}
-		}
-		return &AttributeValue{Type: AttributeType_Array, Array: arr}
-	case map[string]any:
-		var obj []Attribute
-		for key, elem := range v {
-			obj = append(obj, Attribute{
-				Id:    key,
-				Value: NewAttributeValue(elem),
-			})
-		}
-		return &AttributeValue{Type: AttributeType_Object, Object: obj}
 	default:
 		s := fmt.Sprintf("%v", v)
 		return &AttributeValue{Type: AttributeType_String, String: &s}
@@ -95,51 +76,72 @@ func NewAttributeValue(val any) *AttributeValue {
 // HasValue returns true if this AttributeValue carries an actual value (not just a type constraint).
 func (v *AttributeValue) HasValue() bool {
 	return v.Int != nil || v.Bool != nil || v.String != nil ||
-		len(v.Array) > 0 || len(v.Object) > 0 || v.ImagePath != nil || v.Base64Image != nil
+		v.ImagePath != nil || v.Base64Image != nil
 }
 
-// Attribute represents a single credential attribute with display metadata.
+// Attribute represents a single claim within a credential.
 type Attribute struct {
-	// Id for this attribute (only the last part in case of irma/idemix)
-	Id string `json:"id"`
-	// The name for this attribute as displayed to the end user
+	// Canonical identifier: the full claim path as an array of strings and integers.
+	// Examples:
+	//   ["email"]                    — flat IRMA attribute
+	//   ["address", "street"]        — nested SD-JWT claim
+	//   ["courses", 1]              — specific array element
+	//   ["departments", 0, "name"]  — nested object inside array
+	//
+	// The UI sends this path back verbatim in SelectedCredential.AttributePaths
+	// when the user grants disclosure permission.
+	ClaimPath []any `json:"claim_path"`
+
+	// Human-readable name for this attribute, localized.
 	DisplayName TranslatedString `json:"display_name"`
-	// The description for this attribute if any
+
+	// Optional longer description for this attribute, localized.
 	Description *TranslatedString `json:"description,omitempty"`
-	// The value that this attribute has as provided by the issuer (absent when it's just an attribute description)
+
+	// The actual value of this attribute as provided by the issuer.
+	// Nil when describing a requested attribute that hasn't been filled yet.
 	Value *AttributeValue `json:"value,omitempty"`
-	// The value that was requested by a verifier (if any)
+
+	// The value that a verifier requested for this attribute (if any).
 	RequestedValue *AttributeValue `json:"requested_value,omitempty"`
+}
+
+// ClaimPathKey produces a deterministic string key from a claim path for use
+// in maps. Go slices can't be map keys, so this serializes the path.
+func ClaimPathKey(path []any) string {
+	return fmt.Sprintf("%v", path)
 }
 
 // Credential represents a full credential with all its metadata and attribute values.
 type Credential struct {
-	// The id for this credential. For irma/idemix credentials this would look like
-	// `pbdf.sidn-pbdf.email`, for EUDI credentials this would be in the form of `https://example.credential.com`
+	// The id for this credential. For IRMA/idemix credentials this would look like
+	// "pbdf.sidn-pbdf.email", for EUDI credentials this is the VCT URL.
 	CredentialId string `json:"credential_id"`
 	// Hash over all attribute values and the credential id.
 	Hash string `json:"hash"`
-	// Absolute path to the image for this credential stored on disk
+	// Absolute path to the image for this credential stored on disk.
 	ImagePath *string `json:"image_path"`
-	// The display name for this credential
+	// The display name for this credential, localized.
 	Name TranslatedString `json:"name"`
-	// All information about the credential issuer
+	// All information about the credential issuer.
 	Issuer TrustedParty `json:"issuer"`
-	// The IDs for all instances of this credential in all different formats it's available in.
+	// The IDs for all instances of this credential in all different formats.
 	CredentialInstanceIds map[CredentialFormat]string `json:"credential_instance_ids"`
-	// The number of credential instances left per credential format (in case they were issued in batches)
+	// The number of credential instances left per format (batched issuance).
 	BatchInstanceCountsRemaining map[CredentialFormat]*uint `json:"batch_instance_counts_remaining"`
-	// All the attributes and their values in this credential
+	// All the attributes and their values in this credential.
+	// Ordered by the source metadata (IRMA scheme or EUDI issuer metadata).
+	// Nested objects and arrays are flattened with full claim paths.
 	Attributes []Attribute `json:"attributes"`
-	// The date and time (unix format) at which this credential was issued
+	// The date and time (unix format) at which this credential was issued.
 	IssuanceDate int64 `json:"issuance_date"`
-	// The date and time (unix format) when this credential expires
-	ExpiryDate int64 `json:"expiry_date"` // TODO: should be optional
-	// Whether or not this credential has been revoked
+	// The date and time (unix format) when this credential expires (0 if no expiry).
+	ExpiryDate int64 `json:"expiry_date"`
+	// Whether or not this credential has been revoked.
 	Revoked bool `json:"revoked"`
-	// Whether or not revocation is supported for this credential
+	// Whether or not revocation is supported for this credential.
 	RevocationSupported bool `json:"revocation_supported"`
-	// Url at which this credential can be issued (if any)
+	// URL at which this credential can be issued (if any).
 	IssueURL *TranslatedString `json:"issue_url"`
 }
 
@@ -171,32 +173,33 @@ type Faq struct {
 // SelectableCredentialInstance represents a single credential instance that
 // the user can select for disclosure.
 type SelectableCredentialInstance struct {
-	// The id for this credential. For irma/idemix credentials this would look like
-	// `pbdf.sidn-pbdf.email`, for EUDI credentials this would be in the form of `https://example.credential.com`
+	// The id for this credential. For IRMA/idemix credentials this would look like
+	// "pbdf.sidn-pbdf.email", for EUDI credentials this is the VCT URL.
 	CredentialId string `json:"credential_id"`
 	// Hash over all attribute values and the credential id.
 	Hash string `json:"hash"`
-	// Absolute path to the image for this credential stored on disk
+	// Absolute path to the image for this credential stored on disk.
 	ImagePath *string `json:"image_path"`
-	// The display name for this credential
+	// The display name for this credential, localized.
 	Name TranslatedString `json:"name"`
-	// All information about the credential issuer
+	// All information about the credential issuer.
 	Issuer TrustedParty `json:"issuer"`
-	// The credential format for this instance
+	// The credential format for this instance.
 	Format CredentialFormat `json:"format"`
-	// The number of credential instances left for this credential instance
+	// The number of credential instances left for this credential instance.
 	BatchInstanceCountRemaining *uint `json:"batch_instance_count_remaining"`
-	// All the attributes and their values in this credential that are selectable
+	// The attributes selectable for disclosure, ordered by source metadata.
+	// Requested SD claims appear first (in metadata order), non-SD claims after.
 	Attributes []Attribute `json:"attributes"`
-	// The date and time (unix format) at which this credential was issued
+	// The date and time (unix format) at which this credential was issued.
 	IssuanceDate int64 `json:"issuance_date"`
-	// The date and time (unix format) when this credential expires
+	// The date and time (unix format) when this credential expires.
 	ExpiryDate int64 `json:"expiry_date"`
-	// Whether or not this credential has been revoked
+	// Whether or not this credential has been revoked.
 	Revoked bool `json:"revoked"`
-	// Whether or not revocation is supported for this credential
+	// Whether or not revocation is supported for this credential.
 	RevocationSupported bool `json:"revocation_supported"`
-	// Url at which this credential can be issued (if any)
+	// URL at which this credential can be issued (if any).
 	IssueURL *TranslatedString `json:"issue_url"`
 }
 

--- a/eudi/openid4vci/client.go
+++ b/eudi/openid4vci/client.go
@@ -399,7 +399,7 @@ func convertClaimsToAttributes(claims []metadata.ClaimsDescription) []clientmode
 				displayName = metadata.ConvertDisplayToTranslatedString(displays)
 			}
 			attrs = append(attrs, clientmodels.Attribute{
-				Id:          path,
+				ClaimPath:   []any{path},
 				DisplayName: displayName,
 			})
 		}

--- a/eudi/openid4vp/dcql/dcql.go
+++ b/eudi/openid4vp/dcql/dcql.go
@@ -91,33 +91,15 @@ type QueryResponse struct {
 	Credentials []string
 }
 
-// ClaimsPathPointer is a list of components that construct a full path to a claim.
-// Each component is one of:
-//   - string: selects a key within an object
-//   - int/float64: selects an element at the given index within an array
-//   - nil: selects all elements within an array
-//
-// JSON encoding: ["key", 0, null] → []any{"key", 0, nil}
-type ClaimsPathPointer []any
-
-// LastString returns the last string component in the path, or "" if none.
-func (p ClaimsPathPointer) LastString() string {
-	for i := len(p) - 1; i >= 0; i-- {
-		if s, ok := p[i].(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
 type Claim struct {
 	// REQUIRED if claim_sets is present in the credential query, OPTIONAL otherwise.
 	// a string identifying the particular claim. The same id must not be presented more than once.
 	Id string `json:"id"`
 
 	// REQUIRED: A claims path pointer that specifies the path to a claim
-	// within the verifiable credential
-	Path ClaimsPathPointer `json:"path"`
+	// within the verifiable credential. Each component is a string (object key),
+	// int/float64 (array index), or nil (all array elements).
+	Path []any `json:"path"`
 
 	// OPTIONAL: A list of strings, integers or boolean values that specifies the expected values of the claim
 	Values []any `json:"values,omitempty"`

--- a/eudi/openid4vp/eudi_sdjwt_dcql/handler.go
+++ b/eudi/openid4vp/eudi_sdjwt_dcql/handler.go
@@ -208,29 +208,84 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 	seenPaths := make(map[string]struct{})
 	requestedKeys := make(map[string]struct{})
 	for _, claim := range claims {
-		pathKey := fmt.Sprintf("%v", []any(claim.Path))
+		pathKey := clientmodels.ClaimPathKey([]any(claim.Path))
 		if _, duplicate := seenPaths[pathKey]; duplicate {
 			continue
 		}
 		seenPaths[pathKey] = struct{}{}
 
 		attrName := claim.Path.LastString()
-		requestedKeys[attrName] = struct{}{}
 
 		val, _ := payload.GetClaimValue([]any(claim.Path))
-		attr := clientmodels.Attribute{
-			Id:          attrName,
-			DisplayName: claimDisplayName(batch, attrName),
+
+		// When the path ends with nil (null wildcard for all array elements),
+		// expand into individual attributes with indexed paths.
+		if len(claim.Path) > 0 && claim.Path[len(claim.Path)-1] == nil {
+			if arr, ok := val.([]any); ok {
+				basePath := []any(claim.Path[:len(claim.Path)-1])
+				displayName := claimDisplayName(batch, attrName)
+				for i, elem := range arr {
+					elemPath := make([]any, len(basePath)+1)
+					copy(elemPath, basePath)
+					elemPath[len(basePath)] = i
+					pk := clientmodels.ClaimPathKey(elemPath)
+					requestedKeys[pk] = struct{}{}
+					attributes = append(attributes, clientmodels.Attribute{
+						ClaimPath:   elemPath,
+						DisplayName: displayName,
+						Value:       clientmodels.NewAttributeValue(elem),
+					})
+				}
+				continue
+			}
 		}
-		attr.Value = clientmodels.NewAttributeValue(val)
-		attributes = append(attributes, attr)
+
+		// When the value is an array (path doesn't end in nil but resolves to an array),
+		// also expand into indexed elements.
+		if arr, ok := val.([]any); ok {
+			displayName := claimDisplayName(batch, attrName)
+			for i, elem := range arr {
+				elemPath := append(append([]any{}, []any(claim.Path)...), i)
+				pk := clientmodels.ClaimPathKey(elemPath)
+				requestedKeys[pk] = struct{}{}
+				attributes = append(attributes, clientmodels.Attribute{
+					ClaimPath:   elemPath,
+					DisplayName: displayName,
+					Value:       clientmodels.NewAttributeValue(elem),
+				})
+			}
+			continue
+		}
+
+		// When the value is a nested object, flatten into individual attributes.
+		if obj, ok := val.(map[string]any); ok {
+			for key, elem := range obj {
+				elemPath := append(append([]any{}, []any(claim.Path)...), key)
+				pk := clientmodels.ClaimPathKey(elemPath)
+				requestedKeys[pk] = struct{}{}
+				attributes = append(attributes, clientmodels.Attribute{
+					ClaimPath:   elemPath,
+					DisplayName: claimDisplayName(batch, key),
+					Value:       clientmodels.NewAttributeValue(elem),
+				})
+			}
+			continue
+		}
+
+		// Scalar value — single attribute.
+		requestedKeys[pathKey] = struct{}{}
+		attributes = append(attributes, clientmodels.Attribute{
+			ClaimPath:   []any(claim.Path),
+			DisplayName: claimDisplayName(batch, attrName),
+			Value:       clientmodels.NewAttributeValue(val),
+		})
 	}
 
 	// Include non-SD claims: these are always visible in the JWT payload and
 	// will be shared regardless of which disclosures the user selects.
 	nonSdClaims := getNonSdClaimNames(batch, credStore)
 	for _, name := range nonSdClaims {
-		if _, alreadyIncluded := requestedKeys[name]; alreadyIncluded {
+		if _, alreadyIncluded := requestedKeys[clientmodels.ClaimPathKey([]any{name})]; alreadyIncluded {
 			continue
 		}
 		val, err := payload.GetClaimValue([]any{name})
@@ -238,7 +293,7 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 			continue
 		}
 		attr := clientmodels.Attribute{
-			Id:          name,
+			ClaimPath:   []any{name},
 			DisplayName: claimDisplayName(batch, name),
 		}
 		attr.Value = clientmodels.NewAttributeValue(val)
@@ -388,7 +443,7 @@ func buildLogCredential(batch *models.CredentialBatch, claimPaths [][]any) clien
 		}
 		attrName := dcql.ClaimsPathPointer(path).LastString()
 		attr := clientmodels.Attribute{
-			Id:          attrName,
+			ClaimPath:   path,
 			DisplayName: claimDisplayName(batch, attrName),
 		}
 		if val, err := payload.GetClaimValue(path); err == nil {

--- a/eudi/openid4vp/eudi_sdjwt_dcql/handler.go
+++ b/eudi/openid4vp/eudi_sdjwt_dcql/handler.go
@@ -208,22 +208,20 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 	seenPaths := make(map[string]struct{})
 	requestedKeys := make(map[string]struct{})
 	for _, claim := range claims {
-		pathKey := clientmodels.ClaimPathKey([]any(claim.Path))
+		pathKey := clientmodels.ClaimPathKey(claim.Path)
 		if _, duplicate := seenPaths[pathKey]; duplicate {
 			continue
 		}
 		seenPaths[pathKey] = struct{}{}
 
-		attrName := claim.Path.LastString()
-
-		val, _ := payload.GetClaimValue([]any(claim.Path))
+		val, _ := payload.GetClaimValue(claim.Path)
 
 		// When the path ends with nil (null wildcard for all array elements),
 		// expand into individual attributes with indexed paths.
 		if len(claim.Path) > 0 && claim.Path[len(claim.Path)-1] == nil {
 			if arr, ok := val.([]any); ok {
-				basePath := []any(claim.Path[:len(claim.Path)-1])
-				displayName := claimDisplayName(batch, attrName)
+				basePath := claim.Path[:len(claim.Path)-1]
+				displayName := claimDisplayName(batch, basePath)
 				for i, elem := range arr {
 					elemPath := make([]any, len(basePath)+1)
 					copy(elemPath, basePath)
@@ -243,9 +241,9 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 		// When the value is an array (path doesn't end in nil but resolves to an array),
 		// also expand into indexed elements.
 		if arr, ok := val.([]any); ok {
-			displayName := claimDisplayName(batch, attrName)
+			displayName := claimDisplayName(batch, claim.Path)
 			for i, elem := range arr {
-				elemPath := append(append([]any{}, []any(claim.Path)...), i)
+				elemPath := append(append([]any{}, claim.Path...), i)
 				pk := clientmodels.ClaimPathKey(elemPath)
 				requestedKeys[pk] = struct{}{}
 				attributes = append(attributes, clientmodels.Attribute{
@@ -260,12 +258,12 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 		// When the value is a nested object, flatten into individual attributes.
 		if obj, ok := val.(map[string]any); ok {
 			for key, elem := range obj {
-				elemPath := append(append([]any{}, []any(claim.Path)...), key)
+				elemPath := append(append([]any{}, claim.Path...), key)
 				pk := clientmodels.ClaimPathKey(elemPath)
 				requestedKeys[pk] = struct{}{}
 				attributes = append(attributes, clientmodels.Attribute{
 					ClaimPath:   elemPath,
-					DisplayName: claimDisplayName(batch, key),
+					DisplayName: claimDisplayName(batch, elemPath),
 					Value:       clientmodels.NewAttributeValue(elem),
 				})
 			}
@@ -275,8 +273,8 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 		// Scalar value — single attribute.
 		requestedKeys[pathKey] = struct{}{}
 		attributes = append(attributes, clientmodels.Attribute{
-			ClaimPath:   []any(claim.Path),
-			DisplayName: claimDisplayName(batch, attrName),
+			ClaimPath:   claim.Path,
+			DisplayName: claimDisplayName(batch, claim.Path),
 			Value:       clientmodels.NewAttributeValue(val),
 		})
 	}
@@ -294,7 +292,7 @@ func parseBatchAttributes(batch *models.CredentialBatch, query dcql.CredentialQu
 		}
 		attr := clientmodels.Attribute{
 			ClaimPath:   []any{name},
-			DisplayName: claimDisplayName(batch, name),
+			DisplayName: claimDisplayName(batch, []any{name}),
 		}
 		attr.Value = clientmodels.NewAttributeValue(val)
 		attributes = append(attributes, attr)
@@ -357,7 +355,7 @@ func selectClaims(query dcql.CredentialQuery, payload *sdjwtvc.ProcessedSdJwtPay
 // any value constraints. Supports string, boolean, and numeric comparisons as
 // required by the DCQL spec (OpenID4VP Section 6.3).
 func claimMatches(claim dcql.Claim, payload *sdjwtvc.ProcessedSdJwtPayload) bool {
-	val, err := payload.GetClaimValue([]any(claim.Path))
+	val, err := payload.GetClaimValue(claim.Path)
 	if err != nil {
 		return false
 	}
@@ -441,10 +439,9 @@ func buildLogCredential(batch *models.CredentialBatch, claimPaths [][]any) clien
 		if len(path) == 0 {
 			continue
 		}
-		attrName := dcql.ClaimsPathPointer(path).LastString()
 		attr := clientmodels.Attribute{
 			ClaimPath:   path,
-			DisplayName: claimDisplayName(batch, attrName),
+			DisplayName: claimDisplayName(batch, path),
 		}
 		if val, err := payload.GetClaimValue(path); err == nil {
 			if valStr, ok := val.(string); ok {
@@ -491,12 +488,12 @@ func isBatchValid(batch *models.CredentialBatch, now time.Time) bool {
 
 // claimDisplayName looks up the display name for a claim from the stored credential metadata.
 // Falls back to the raw claim name if no display metadata is available.
-func claimDisplayName(batch *models.CredentialBatch, claimName string) clientmodels.TranslatedString {
+func claimDisplayName(batch *models.CredentialBatch, claimPath []any) clientmodels.TranslatedString {
 	if batch.CredentialMetadata != nil {
 		for _, claim := range batch.CredentialMetadata.Claims {
 			var path []string
 			if err := json.Unmarshal(claim.Path, &path); err == nil {
-				if len(path) > 0 && path[len(path)-1] == claimName {
+				if claimPathMatchesStringPath(claimPath, path) {
 					ts := clientmodels.TranslatedString{}
 					for _, d := range claim.Display {
 						locale := "en"
@@ -513,4 +510,26 @@ func claimDisplayName(batch *models.CredentialBatch, claimName string) clientmod
 		}
 	}
 	return clientmodels.TranslatedString{}
+}
+
+// claimPathMatchesStringPath checks if a []any claim path matches a []string
+// metadata path. Integer components in claimPath are skipped for matching
+// (metadata paths don't contain array indices).
+func claimPathMatchesStringPath(claimPath []any, metadataPath []string) bool {
+	// Extract only the string components from the claim path.
+	var stringParts []string
+	for _, c := range claimPath {
+		if s, ok := c.(string); ok {
+			stringParts = append(stringParts, s)
+		}
+	}
+	if len(stringParts) != len(metadataPath) {
+		return false
+	}
+	for i := range stringParts {
+		if stringParts[i] != metadataPath[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/eudi/openid4vp/irma_sdjwt_dcql/handler.go
+++ b/eudi/openid4vp/irma_sdjwt_dcql/handler.go
@@ -121,15 +121,7 @@ func (h *SdJwtVcDcqlHandler) PrepareDisclosure(selections []dcql.DisclosureSelec
 			Credentials: []string{presentation},
 		})
 
-		// Extract flat attribute names from claim paths for log display.
-		attrNames := make([]string, 0, len(sel.ClaimPaths))
-		for _, path := range sel.ClaimPaths {
-			name := dcql.ClaimsPathPointer(path).LastString()
-			if name != "" {
-				attrNames = append(attrNames, name)
-			}
-		}
-		credLog := h.buildLogCredential(cred.Metadata, attrNames)
+		credLog := h.buildLogCredential(cred.Metadata, sel.ClaimPaths)
 		result.CredentialLogs = append(result.CredentialLogs, credLog)
 	}
 
@@ -147,12 +139,12 @@ type dcqlClaimMatch struct {
 	hasValue       bool
 }
 
-// claimKey returns the claim's ID if set, otherwise its dot-joined path.
+// dcqlClaimKey returns the claim's ID if set, otherwise the serialized claim path.
 func dcqlClaimKey(claim dcql.Claim) string {
 	if claim.Id != "" {
 		return claim.Id
 	}
-	return claim.Path.LastString()
+	return clientmodels.ClaimPathKey(claim.Path)
 }
 
 // getClaimMatches checks which claims from the query match the credential's attributes.
@@ -369,7 +361,7 @@ func (h *SdJwtVcDcqlHandler) buildCredentialDescriptor(credTypeId irma.Credentia
 		for _, c := range query.Claims {
 			key := c.Id
 			if key == "" {
-				key = c.Path.LastString()
+				key = clientmodels.ClaimPathKey(c.Path)
 			}
 			claimMap[key] = c
 		}
@@ -384,15 +376,15 @@ func (h *SdJwtVcDcqlHandler) buildCredentialDescriptor(credTypeId irma.Credentia
 	// Build attributes for the selected claims
 	var attributes []clientmodels.Attribute
 	for _, claim := range claimsToShow {
-		attrName := claim.Path.LastString()
+		pathKey := clientmodels.ClaimPathKey(claim.Path)
 		attr := clientmodels.Attribute{
-			ClaimPath:   []any(claim.Path),
-			DisplayName: clientmodels.TranslatedString{"en": attrName},
+			ClaimPath:   claim.Path,
+			DisplayName: clientmodels.TranslatedString{"en": pathKey},
 		}
 
 		// Look up display metadata from the credential type schema
 		for _, at := range credType.AttributeTypes {
-			if at.ID == attrName {
+			if clientmodels.ClaimPathKey([]any{at.ID}) == pathKey {
 				attr.DisplayName = clientmodels.TranslatedString(at.Name)
 				break
 			}
@@ -425,7 +417,7 @@ func (h *SdJwtVcDcqlHandler) buildCredentialDescriptor(credTypeId irma.Credentia
 }
 
 // buildLogCredential creates a LogCredential for a disclosed credential.
-func (h *SdJwtVcDcqlHandler) buildLogCredential(metadata irmaclient.SdJwtVcBatchMetadata, disclosedAttributeNames []string) clientmodels.LogCredential {
+func (h *SdJwtVcDcqlHandler) buildLogCredential(metadata irmaclient.SdJwtVcBatchMetadata, disclosedClaimPaths [][]any) clientmodels.LogCredential {
 	credTypeId := irma.NewCredentialTypeIdentifier(metadata.CredentialType)
 
 	logCred := clientmodels.LogCredential{
@@ -449,35 +441,32 @@ func (h *SdJwtVcDcqlHandler) buildLogCredential(metadata irmaclient.SdJwtVcBatch
 
 	// Build disclosed attributes
 	var attributes []clientmodels.Attribute
-	for _, attrName := range disclosedAttributeNames {
+	for _, claimPath := range disclosedClaimPaths {
+		pathKey := clientmodels.ClaimPathKey(claimPath)
 		attr := clientmodels.Attribute{
-			ClaimPath:   []any{attrName},
-			DisplayName: clientmodels.TranslatedString{"en": attrName},
+			ClaimPath:   claimPath,
+			DisplayName: clientmodels.TranslatedString{"en": pathKey},
 		}
 
-		// Look up display name from schema
+		// Look up display name and value from schema.
+		// IRMA attributes are flat, so ClaimPathKey([]any{at.ID}) matches the path key.
+		var matchedAtType *irma.AttributeType
 		if credType, ok := h.config.CredentialTypes[credTypeId]; ok {
 			for _, at := range credType.AttributeTypes {
-				if at.ID == attrName {
+				if clientmodels.ClaimPathKey([]any{at.ID}) == pathKey {
 					attr.DisplayName = clientmodels.TranslatedString(at.Name)
+					matchedAtType = at
 					break
 				}
 			}
 		}
 
 		// Set the disclosed value
-		if rawVal, exists := metadata.Attributes[attrName]; exists {
-			if strVal, ok := rawVal.(string); ok {
-				displayHint := ""
-				if credType, ok := h.config.CredentialTypes[credTypeId]; ok {
-					for _, at := range credType.AttributeTypes {
-						if at.ID == attrName {
-							displayHint = at.DisplayHint
-							break
-						}
-					}
+		if matchedAtType != nil {
+			if rawVal, exists := metadata.Attributes[matchedAtType.ID]; exists {
+				if strVal, ok := rawVal.(string); ok {
+					attr.Value = buildAttributeValue(matchedAtType.DisplayHint, &strVal)
 				}
-				attr.Value = buildAttributeValue(displayHint, &strVal)
 			}
 		}
 

--- a/eudi/openid4vp/irma_sdjwt_dcql/handler.go
+++ b/eudi/openid4vp/irma_sdjwt_dcql/handler.go
@@ -307,7 +307,7 @@ func (h *SdJwtVcDcqlHandler) buildMatchedAttributes(
 		if !ok {
 			// If the attribute type is not in the schema, create a basic attribute
 			attr := clientmodels.Attribute{
-				Id:          match.attributeName,
+				ClaimPath:   []any{match.attributeName},
 				DisplayName: clientmodels.TranslatedString{"en": match.attributeName},
 			}
 			if rawVal, exists := metadata.Attributes[match.attributeName]; exists {
@@ -321,7 +321,7 @@ func (h *SdJwtVcDcqlHandler) buildMatchedAttributes(
 
 		description := clientmodels.TranslatedString(at.Description)
 		attr := clientmodels.Attribute{
-			Id:          at.ID,
+			ClaimPath:   []any{at.ID},
 			DisplayName: clientmodels.TranslatedString(at.Name),
 			Description: &description,
 		}
@@ -386,7 +386,7 @@ func (h *SdJwtVcDcqlHandler) buildCredentialDescriptor(credTypeId irma.Credentia
 	for _, claim := range claimsToShow {
 		attrName := claim.Path.LastString()
 		attr := clientmodels.Attribute{
-			Id:          attrName,
+			ClaimPath:   []any(claim.Path),
 			DisplayName: clientmodels.TranslatedString{"en": attrName},
 		}
 
@@ -451,7 +451,7 @@ func (h *SdJwtVcDcqlHandler) buildLogCredential(metadata irmaclient.SdJwtVcBatch
 	var attributes []clientmodels.Attribute
 	for _, attrName := range disclosedAttributeNames {
 		attr := clientmodels.Attribute{
-			Id:          attrName,
+			ClaimPath:   []any{attrName},
 			DisplayName: clientmodels.TranslatedString{"en": attrName},
 		}
 

--- a/eudi/openid4vp/irma_sdjwt_dcql/handler_test.go
+++ b/eudi/openid4vp/irma_sdjwt_dcql/handler_test.go
@@ -57,7 +57,7 @@ func testSatisfiableSingleCredentialSingleOption(t *testing.T) {
 
 	requireSatisfiable(t, plan, expectPickOne{owned: 1, obtainable: 1})
 	assert.Equal(t, "test.test.email", plan.DisclosureChoicesOverview[0].OwnedOptions[0].CredentialId)
-	assert.Equal(t, "email", plan.DisclosureChoicesOverview[0].OwnedOptions[0].Attributes[0].Id)
+	assert.Equal(t, "email", plan.DisclosureChoicesOverview[0].OwnedOptions[0].Attributes[0].ClaimPath[0].(string))
 }
 
 func testSatisfiableSingleCredentialMultipleInstances(t *testing.T) {
@@ -476,7 +476,7 @@ func testClaimSetsOneOptionSatisfiable(t *testing.T) {
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	assert.Equal(t, infoGmail.Hash, owned.Hash)
 	require.Len(t, owned.Attributes, 1)
-	assert.Equal(t, "domain", owned.Attributes[0].Id)
+	assert.Equal(t, "domain", owned.Attributes[0].ClaimPath[0].(string))
 }
 
 func testClaimSetsBothSatisfiablePicksFirst(t *testing.T) {
@@ -501,7 +501,7 @@ func testClaimSetsBothSatisfiablePicksFirst(t *testing.T) {
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	assert.Equal(t, infoGmail.Hash, owned.Hash)
 	require.Len(t, owned.Attributes, 1)
-	assert.Equal(t, "email", owned.Attributes[0].Id) // first claim_set wins
+	assert.Equal(t, "email", owned.Attributes[0].ClaimPath[0].(string)) // first claim_set wins
 }
 
 func testClaimSetsBothSatisfiableByDifferentInstances(t *testing.T) {
@@ -527,11 +527,11 @@ func testClaimSetsBothSatisfiableByDifferentInstances(t *testing.T) {
 
 	gmail := byHash[infoGmail.Hash]
 	require.Len(t, gmail.Attributes, 1)
-	assert.Equal(t, "email", gmail.Attributes[0].Id)
+	assert.Equal(t, "email", gmail.Attributes[0].ClaimPath[0].(string))
 
 	hotmail := byHash[infoHotmail.Hash]
 	require.Len(t, hotmail.Attributes, 1)
-	assert.Equal(t, "domain", hotmail.Attributes[0].Id)
+	assert.Equal(t, "domain", hotmail.Attributes[0].ClaimPath[0].(string))
 }
 
 func testClaimSetsNotSatisfiable(t *testing.T) {

--- a/eudi/openid4vp/irma_sdjwt_dcql/handler_test.go
+++ b/eudi/openid4vp/irma_sdjwt_dcql/handler_test.go
@@ -57,7 +57,7 @@ func testSatisfiableSingleCredentialSingleOption(t *testing.T) {
 
 	requireSatisfiable(t, plan, expectPickOne{owned: 1, obtainable: 1})
 	assert.Equal(t, "test.test.email", plan.DisclosureChoicesOverview[0].OwnedOptions[0].CredentialId)
-	assert.Equal(t, "email", plan.DisclosureChoicesOverview[0].OwnedOptions[0].Attributes[0].ClaimPath[0].(string))
+	assert.Equal(t, []any{"email"}, plan.DisclosureChoicesOverview[0].OwnedOptions[0].Attributes[0].ClaimPath)
 }
 
 func testSatisfiableSingleCredentialMultipleInstances(t *testing.T) {
@@ -476,7 +476,7 @@ func testClaimSetsOneOptionSatisfiable(t *testing.T) {
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	assert.Equal(t, infoGmail.Hash, owned.Hash)
 	require.Len(t, owned.Attributes, 1)
-	assert.Equal(t, "domain", owned.Attributes[0].ClaimPath[0].(string))
+	assert.Equal(t, []any{"domain"}, owned.Attributes[0].ClaimPath)
 }
 
 func testClaimSetsBothSatisfiablePicksFirst(t *testing.T) {
@@ -501,7 +501,7 @@ func testClaimSetsBothSatisfiablePicksFirst(t *testing.T) {
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	assert.Equal(t, infoGmail.Hash, owned.Hash)
 	require.Len(t, owned.Attributes, 1)
-	assert.Equal(t, "email", owned.Attributes[0].ClaimPath[0].(string)) // first claim_set wins
+	assert.Equal(t, []any{"email"}, owned.Attributes[0].ClaimPath) // first claim_set wins
 }
 
 func testClaimSetsBothSatisfiableByDifferentInstances(t *testing.T) {
@@ -527,11 +527,11 @@ func testClaimSetsBothSatisfiableByDifferentInstances(t *testing.T) {
 
 	gmail := byHash[infoGmail.Hash]
 	require.Len(t, gmail.Attributes, 1)
-	assert.Equal(t, "email", gmail.Attributes[0].ClaimPath[0].(string))
+	assert.Equal(t, []any{"email"}, gmail.Attributes[0].ClaimPath)
 
 	hotmail := byHash[infoHotmail.Hash]
 	require.Len(t, hotmail.Attributes, 1)
-	assert.Equal(t, "domain", hotmail.Attributes[0].ClaimPath[0].(string))
+	assert.Equal(t, []any{"domain"}, hotmail.Attributes[0].ClaimPath)
 }
 
 func testClaimSetsNotSatisfiable(t *testing.T) {

--- a/eudi/services/credential_service.go
+++ b/eudi/services/credential_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"slices"
+	"sort"
 	"time"
 
 	"github.com/privacybydesign/irmago/common/clientmodels"
@@ -75,8 +76,7 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 				credentialDisplays[locale] = d.Name
 			}
 
-			attrs = make([]clientmodels.Attribute, len(batch.CredentialMetadata.Claims))
-			for j, claim := range batch.CredentialMetadata.Claims {
+			for _, claim := range batch.CredentialMetadata.Claims {
 				attrDisplay := clientmodels.TranslatedString{}
 				for _, d := range claim.Display {
 					locale := clientmodels.DefaultFallbackLanguage
@@ -86,7 +86,10 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 					attrDisplay[locale] = d.Name
 				}
 
-				// Build a slice from the claim path for processing
+				// Build a slice from the claim path for processing.
+				// Only string components are handled here because issuer metadata claim paths
+				// always use string keys. Integer indices and null (used in DCQL queries for
+				// array element selection) do not appear in issuer credential metadata.
 				var claimPath []any
 				if err := json.Unmarshal(claim.Path, &claimPath); err != nil {
 					log.Fatalf("Error unmarshalling JSON: %v", err)
@@ -95,15 +98,45 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 				claimValue, err := processedSdJwtPayload.GetClaimValue(claimPath)
 				if err != nil {
 					log.Printf("unrecognized claim at path %v; falling back to empty string for claim with path %v: %v", claim.Path, claimPath, err)
-					claimValue = "" // fallback to an empty string if claim value cannot be extracted
+					claimValue = ""
 				}
 
-				attrValue := clientmodels.NewAttributeValue(claimValue)
-
-				attrs[j] = clientmodels.Attribute{
-					ClaimPath:   claimPath,
-					DisplayName: attrDisplay,
-					Value:       attrValue,
+				// Flatten arrays and objects into separate attributes with full paths.
+				switch v := claimValue.(type) {
+				case []any:
+					for i, elem := range v {
+						elemPath := make([]any, len(claimPath)+1)
+						copy(elemPath, claimPath)
+						elemPath[len(claimPath)] = i
+						attrs = append(attrs, clientmodels.Attribute{
+							ClaimPath:   elemPath,
+							DisplayName: attrDisplay,
+							Value:       clientmodels.NewAttributeValue(elem),
+						})
+					}
+				case map[string]any:
+					// Sort keys for deterministic order.
+					keys := make([]string, 0, len(v))
+					for key := range v {
+						keys = append(keys, key)
+					}
+					sort.Strings(keys)
+					for _, key := range keys {
+						elemPath := make([]any, len(claimPath)+1)
+						copy(elemPath, claimPath)
+						elemPath[len(claimPath)] = key
+						attrs = append(attrs, clientmodels.Attribute{
+							ClaimPath:   elemPath,
+							DisplayName: attrDisplay,
+							Value:       clientmodels.NewAttributeValue(v[key]),
+						})
+					}
+				default:
+					attrs = append(attrs, clientmodels.Attribute{
+						ClaimPath:   claimPath,
+						DisplayName: attrDisplay,
+						Value:       clientmodels.NewAttributeValue(claimValue),
+					})
 				}
 			}
 		}

--- a/eudi/services/credential_service.go
+++ b/eudi/services/credential_service.go
@@ -100,19 +100,8 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 
 				attrValue := clientmodels.NewAttributeValue(claimValue)
 
-				// Use the last element of the claim path as the attribute ID (e.g., ["address", "city"] → "city").
-				// Only string components are handled here because issuer metadata claim paths always use
-				// string keys. Integer indices and null (used in DCQL queries for array element selection)
-				// do not appear in issuer credential metadata.
-				attrId := ""
-				if len(claimPath) > 0 {
-					if last, ok := claimPath[len(claimPath)-1].(string); ok {
-						attrId = last
-					}
-				}
-
 				attrs[j] = clientmodels.Attribute{
-					Id:          attrId,
+					ClaimPath:   claimPath,
 					DisplayName: attrDisplay,
 					Value:       attrValue,
 				}

--- a/eudi/services/credential_service.go
+++ b/eudi/services/credential_service.go
@@ -121,39 +121,7 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 					claimValue = ""
 				}
 
-				// Flatten arrays and objects into separate attributes with full paths.
-				switch v := claimValue.(type) {
-				case []any:
-					for i, elem := range v {
-						elemPath := append(append([]any{}, claimPath...), i)
-						attrs = append(attrs, clientmodels.Attribute{
-							ClaimPath:   elemPath,
-							DisplayName: childDisplayName(claimDisplayLookup, elemPath, attrDisplay),
-							Value:       clientmodels.NewAttributeValue(elem),
-						})
-					}
-				case map[string]any:
-					// Sort keys for deterministic order.
-					keys := make([]string, 0, len(v))
-					for key := range v {
-						keys = append(keys, key)
-					}
-					sort.Strings(keys)
-					for _, key := range keys {
-						elemPath := append(append([]any{}, claimPath...), key)
-						attrs = append(attrs, clientmodels.Attribute{
-							ClaimPath:   elemPath,
-							DisplayName: childDisplayName(claimDisplayLookup, elemPath, attrDisplay),
-							Value:       clientmodels.NewAttributeValue(v[key]),
-						})
-					}
-				default:
-					attrs = append(attrs, clientmodels.Attribute{
-						ClaimPath:   claimPath,
-						DisplayName: attrDisplay,
-						Value:       clientmodels.NewAttributeValue(claimValue),
-					})
-				}
+				attrs = flattenClaimValue(attrs, claimPath, claimValue, attrDisplay, claimDisplayLookup)
 			}
 		}
 
@@ -310,6 +278,43 @@ func (s *credentialService) VerifyAndStoreIssuedCredentials(
 	}
 
 	return s.credentialStore.StoreBatch(batch)
+}
+
+// flattenClaimValue recursively flattens arrays and objects into individual scalar
+// attributes. Each leaf value gets its own Attribute with the full path from root.
+func flattenClaimValue(
+	attrs []clientmodels.Attribute,
+	path []any,
+	value any,
+	display clientmodels.TranslatedString,
+	lookup map[string]clientmodels.TranslatedString,
+) []clientmodels.Attribute {
+	switch v := value.(type) {
+	case []any:
+		for i, elem := range v {
+			childPath := append(append([]any{}, path...), i)
+			childDisplay := childDisplayName(lookup, childPath, display)
+			attrs = flattenClaimValue(attrs, childPath, elem, childDisplay, lookup)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			childPath := append(append([]any{}, path...), key)
+			childDisplay := childDisplayName(lookup, childPath, display)
+			attrs = flattenClaimValue(attrs, childPath, v[key], childDisplay, lookup)
+		}
+	default:
+		attrs = append(attrs, clientmodels.Attribute{
+			ClaimPath:   path,
+			DisplayName: display,
+			Value:       clientmodels.NewAttributeValue(value),
+		})
+	}
+	return attrs
 }
 
 // childDisplayName looks up display names for a child path created during flattening.

--- a/eudi/services/credential_service.go
+++ b/eudi/services/credential_service.go
@@ -76,6 +76,26 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 				credentialDisplays[locale] = d.Name
 			}
 
+			// Build a display lookup from all metadata claims, keyed by serialized path.
+			// This allows child paths created during flattening to inherit display names
+			// from more specific metadata entries when available.
+			claimDisplayLookup := map[string]clientmodels.TranslatedString{}
+			for _, claim := range batch.CredentialMetadata.Claims {
+				var path []any
+				if err := json.Unmarshal(claim.Path, &path); err != nil {
+					continue
+				}
+				display := clientmodels.TranslatedString{}
+				for _, d := range claim.Display {
+					locale := clientmodels.DefaultFallbackLanguage
+					if d.Locale.Valid {
+						locale, _ = metadata.TryGetBaseLanguageFromLocale(d.Locale.V)
+					}
+					display[locale] = d.Name
+				}
+				claimDisplayLookup[clientmodels.ClaimPathKey(path)] = display
+			}
+
 			for _, claim := range batch.CredentialMetadata.Claims {
 				attrDisplay := clientmodels.TranslatedString{}
 				for _, d := range claim.Display {
@@ -105,12 +125,10 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 				switch v := claimValue.(type) {
 				case []any:
 					for i, elem := range v {
-						elemPath := make([]any, len(claimPath)+1)
-						copy(elemPath, claimPath)
-						elemPath[len(claimPath)] = i
+						elemPath := append(append([]any{}, claimPath...), i)
 						attrs = append(attrs, clientmodels.Attribute{
 							ClaimPath:   elemPath,
-							DisplayName: attrDisplay,
+							DisplayName: childDisplayName(claimDisplayLookup, elemPath, attrDisplay),
 							Value:       clientmodels.NewAttributeValue(elem),
 						})
 					}
@@ -122,12 +140,10 @@ func (s *credentialService) GetCredentialMetadataList() ([]*clientmodels.Credent
 					}
 					sort.Strings(keys)
 					for _, key := range keys {
-						elemPath := make([]any, len(claimPath)+1)
-						copy(elemPath, claimPath)
-						elemPath[len(claimPath)] = key
+						elemPath := append(append([]any{}, claimPath...), key)
 						attrs = append(attrs, clientmodels.Attribute{
 							ClaimPath:   elemPath,
-							DisplayName: attrDisplay,
+							DisplayName: childDisplayName(claimDisplayLookup, elemPath, attrDisplay),
 							Value:       clientmodels.NewAttributeValue(v[key]),
 						})
 					}
@@ -294,6 +310,16 @@ func (s *credentialService) VerifyAndStoreIssuedCredentials(
 	}
 
 	return s.credentialStore.StoreBatch(batch)
+}
+
+// childDisplayName looks up display names for a child path created during flattening.
+// It first checks whether the metadata contains a claim entry for the exact child path.
+// If not, it falls back to the parent's display names.
+func childDisplayName(lookup map[string]clientmodels.TranslatedString, childPath []any, parentDisplay clientmodels.TranslatedString) clientmodels.TranslatedString {
+	if d, ok := lookup[clientmodels.ClaimPathKey(childPath)]; ok && len(d) > 0 {
+		return d
+	}
+	return parentDisplay
 }
 
 // hashForSdJwtVc computes the deterministic hash used for batch deduplication.

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -402,19 +402,11 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 		require.Equal(t, "Demo MijnOverheid.nl", credential.Issuer.Name["en"])
 
 		requireAttrsInOrder(t, credential.Attributes,
-			expectedAttr{Path: []any{"firstnames"}, Value: "Barry"},
-			expectedAttr{Path: []any{"firstname"}, Value: "Bar"},
-			expectedAttr{Path: []any{"familyname"}, Value: "Batsbak"},
-			expectedAttr{Path: []any{"prefix"}, Value: "Sir"},
+			expectedAttr{Path: []any{"firstnames"}, DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"}, Value: "Barry"},
+			expectedAttr{Path: []any{"firstname"}, DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"}, Value: "Bar"},
+			expectedAttr{Path: []any{"familyname"}, DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"}, Value: "Batsbak"},
+			expectedAttr{Path: []any{"prefix"}, DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"}, Value: "Sir"},
 		)
-
-		require.Equal(t, "First names", credential.Attributes[0].DisplayName["en"])
-		require.NotNil(t, credential.Attributes[0].Description)
-		require.Equal(t, "All of your first names", (*credential.Attributes[0].Description)["en"])
-
-		require.Equal(t, "Family name", credential.Attributes[2].DisplayName["en"])
-		require.NotNil(t, credential.Attributes[2].Description)
-		require.Equal(t, "Your family name", (*credential.Attributes[2].Description)["en"])
 
 		c.Close()
 		keyshareServer.Stop()
@@ -579,11 +571,8 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
 	)
-	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
-	require.NotNil(t, cred.Attributes[0].Description)
-	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testIrmaDisclosureSessionLogs(t *testing.T) {
@@ -643,11 +632,8 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
 	)
-	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
-	require.NotNil(t, cred.Attributes[0].Description)
-	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
@@ -662,11 +648,8 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
 	)
-	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
-	require.NotNil(t, cred.Attributes[0].Description)
-	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testEudiSessionLogs(t *testing.T) {
@@ -722,11 +705,8 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
 	)
-	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
-	require.NotNil(t, cred.Attributes[0].Description)
-	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func requireRegularIrmaIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
@@ -753,11 +733,8 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
 	)
-	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
-	require.NotNil(t, cred.Attributes[0].Description)
-	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testDeletingCombinedCredentialDeletesBothFormats(t *testing.T) {

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -402,10 +402,10 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 		require.Equal(t, "Demo MijnOverheid.nl", credential.Issuer.Name["en"])
 
 		requireAttrsInOrder(t, credential.Attributes,
-			expectedAttr{Path: []any{"firstnames"}, DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"}, Value: "Barry"},
-			expectedAttr{Path: []any{"firstname"}, DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"}, Value: "Bar"},
-			expectedAttr{Path: []any{"familyname"}, DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"}, Value: "Batsbak"},
-			expectedAttr{Path: []any{"prefix"}, DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"}, Value: "Sir"},
+			expectedAttr{Path: []any{"firstnames"}, DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"}, Description: &clientmodels.TranslatedString{"en": "All of your first names", "nl": "Al uw voornamen"}, Value: "Barry"},
+			expectedAttr{Path: []any{"firstname"}, DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"}, Description: &clientmodels.TranslatedString{"en": "Your first name", "nl": "Uw voornaam"}, Value: "Bar"},
+			expectedAttr{Path: []any{"familyname"}, DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"}, Description: &clientmodels.TranslatedString{"en": "Your family name", "nl": "Uw achternaam"}, Value: "Batsbak"},
+			expectedAttr{Path: []any{"prefix"}, DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"}, Description: &clientmodels.TranslatedString{"en": "Family name prefix", "nl": "Tussenvoegsel van uw achternaam"}, Value: "Sir"},
 		)
 
 		c.Close()
@@ -560,7 +560,6 @@ func testDoubleSdJwtIssuanceFailsAfterRevocationListUpdate(t *testing.T) {
 	require.Equal(t, 10, int(*cred.BatchInstanceCountsRemaining[clientmodels.CredentialFormat(clientmodels.Format_SdJwtVc)]))
 }
 
-
 func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, log.Type, clientmodels.LogType_CredentialRemoval)
 	require.Len(t, log.RemovalLog.Credentials, 1)
@@ -571,7 +570,7 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
 	)
 }
 
@@ -632,7 +631,7 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
 	)
 }
 
@@ -648,7 +647,7 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
 	)
 }
 
@@ -705,7 +704,7 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
 	)
 }
 
@@ -733,7 +732,7 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
 	)
 }
 

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -969,7 +969,12 @@ func startCrossDeviceIrmaSessionAtServer(t *testing.T, server *IrmaServer, req i
 }
 
 func startSameDeviceIrmaSessionAtServer(t *testing.T, server *IrmaServer, req any) string {
-	qr, _, _, err := server.irma.StartSession(req, nil, "")
+	sessionJson, _ := startSameDeviceIrmaSessionAtServerWithToken(t, server, req)
+	return sessionJson
+}
+
+func startSameDeviceIrmaSessionAtServerWithToken(t *testing.T, server *IrmaServer, req any) (string, irma.RequestorToken) {
+	qr, token, _, err := server.irma.StartSession(req, nil, "")
 	require.NoError(t, err)
 	session := client.SessionRequestData{
 		Qr:                     *qr,
@@ -978,7 +983,7 @@ func startSameDeviceIrmaSessionAtServer(t *testing.T, server *IrmaServer, req an
 	}
 	sessionJson, err := json.Marshal(session)
 	require.NoError(t, err)
-	return string(sessionJson)
+	return string(sessionJson), token
 }
 
 func createIrmaIssuanceRequestWithSdJwts(credentialId string, attributeId string) *irma.IssuanceRequest {

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -402,10 +402,30 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 		require.Equal(t, "Demo MijnOverheid.nl", credential.Issuer.Name["en"])
 
 		requireAttrsInOrder(t, credential.Attributes,
-			expectedAttr{Path: []any{"firstnames"}, DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"}, Description: &clientmodels.TranslatedString{"en": "All of your first names", "nl": "Al uw voornamen"}, Value: "Barry"},
-			expectedAttr{Path: []any{"firstname"}, DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"}, Description: &clientmodels.TranslatedString{"en": "Your first name", "nl": "Uw voornaam"}, Value: "Bar"},
-			expectedAttr{Path: []any{"familyname"}, DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"}, Description: &clientmodels.TranslatedString{"en": "Your family name", "nl": "Uw achternaam"}, Value: "Batsbak"},
-			expectedAttr{Path: []any{"prefix"}, DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"}, Description: &clientmodels.TranslatedString{"en": "Family name prefix", "nl": "Tussenvoegsel van uw achternaam"}, Value: "Sir"},
+			expectedAttr{
+				Path:        []any{"firstnames"},
+				DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
+				Description: &clientmodels.TranslatedString{"en": "All of your first names", "nl": "Al uw voornamen"},
+				Value:       "Barry",
+			},
+			expectedAttr{
+				Path:        []any{"firstname"},
+				DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+				Description: &clientmodels.TranslatedString{"en": "Your first name", "nl": "Uw voornaam"},
+				Value:       "Bar",
+			},
+			expectedAttr{
+				Path:        []any{"familyname"},
+				DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+				Description: &clientmodels.TranslatedString{"en": "Your family name", "nl": "Uw achternaam"},
+				Value:       "Batsbak",
+			},
+			expectedAttr{
+				Path:        []any{"prefix"},
+				DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"},
+				Description: &clientmodels.TranslatedString{"en": "Family name prefix", "nl": "Tussenvoegsel van uw achternaam"},
+				Value:       "Sir",
+			},
 		)
 
 		c.Close()
@@ -570,7 +590,12 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
+			Value:       "test@gmail.com",
+		},
 	)
 }
 
@@ -631,7 +656,12 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
+			Value:       "test@gmail.com",
+		},
 	)
 }
 
@@ -647,7 +677,12 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
+			Value:       "test@gmail.com",
+		},
 	)
 }
 
@@ -704,7 +739,12 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
+			Value:       "test@gmail.com",
+		},
 	)
 }
 
@@ -732,7 +772,12 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"}, Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"}, Value: "test@gmail.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
+			Value:       "test@gmail.com",
+		},
 	)
 }
 

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -401,24 +401,20 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 		require.Equal(t, "Demo Name", credential.Name["en"])
 		require.Equal(t, "Demo MijnOverheid.nl", credential.Issuer.Name["en"])
 
-		require.Equal(t, "Barry", getLogAttrValue(credential.Attributes, "firstnames"))
-		require.Equal(t, "Bar", getLogAttrValue(credential.Attributes, "firstname"))
-		require.Equal(t, "Batsbak", getLogAttrValue(credential.Attributes, "familyname"))
-		require.Equal(t, "Sir", getLogAttrValue(credential.Attributes, "prefix"))
+		requireAttrsInOrder(t, credential.Attributes,
+			attr([]any{"firstnames"}, "Barry"),
+			attr([]any{"firstname"}, "Bar"),
+			attr([]any{"familyname"}, "Batsbak"),
+			attr([]any{"prefix"}, "Sir"),
+		)
 
-		firstnamesAttr := getLogAttr(credential.Attributes, "firstnames")
-		require.NotNil(t, firstnamesAttr)
-		require.NotNil(t, firstnamesAttr.Description)
-		firstNameDescription := *firstnamesAttr.Description
-		require.Equal(t, "First names", firstnamesAttr.DisplayName["en"])
-		require.Equal(t, "All of your first names", firstNameDescription["en"])
+		require.Equal(t, "First names", credential.Attributes[0].DisplayName["en"])
+		require.NotNil(t, credential.Attributes[0].Description)
+		require.Equal(t, "All of your first names", (*credential.Attributes[0].Description)["en"])
 
-		familynameAttr := getLogAttr(credential.Attributes, "familyname")
-		require.NotNil(t, familynameAttr)
-		require.NotNil(t, familynameAttr.Description)
-		familyNameDescription := *familynameAttr.Description
-		require.Equal(t, "Family name", familynameAttr.DisplayName["en"])
-		require.Equal(t, "Your family name", familyNameDescription["en"])
+		require.Equal(t, "Family name", credential.Attributes[2].DisplayName["en"])
+		require.NotNil(t, credential.Attributes[2].Description)
+		require.Equal(t, "Your family name", (*credential.Attributes[2].Description)["en"])
 
 		c.Close()
 		keyshareServer.Stop()
@@ -572,25 +568,6 @@ func testDoubleSdJwtIssuanceFailsAfterRevocationListUpdate(t *testing.T) {
 	require.Equal(t, 10, int(*cred.BatchInstanceCountsRemaining[clientmodels.CredentialFormat(clientmodels.Format_SdJwtVc)]))
 }
 
-// getLogAttrValue finds an attribute by ID and returns its string value.
-func getLogAttrValue(attrs []clientmodels.Attribute, id string) string {
-	for _, a := range attrs {
-		if a.Id == id && a.Value != nil && a.Value.String != nil {
-			return *a.Value.String
-		}
-	}
-	return ""
-}
-
-// getLogAttr finds an attribute by ID and returns it, or nil if not found.
-func getLogAttr(attrs []clientmodels.Attribute, id string) *clientmodels.Attribute {
-	for i := range attrs {
-		if attrs[i].Id == id {
-			return &attrs[i]
-		}
-	}
-	return nil
-}
 
 func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, log.Type, clientmodels.LogType_CredentialRemoval)
@@ -601,13 +578,12 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 	require.Equal(t, "Demo Email address", cred.Name["en"])
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
-	emailAttr := getLogAttr(cred.Attributes, "email")
-	require.NotNil(t, emailAttr)
-	require.NotNil(t, emailAttr.Description)
-	emailDescription := *emailAttr.Description
-	require.Equal(t, "test@gmail.com", getLogAttrValue(cred.Attributes, "email"))
-	require.Equal(t, "Email address", emailAttr.DisplayName["en"])
-	require.Equal(t, "Your verified email address", emailDescription["en"])
+	requireAttrsInOrder(t, cred.Attributes,
+		attr([]any{"email"}, "test@gmail.com"),
+	)
+	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
+	require.NotNil(t, cred.Attributes[0].Description)
+	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testIrmaDisclosureSessionLogs(t *testing.T) {
@@ -666,13 +642,12 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo Email address", cred.Name["en"])
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
-	emailAttr := getLogAttr(cred.Attributes, "email")
-	require.NotNil(t, emailAttr)
-	require.NotNil(t, emailAttr.Description)
-	emailDescription := *emailAttr.Description
-	require.Equal(t, "test@gmail.com", getLogAttrValue(cred.Attributes, "email"))
-	require.Equal(t, "Email address", emailAttr.DisplayName["en"])
-	require.Equal(t, "Your verified email address", emailDescription["en"])
+	requireAttrsInOrder(t, cred.Attributes,
+		attr([]any{"email"}, "test@gmail.com"),
+	)
+	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
+	require.NotNil(t, cred.Attributes[0].Description)
+	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
@@ -686,13 +661,12 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo Email address", cred.Name["en"])
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
-	emailAttr := getLogAttr(cred.Attributes, "email")
-	require.NotNil(t, emailAttr)
-	require.NotNil(t, emailAttr.Description)
-	emailDescription := *emailAttr.Description
-	require.Equal(t, "test@gmail.com", getLogAttrValue(cred.Attributes, "email"))
-	require.Equal(t, "Email address", emailAttr.DisplayName["en"])
-	require.Equal(t, "Your verified email address", emailDescription["en"])
+	requireAttrsInOrder(t, cred.Attributes,
+		attr([]any{"email"}, "test@gmail.com"),
+	)
+	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
+	require.NotNil(t, cred.Attributes[0].Description)
+	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testEudiSessionLogs(t *testing.T) {
@@ -747,17 +721,12 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo Email address", cred.Name["en"])
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
-	emailAttr := getLogAttr(cred.Attributes, "email")
-	require.NotNil(t, emailAttr)
-	require.NotNil(t, emailAttr.Description)
-	emailDescription := *emailAttr.Description
-	require.Equal(t, "test@gmail.com", getLogAttrValue(cred.Attributes, "email"))
-	require.Equal(t, "Email address", emailAttr.DisplayName["en"])
-	require.Equal(t, "Your verified email address", emailDescription["en"])
-
-	// Verify that attribute value is present for OpenID4VP disclosures
-	require.NotNil(t, emailAttr.Value.String)
-	require.Equal(t, "test@gmail.com", *emailAttr.Value.String, "attribute value should match")
+	requireAttrsInOrder(t, cred.Attributes,
+		attr([]any{"email"}, "test@gmail.com"),
+	)
+	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
+	require.NotNil(t, cred.Attributes[0].Description)
+	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func requireRegularIrmaIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
@@ -783,13 +752,12 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo Email address", cred.Name["en"])
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
-	emailAttr := getLogAttr(cred.Attributes, "email")
-	require.NotNil(t, emailAttr)
-	require.NotNil(t, emailAttr.Description)
-	emailDescription := *emailAttr.Description
-	require.Equal(t, "test@gmail.com", getLogAttrValue(cred.Attributes, "email"))
-	require.Equal(t, "Email address", emailAttr.DisplayName["en"])
-	require.Equal(t, "Your verified email address", emailDescription["en"])
+	requireAttrsInOrder(t, cred.Attributes,
+		attr([]any{"email"}, "test@gmail.com"),
+	)
+	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
+	require.NotNil(t, cred.Attributes[0].Description)
+	require.Equal(t, "Your verified email address", (*cred.Attributes[0].Description)["en"])
 }
 
 func testDeletingCombinedCredentialDeletesBothFormats(t *testing.T) {
@@ -897,7 +865,7 @@ func discloseOverOpenID4VP(t *testing.T, c *client.Client, sessionHandler *MockS
 	require.Equal(t, clientmodels.Status_RequestPermission, sessionState.Status)
 
 	emailCred := sessionState.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, sessionState.Id, makeDisclosureChoice(emailCred, "email"))
+	grantPermission(t, c, sessionState.Id, makeDisclosureChoice(emailCred))
 
 	sessionState = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Status_Success, sessionState.Status)
@@ -939,7 +907,7 @@ func performIrmaDisclosureSession(t *testing.T, c *client.Client, sessionHandler
 	require.Equal(t, clientmodels.Status_RequestPermission, session.Status)
 
 	emailCred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred, "email"))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Status_Success, session.Status)
@@ -960,7 +928,7 @@ func performIrmaSignatureSession(t *testing.T, c *client.Client, sessionHandler 
 	require.Equal(t, clientmodels.Status_RequestPermission, session.Status)
 
 	emailCred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred, "email"))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Status_Success, session.Status)
@@ -1229,7 +1197,7 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		}
 		hasPrefix := false
 		for _, attr := range cred.Attributes {
-			if attr.Id == "prefix" {
+			if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("prefix") {
 				hasPrefix = true
 				break
 			}
@@ -1245,18 +1213,18 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 	require.NotNil(t, credWithoutPrefix)
 	attrIds := make([]string, len(credWithoutPrefix.Attributes))
 	for i, attr := range credWithoutPrefix.Attributes {
-		attrIds[i] = attr.Id
+		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
 	}
-	require.Equal(t, []string{"firstnames", "firstname", "familyname"}, attrIds,
+	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname")}, attrIds,
 		"empty optional attribute 'prefix' should not be included")
 
 	// Credential with prefix: optional non-empty attribute should be included
 	require.NotNil(t, credWithPrefix)
 	attrIds = make([]string, len(credWithPrefix.Attributes))
 	for i, attr := range credWithPrefix.Attributes {
-		attrIds[i] = attr.Id
+		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
 	}
-	require.Equal(t, []string{"firstnames", "firstname", "familyname", "prefix"}, attrIds,
+	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname"), pk("prefix")}, attrIds,
 		"non-empty optional attribute 'prefix' should be included")
 	require.Equal(t, "Sir", *credWithPrefix.Attributes[3].Value.String)
 
@@ -1287,7 +1255,7 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 			continue
 		}
 		for _, attr := range cred.Attributes {
-			if attr.Id == "firstname" && attr.Value != nil &&
+			if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("firstname") && attr.Value != nil &&
 				attr.Value.String != nil && *attr.Value.String == "" {
 				credEmptyFirstname = cred
 				break
@@ -1298,8 +1266,8 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 	require.NotNil(t, credEmptyFirstname, "credential with empty firstname should exist")
 	attrIds = make([]string, len(credEmptyFirstname.Attributes))
 	for i, attr := range credEmptyFirstname.Attributes {
-		attrIds[i] = attr.Id
+		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
 	}
-	require.Equal(t, []string{"firstnames", "firstname", "familyname"}, attrIds,
+	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname")}, attrIds,
 		"empty non-optional attribute 'firstname' should still be included")
 }

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -1216,13 +1216,7 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		if cred.CredentialId != "irma-demo.MijnOverheid.fullName" {
 			continue
 		}
-		hasPrefix := false
-		for _, attr := range cred.Attributes {
-			if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("prefix") {
-				hasPrefix = true
-				break
-			}
-		}
+		_, hasPrefix := attributeMap(cred.Attributes)[pk("prefix")]
 		if hasPrefix {
 			credWithPrefix = cred
 		} else {
@@ -1232,22 +1226,48 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 
 	// Credential without prefix: optional empty attribute should be excluded
 	require.NotNil(t, credWithoutPrefix)
-	attrIds := make([]string, len(credWithoutPrefix.Attributes))
-	for i, attr := range credWithoutPrefix.Attributes {
-		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
-	}
-	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname")}, attrIds,
-		"empty optional attribute 'prefix' should not be included")
+	requireAttrsInOrder(t, credWithoutPrefix.Attributes,
+		expectedAttr{
+			Path:        []any{"firstnames"},
+			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
+			Value:       "Barry",
+		},
+		expectedAttr{
+			Path:        []any{"firstname"},
+			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			Value:       "Bar",
+		},
+		expectedAttr{
+			Path:        []any{"familyname"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			Value:       "Batsbak",
+		},
+	)
 
 	// Credential with prefix: optional non-empty attribute should be included
 	require.NotNil(t, credWithPrefix)
-	attrIds = make([]string, len(credWithPrefix.Attributes))
-	for i, attr := range credWithPrefix.Attributes {
-		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
-	}
-	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname"), pk("prefix")}, attrIds,
-		"non-empty optional attribute 'prefix' should be included")
-	require.Equal(t, "Sir", *credWithPrefix.Attributes[3].Value.String)
+	requireAttrsInOrder(t, credWithPrefix.Attributes,
+		expectedAttr{
+			Path:        []any{"firstnames"},
+			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
+			Value:       "Barry",
+		},
+		expectedAttr{
+			Path:        []any{"firstname"},
+			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			Value:       "Bar",
+		},
+		expectedAttr{
+			Path:        []any{"familyname"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			Value:       "Batsbak",
+		},
+		expectedAttr{
+			Path:        []any{"prefix"},
+			DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"},
+			Value:       "Sir",
+		},
+	)
 
 	// Issue a credential with an empty non-optional attribute ("firstname" = "")
 	// Non-optional attributes should always be included, even when empty.
@@ -1275,20 +1295,29 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		if cred.CredentialId != "irma-demo.MijnOverheid.fullName" {
 			continue
 		}
-		for _, attr := range cred.Attributes {
-			if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("firstname") && attr.Value != nil &&
-				attr.Value.String != nil && *attr.Value.String == "" {
-				credEmptyFirstname = cred
-				break
-			}
+		am := attributeMap(cred.Attributes)
+		if attr, ok := am[pk("firstname")]; ok && attr.Value != nil &&
+			attr.Value.String != nil && *attr.Value.String == "" {
+			credEmptyFirstname = cred
 		}
 	}
 
 	require.NotNil(t, credEmptyFirstname, "credential with empty firstname should exist")
-	attrIds = make([]string, len(credEmptyFirstname.Attributes))
-	for i, attr := range credEmptyFirstname.Attributes {
-		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
-	}
-	require.Equal(t, []string{pk("firstnames"), pk("firstname"), pk("familyname")}, attrIds,
-		"empty non-optional attribute 'firstname' should still be included")
+	requireAttrsInOrder(t, credEmptyFirstname.Attributes,
+		expectedAttr{
+			Path:        []any{"firstnames"},
+			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
+			Value:       "Barry",
+		},
+		expectedAttr{
+			Path:        []any{"firstname"},
+			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			Value:       "",
+		},
+		expectedAttr{
+			Path:        []any{"familyname"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			Value:       "Batsbak",
+		},
+	)
 }

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -406,25 +406,25 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 				Path:        []any{"firstnames"},
 				DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
 				Description: &clientmodels.TranslatedString{"en": "All of your first names", "nl": "Al uw voornamen"},
-				Value:       "Barry",
+				Value:       strVal("Barry"),
 			},
 			expectedAttr{
 				Path:        []any{"firstname"},
 				DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
 				Description: &clientmodels.TranslatedString{"en": "Your first name", "nl": "Uw voornaam"},
-				Value:       "Bar",
+				Value:       strVal("Bar"),
 			},
 			expectedAttr{
 				Path:        []any{"familyname"},
 				DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
 				Description: &clientmodels.TranslatedString{"en": "Your family name", "nl": "Uw achternaam"},
-				Value:       "Batsbak",
+				Value:       strVal("Batsbak"),
 			},
 			expectedAttr{
 				Path:        []any{"prefix"},
 				DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"},
 				Description: &clientmodels.TranslatedString{"en": "Family name prefix", "nl": "Tussenvoegsel van uw achternaam"},
-				Value:       "Sir",
+				Value:       strVal("Sir"),
 			},
 		)
 
@@ -594,7 +594,7 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
-			Value:       "test@gmail.com",
+			Value:       strVal("test@gmail.com"),
 		},
 	)
 }
@@ -660,7 +660,7 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
-			Value:       "test@gmail.com",
+			Value:       strVal("test@gmail.com"),
 		},
 	)
 }
@@ -681,7 +681,7 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
-			Value:       "test@gmail.com",
+			Value:       strVal("test@gmail.com"),
 		},
 	)
 }
@@ -743,7 +743,7 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
-			Value:       "test@gmail.com",
+			Value:       strVal("test@gmail.com"),
 		},
 	)
 }
@@ -776,7 +776,7 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
-			Value:       "test@gmail.com",
+			Value:       strVal("test@gmail.com"),
 		},
 	)
 }
@@ -1235,17 +1235,17 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"firstnames"},
 			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
-			Value:       "Barry",
+			Value:       strVal("Barry"),
 		},
 		expectedAttr{
 			Path:        []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
-			Value:       "Bar",
+			Value:       strVal("Bar"),
 		},
 		expectedAttr{
 			Path:        []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
-			Value:       "Batsbak",
+			Value:       strVal("Batsbak"),
 		},
 	)
 
@@ -1255,22 +1255,22 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"firstnames"},
 			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
-			Value:       "Barry",
+			Value:       strVal("Barry"),
 		},
 		expectedAttr{
 			Path:        []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
-			Value:       "Bar",
+			Value:       strVal("Bar"),
 		},
 		expectedAttr{
 			Path:        []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
-			Value:       "Batsbak",
+			Value:       strVal("Batsbak"),
 		},
 		expectedAttr{
 			Path:        []any{"prefix"},
 			DisplayName: clientmodels.TranslatedString{"en": "Prefix", "nl": "Tussenvoegsel"},
-			Value:       "Sir",
+			Value:       strVal("Sir"),
 		},
 	)
 
@@ -1312,17 +1312,17 @@ func testOptionalEmptyAttributesExcludedFromGetCredentials(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"firstnames"},
 			DisplayName: clientmodels.TranslatedString{"en": "First names", "nl": "Voornamen"},
-			Value:       "Barry",
+			Value:       strVal("Barry"),
 		},
 		expectedAttr{
 			Path:        []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
-			Value:       "",
+			Value:       strVal(""),
 		},
 		expectedAttr{
 			Path:        []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
-			Value:       "Batsbak",
+			Value:       strVal("Batsbak"),
 		},
 	)
 }

--- a/internal/sessiontest/client_integration_test.go
+++ b/internal/sessiontest/client_integration_test.go
@@ -402,10 +402,10 @@ func testIdemixOnlyCredentialRemovalLog(t *testing.T) {
 		require.Equal(t, "Demo MijnOverheid.nl", credential.Issuer.Name["en"])
 
 		requireAttrsInOrder(t, credential.Attributes,
-			attr([]any{"firstnames"}, "Barry"),
-			attr([]any{"firstname"}, "Bar"),
-			attr([]any{"familyname"}, "Batsbak"),
-			attr([]any{"prefix"}, "Sir"),
+			expectedAttr{Path: []any{"firstnames"}, Value: "Barry"},
+			expectedAttr{Path: []any{"firstname"}, Value: "Bar"},
+			expectedAttr{Path: []any{"familyname"}, Value: "Batsbak"},
+			expectedAttr{Path: []any{"prefix"}, Value: "Sir"},
 		)
 
 		require.Equal(t, "First names", credential.Attributes[0].DisplayName["en"])
@@ -579,7 +579,7 @@ func requireIdemixOnlyCredentialRemovalLog(t *testing.T, log clientmodels.LogInf
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		attr([]any{"email"}, "test@gmail.com"),
+		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
 	)
 	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
 	require.NotNil(t, cred.Attributes[0].Description)
@@ -643,7 +643,7 @@ func requireIrmaDisclosureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		attr([]any{"email"}, "test@gmail.com"),
+		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
 	)
 	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
 	require.NotNil(t, cred.Attributes[0].Description)
@@ -662,7 +662,7 @@ func requireSignatureLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		attr([]any{"email"}, "test@gmail.com"),
+		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
 	)
 	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
 	require.NotNil(t, cred.Attributes[0].Description)
@@ -722,7 +722,7 @@ func requireOpenID4VPLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		attr([]any{"email"}, "test@gmail.com"),
+		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
 	)
 	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
 	require.NotNil(t, cred.Attributes[0].Description)
@@ -753,7 +753,7 @@ func requireIrmaSdJwtIssuanceLog(t *testing.T, log clientmodels.LogInfo) {
 	require.Equal(t, "Demo test issuer", cred.Issuer.Name["en"])
 
 	requireAttrsInOrder(t, cred.Attributes,
-		attr([]any{"email"}, "test@gmail.com"),
+		expectedAttr{Path: []any{"email"}, Value: "test@gmail.com"},
 	)
 	require.Equal(t, "Email address", cred.Attributes[0].DisplayName["en"])
 	require.NotNil(t, cred.Attributes[0].Description)

--- a/internal/sessiontest/irma_disclosure_test.go
+++ b/internal/sessiontest/irma_disclosure_test.go
@@ -113,7 +113,8 @@ func testDisclosureWithPredefinedValues(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
@@ -220,6 +221,13 @@ func testDisclosureWithPredefinedValues(
 	// make sure the disclosure session is finished
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.RU.studentCard.studentID", Value: "67890"},
+			{Identifier: "irma-demo.RU.studentCard.university", Value: "Universiteit Utrecht"},
+		},
+	})
 }
 
 func testDisclosureWithOptionalAttributesFromSameCredential_CredentialNotPresent(
@@ -340,7 +348,8 @@ func testSingleCredentialDisclosureWithOptionalCredential_ShouldMoveToDisclosure
 		mijnOverheidDisclosure()[0],
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	require.Equal(t, 1, session.Id)
@@ -384,6 +393,14 @@ func testSingleCredentialDisclosureWithOptionalCredential_ShouldMoveToDisclosure
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{}, // optional disjunction, nothing disclosed
+		{
+			{Identifier: "irma-demo.MijnOverheid.fullName.firstnames", Value: "Barry"},
+			{Identifier: "irma-demo.MijnOverheid.fullName.familyname", Value: "Batsbak"},
+		},
+	})
 }
 
 func testMultipleStepsOfIssuanceDuringDisclosure(
@@ -400,7 +417,8 @@ func testMultipleStepsOfIssuanceDuringDisclosure(
 		studentCardOrMijnOverheidDisclosure()[0],
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -459,6 +477,16 @@ func testMultipleStepsOfIssuanceDuringDisclosure(
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "test.test.email.email", Value: "test@gmail.com"},
+		},
+		{
+			{Identifier: "irma-demo.MijnOverheid.fullName.firstnames", Value: "Barry"},
+			{Identifier: "irma-demo.MijnOverheid.fullName.familyname", Value: "Batsbak"},
+		},
+	})
 }
 
 func testWrongCredentialIssuedDuringDisclosure(
@@ -482,7 +510,8 @@ func testWrongCredentialIssuedDuringDisclosure(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
@@ -607,6 +636,13 @@ func testWrongCredentialIssuedDuringDisclosure(
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.RU.studentCard.university", Value: "Radboud University"},
+			{Identifier: "irma-demo.RU.studentCard.level", Value: "high"},
+		},
+	})
 }
 
 func testPreExistingWrongCredentialNotReported(
@@ -648,7 +684,8 @@ func testPreExistingWrongCredentialNotReported(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
@@ -731,6 +768,13 @@ func testPreExistingWrongCredentialNotReported(
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.RU.studentCard.university", Value: "Radboud University"},
+			{Identifier: "irma-demo.RU.studentCard.level", Value: "high"},
+		},
+	})
 }
 
 func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
@@ -755,7 +799,8 @@ func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -808,6 +853,13 @@ func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.RU.studentCard.university", Value: "University of the Arts"},
+			{Identifier: "irma-demo.RU.studentCard.level", Value: "high"},
+		},
+	})
 }
 
 func testChoiceBetweenEmailAndStudentCardBothPresent(
@@ -829,7 +881,8 @@ func testChoiceBetweenEmailAndStudentCardBothPresent(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -885,6 +938,12 @@ func testChoiceBetweenEmailAndStudentCardBothPresent(
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "test.test.email.email", Value: "test@gmail.com"},
+		},
+	})
 }
 
 func testChoiceBetweenSingletonAndNonSingletonCredentialsNonePresent(
@@ -1123,7 +1182,8 @@ func testSingleCredentialDisclosureWithAvailableCredential(
 	}
 
 	c.DeleteKeyshareTokens()
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, disclosureRequest))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, disclosureRequest)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -1153,6 +1213,12 @@ func testSingleCredentialDisclosureWithAvailableCredential(
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "test.test.email.email", Value: "test@gmail.com"},
+		},
+	})
 }
 
 func testDisclosureClientReturnUrl(

--- a/internal/sessiontest/irma_disclosure_test.go
+++ b/internal/sessiontest/irma_disclosure_test.go
@@ -173,7 +173,7 @@ func testDisclosureWithPredefinedValues(
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "University of the Arts",
+			Value:       strVal("University of the Arts"),
 		},
 	)
 	require.Equal(t, &expectedValue, wrongCred.Attributes[0].RequestedValue.String)
@@ -551,7 +551,7 @@ func testWrongCredentialIssuedDuringDisclosure(
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "University of the Arts",
+			Value:       strVal("University of the Arts"),
 		},
 	)
 	expectedRequiredValue := requiredValue
@@ -591,7 +591,7 @@ func testWrongCredentialIssuedDuringDisclosure(
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "Open University",
+			Value:       strVal("Open University"),
 		},
 	)
 
@@ -726,7 +726,7 @@ func testPreExistingWrongCredentialNotReported(
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "Open University",
+			Value:       strVal("Open University"),
 		},
 	)
 

--- a/internal/sessiontest/irma_disclosure_test.go
+++ b/internal/sessiontest/irma_disclosure_test.go
@@ -168,9 +168,9 @@ func testDisclosureWithPredefinedValues(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not studentID
-	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
-	require.Equal(t, "University of the Arts", *wrongCred.Attributes[0].Value.String)
+	requireAttrsInOrder(t, wrongCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "University of the Arts"},
+	)
 	require.Equal(t, &expectedValue, wrongCred.Attributes[0].RequestedValue.String)
 
 	// make sure the previous issuance session was finished
@@ -514,9 +514,9 @@ func testWrongCredentialIssuedDuringDisclosure(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
-	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
-	require.Equal(t, "University of the Arts", *wrongCred.Attributes[0].Value.String)
+	requireAttrsInOrder(t, wrongCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "University of the Arts"},
+	)
 	expectedRequiredValue := requiredValue
 	require.Equal(t, &expectedRequiredValue, wrongCred.Attributes[0].RequestedValue.String)
 
@@ -550,9 +550,9 @@ func testWrongCredentialIssuedDuringDisclosure(
 	wrongCred = plan.IssueDuringDislosure.WrongCredentialIssued
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
-	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
-	require.Equal(t, "Open University", *wrongCred.Attributes[0].Value.String)
+	requireAttrsInOrder(t, wrongCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Open University"},
+	)
 
 	// Finish the second wrong issuance session
 	session = awaitSessionState(t, sessionHandler)
@@ -673,9 +673,9 @@ func testPreExistingWrongCredentialNotReported(
 	wrongCred := plan.IssueDuringDislosure.WrongCredentialIssued
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
-	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
-	require.Equal(t, "Open University", *wrongCred.Attributes[0].Value.String)
+	requireAttrsInOrder(t, wrongCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Open University"},
+	)
 
 	// Finish the wrong issuance session
 	session = awaitSessionState(t, sessionHandler)

--- a/internal/sessiontest/irma_disclosure_test.go
+++ b/internal/sessiontest/irma_disclosure_test.go
@@ -169,7 +169,11 @@ func testDisclosureWithPredefinedValues(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not studentID
 	requireAttrsInOrder(t, wrongCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "University of the Arts"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "University of the Arts",
+		},
 	)
 	require.Equal(t, &expectedValue, wrongCred.Attributes[0].RequestedValue.String)
 
@@ -515,7 +519,11 @@ func testWrongCredentialIssuedDuringDisclosure(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
 	requireAttrsInOrder(t, wrongCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "University of the Arts"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "University of the Arts",
+		},
 	)
 	expectedRequiredValue := requiredValue
 	require.Equal(t, &expectedRequiredValue, wrongCred.Attributes[0].RequestedValue.String)
@@ -551,7 +559,11 @@ func testWrongCredentialIssuedDuringDisclosure(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	requireAttrsInOrder(t, wrongCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Open University"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "Open University",
+		},
 	)
 
 	// Finish the second wrong issuance session
@@ -674,7 +686,11 @@ func testPreExistingWrongCredentialNotReported(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	requireAttrsInOrder(t, wrongCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Open University"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "Open University",
+		},
 	)
 
 	// Finish the wrong issuance session

--- a/internal/sessiontest/irma_disclosure_test.go
+++ b/internal/sessiontest/irma_disclosure_test.go
@@ -129,7 +129,7 @@ func testDisclosureWithPredefinedValues(
 
 	require.Equal(t, step1.Options[0].Attributes, []clientmodels.Attribute{
 		{
-			Id: "studentID",
+			ClaimPath: []any{"studentID"},
 			DisplayName: clientmodels.TranslatedString{
 				"nl": "Studentnummer",
 				"en": "Student number",
@@ -139,7 +139,7 @@ func testDisclosureWithPredefinedValues(
 			},
 		},
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"nl": "Universiteit",
 				"en": "University",
@@ -169,7 +169,7 @@ func testDisclosureWithPredefinedValues(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not studentID
 	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, "university", wrongCred.Attributes[0].Id)
+	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
 	require.Equal(t, "University of the Arts", *wrongCred.Attributes[0].Value.String)
 	require.Equal(t, &expectedValue, wrongCred.Attributes[0].RequestedValue.String)
 
@@ -207,7 +207,7 @@ func testDisclosureWithPredefinedValues(
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1})
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 1, makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id))
+	grantPermission(t, c, 1, makeDisclosureChoice(choice))
 
 	// make sure the previous issuance session is finished
 	session = awaitSessionState(t, sessionHandler)
@@ -375,7 +375,7 @@ func testSingleCredentialDisclosureWithOptionalCredential_ShouldMoveToDisclosure
 	choice := required.OwnedOptions[0]
 	grantPermission(t, c, 1,
 		clientmodels.DisclosureDisconSelection{}, // empty for optional
-		makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id),
+		makeDisclosureChoice(choice),
 	)
 
 	session = awaitSessionState(t, sessionHandler)
@@ -449,8 +449,8 @@ func testMultipleStepsOfIssuanceDuringDisclosure(
 	overheid := plan.DisclosureChoicesOverview[1].OwnedOptions[0]
 
 	grantPermission(t, c, 1,
-		makeDisclosureChoice(email, email.Attributes[0].Id),
-		makeDisclosureChoice(overheid, overheid.Attributes[0].Id, overheid.Attributes[1].Id),
+		makeDisclosureChoice(email),
+		makeDisclosureChoice(overheid),
 	)
 
 	session = awaitSessionState(t, sessionHandler)
@@ -515,7 +515,7 @@ func testWrongCredentialIssuedDuringDisclosure(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
 	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, "university", wrongCred.Attributes[0].Id)
+	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
 	require.Equal(t, "University of the Arts", *wrongCred.Attributes[0].Value.String)
 	expectedRequiredValue := requiredValue
 	require.Equal(t, &expectedRequiredValue, wrongCred.Attributes[0].RequestedValue.String)
@@ -551,7 +551,7 @@ func testWrongCredentialIssuedDuringDisclosure(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, "university", wrongCred.Attributes[0].Id)
+	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
 	require.Equal(t, "Open University", *wrongCred.Attributes[0].Value.String)
 
 	// Finish the second wrong issuance session
@@ -591,7 +591,7 @@ func testWrongCredentialIssuedDuringDisclosure(
 
 	// Grant permission and complete
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 1, makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id))
+	grantPermission(t, c, 1, makeDisclosureChoice(choice))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -674,7 +674,7 @@ func testPreExistingWrongCredentialNotReported(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, "university", wrongCred.Attributes[0].Id)
+	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
 	require.Equal(t, "Open University", *wrongCred.Attributes[0].Value.String)
 
 	// Finish the wrong issuance session
@@ -711,7 +711,7 @@ func testPreExistingWrongCredentialNotReported(
 	requireSessionState(t, session, 4, clientmodels.Type_Issuance, clientmodels.Status_Success)
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 2, makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id))
+	grantPermission(t, c, 2, makeDisclosureChoice(choice))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -766,7 +766,7 @@ func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
 	require.Equal(t,
 		[]clientmodels.Attribute{
 			{
-				Id:          "university",
+				ClaimPath:   []any{"university"},
 				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
 				Description: &clientmodels.TranslatedString{"en": "The name of the university", "nl": "Naam van de universiteit"},
 				Value: &clientmodels.AttributeValue{
@@ -775,7 +775,7 @@ func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
 				},
 			},
 			{
-				Id:          "level",
+				ClaimPath:   []any{"level"},
 				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
 				Description: &clientmodels.TranslatedString{"en": "Whether you are a regular or PhD student", "nl": "Of u een gewone of PhD student bent"},
 				Value: &clientmodels.AttributeValue{
@@ -787,7 +787,7 @@ func testChoiceBetweenTwoNonSingletonCredentialsBothPresent(
 		studentCard.Attributes,
 	)
 
-	grantPermission(t, c, session.Id, makeDisclosureChoice(studentCard, "university", "level"))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(studentCard))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -835,7 +835,7 @@ func testChoiceBetweenEmailAndStudentCardBothPresent(
 	require.Equal(t, "test.test.email", emailOption.CredentialId)
 	require.Equal(t, []clientmodels.Attribute{
 		{
-			Id:          "email",
+			ClaimPath:   []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
 			Description: &clientmodels.TranslatedString{"en": "Your verified email address", "nl": "Uw geverifiëerde e-mailadres"},
 			Value: &clientmodels.AttributeValue{
@@ -854,7 +854,7 @@ func testChoiceBetweenEmailAndStudentCardBothPresent(
 	require.Equal(t, "irma-demo.RU.studentCard", studentCardOption.CredentialId)
 	require.Equal(t, []clientmodels.Attribute{
 		{
-			Id:          "university",
+			ClaimPath:   []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
 			Description: &clientmodels.TranslatedString{"en": "The name of the university", "nl": "Naam van de universiteit"},
 			Value: &clientmodels.AttributeValue{
@@ -864,7 +864,7 @@ func testChoiceBetweenEmailAndStudentCardBothPresent(
 		},
 	}, studentCardOption.Attributes)
 
-	grantPermission(t, c, session.Id, makeDisclosureChoice(emailOption, "email"))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(emailOption))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)
@@ -960,14 +960,14 @@ func testSingleCredentialDisclosureWithUnavailableSingletonCredential_RefreshAft
 
 	require.Equal(t, toIssue.Attributes, []clientmodels.Attribute{
 		{
-			Id:          "firstname",
+			ClaimPath:   []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{"nl": "Voornaam", "en": "First name"},
 			RequestedValue: &clientmodels.AttributeValue{
 				Type: clientmodels.AttributeType_String,
 			},
 		},
 		{
-			Id:          "familyname",
+			ClaimPath:   []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{"nl": "Achternaam", "en": "Family name"},
 			RequestedValue: &clientmodels.AttributeValue{
 				Type: clientmodels.AttributeType_String,
@@ -1121,7 +1121,7 @@ func testSingleCredentialDisclosureWithAvailableCredential(
 	require.Len(t, plan.DisclosureChoicesOverview[0].ObtainableOptions, 1)
 
 	emailCred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred, "email"))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Protocol_Irma, session.Protocol)

--- a/internal/sessiontest/irma_issuance_test.go
+++ b/internal/sessiontest/irma_issuance_test.go
@@ -289,7 +289,7 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	requireAttrsInOrder(t, offered.Attributes, expectedAttr{
 		Path:        []any{"election"},
 		DisplayName: clientmodels.TranslatedString{"en": "Election", "nl": "Verkiezing"},
-		Value:       "plantsoen",
+		Value:       strVal("plantsoen"),
 	})
 
 	// Accept the issuance
@@ -341,7 +341,7 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	requireAttrsInOrder(t, owned.Attributes, expectedAttr{
 		Path:        []any{"election"},
 		DisplayName: clientmodels.TranslatedString{"en": "Election", "nl": "Verkiezing"},
-		Value:       "plantsoen",
+		Value:       strVal("plantsoen"),
 	})
 
 	// Now request the votingnumber attribute directly — it should be disclosable
@@ -472,22 +472,22 @@ func testAttributesOrderedByDisplayIndex(
 		{
 			Path:        []any{"level"},
 			DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
-			Value:       "high",
+			Value:       strVal("high"),
 		},
 		{
 			Path:        []any{"studentID"},
 			DisplayName: clientmodels.TranslatedString{"en": "Student number", "nl": "Studentnummer"},
-			Value:       "67890",
+			Value:       strVal("67890"),
 		},
 		{
 			Path:        []any{"studentCardNumber"},
 			DisplayName: clientmodels.TranslatedString{"en": "Student card number", "nl": "Studentenkaartnummer"},
-			Value:       "12345",
+			Value:       strVal("12345"),
 		},
 		{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "University of the Arts",
+			Value:       strVal("University of the Arts"),
 		},
 	}
 	requireAttrsInOrder(t, studentCard.Attributes, studentCardExpectedAttrs...)
@@ -538,7 +538,7 @@ func testRevocationAttributesExcludedFromCredentials(
 	requireAttrsInOrder(t, rootCred.Attributes, expectedAttr{
 		Path:        []any{"BSN"},
 		DisplayName: clientmodels.TranslatedString{"en": "BSN", "nl": "BSN"},
-		Value:       "299792458",
+		Value:       strVal("299792458"),
 	})
 
 	// Revoke the credential on the server
@@ -566,7 +566,7 @@ func testRevocationAttributesExcludedFromCredentials(
 	requireAttrsInOrder(t, choice.Attributes, expectedAttr{
 		Path:        []any{"BSN"},
 		DisplayName: clientmodels.TranslatedString{"en": "BSN", "nl": "BSN"},
-		Value:       "299792458",
+		Value:       strVal("299792458"),
 	})
 
 	// Grant permission — the client will attempt to construct a proof and discover the revocation

--- a/internal/sessiontest/irma_issuance_test.go
+++ b/internal/sessiontest/irma_issuance_test.go
@@ -277,12 +277,12 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	require.Len(t, session.OfferedCredentials, 1)
 	offered := session.OfferedCredentials[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", offered.CredentialId)
-	for _, attr := range offered.Attributes {
-		require.NotEqual(t, pk("votingnumber"), clientmodels.ClaimPathKey(attr.ClaimPath),
-			"random blind attribute should not be included in offered credentials")
-	}
-	require.Len(t, offered.Attributes, 1, "should only have election attribute, not votingnumber")
-	require.Equal(t, []any{"election"}, offered.Attributes[0].ClaimPath)
+	requireNoAttr(t, attributeMap(offered.Attributes), []any{"votingnumber"})
+	requireAttrsInOrder(t, offered.Attributes, expectedAttr{
+		Path:        []any{"election"},
+		DisplayName: clientmodels.TranslatedString{"en": "Election", "nl": "Verkiezing"},
+		Value:       "plantsoen",
+	})
 
 	// Accept the issuance
 	userInteraction(t, c, clientmodels.SessionUserInteraction{
@@ -305,8 +305,10 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	}
 	require.NotNil(t, stempasCred, "should have irma-demo.stemmen.stempas credential")
 	require.Len(t, stempasCred.Attributes, 2, "GetCredentials should include both election and votingnumber")
-	require.Contains(t, [][]any{stempasCred.Attributes[0].ClaimPath, stempasCred.Attributes[1].ClaimPath}, []any{"election"})
-	require.Contains(t, [][]any{stempasCred.Attributes[0].ClaimPath, stempasCred.Attributes[1].ClaimPath}, []any{"votingnumber"})
+	stempassAttrs := attributeMap(stempasCred.Attributes)
+	requireAttr(t, stempassAttrs, []any{"election"}, "plantsoen")
+	_, hasVotingnumber := stempassAttrs[pk("votingnumber")]
+	require.True(t, hasVotingnumber, "should have votingnumber attribute")
 
 	// Start a disclosure session for the election attribute
 	disclosureRequest := irma.NewDisclosureRequest()
@@ -328,8 +330,11 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	require.Len(t, plan.DisclosureChoicesOverview[0].OwnedOptions, 1)
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", owned.CredentialId)
-	require.Len(t, owned.Attributes, 1)
-	require.Equal(t, []any{"election"}, owned.Attributes[0].ClaimPath)
+	requireAttrsInOrder(t, owned.Attributes, expectedAttr{
+		Path:        []any{"election"},
+		DisplayName: clientmodels.TranslatedString{"en": "Election", "nl": "Verkiezing"},
+		Value:       "plantsoen",
+	})
 
 	// Now request the votingnumber attribute directly — it should be disclosable
 	disclosureRequest2 := irma.NewDisclosureRequest()
@@ -352,7 +357,8 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	owned = plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", owned.CredentialId)
 	require.Len(t, owned.Attributes, 1)
-	require.Equal(t, []any{"votingnumber"}, owned.Attributes[0].ClaimPath)
+	_, votingnumberFound := attributeMap(owned.Attributes)[pk("votingnumber")]
+	require.True(t, votingnumberFound, "owned option should have votingnumber attribute")
 }
 
 func testTrustedPartyLogoPathsInLogs(
@@ -430,7 +436,6 @@ func testAttributesOrderedByDisplayIndex(
 	// irma-demo.RU.studentCard has displayIndex set:
 	// university=3, studentCardNumber=2, studentID=1, level=0
 	// So the expected display order is: level, studentID, studentCardNumber, university
-	expectedOrder := []string{"level", "studentID", "studentCardNumber", "university"}
 
 	// Issue the credential
 	issue(t, irmaServer, c, sessionHandler, createStudentCardIssuanceRequest())
@@ -448,17 +453,29 @@ func testAttributesOrderedByDisplayIndex(
 		}
 	}
 	require.NotNil(t, studentCard)
-	require.Len(t, studentCard.Attributes, 4)
-	attrIds := make([]string, len(studentCard.Attributes))
-	for i, attr := range studentCard.Attributes {
-		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
+	studentCardExpectedAttrs := []expectedAttr{
+		{
+			Path:        []any{"level"},
+			DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			Value:       "high",
+		},
+		{
+			Path:        []any{"studentID"},
+			DisplayName: clientmodels.TranslatedString{"en": "Student number", "nl": "Studentnummer"},
+			Value:       "67890",
+		},
+		{
+			Path:        []any{"studentCardNumber"},
+			DisplayName: clientmodels.TranslatedString{"en": "Student card number", "nl": "Studentenkaartnummer"},
+			Value:       "12345",
+		},
+		{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "University of the Arts",
+		},
 	}
-	expectedOrderKeys := make([]string, len(expectedOrder))
-	for i, id := range expectedOrder {
-		expectedOrderKeys[i] = pk(id)
-	}
-	require.Equal(t, expectedOrderKeys, attrIds,
-		"GetCredentials should return attributes ordered by displayIndex")
+	requireAttrsInOrder(t, studentCard.Attributes, studentCardExpectedAttrs...)
 
 	// Check OfferedCredentials during issuance also respects displayIndex
 	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, createStudentCardIssuanceRequest()))
@@ -467,12 +484,7 @@ func testAttributesOrderedByDisplayIndex(
 
 	require.Len(t, session.OfferedCredentials, 1)
 	offered := session.OfferedCredentials[0]
-	offeredAttrIds := make([]string, len(offered.Attributes))
-	for i, attr := range offered.Attributes {
-		offeredAttrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
-	}
-	require.Equal(t, expectedOrderKeys, offeredAttrIds,
-		"OfferedCredentials should return attributes ordered by displayIndex")
+	requireAttrsInOrder(t, offered.Attributes, studentCardExpectedAttrs...)
 }
 
 func testRevocationAttributesExcludedFromCredentials(
@@ -507,13 +519,12 @@ func testRevocationAttributesExcludedFromCredentials(
 	}
 	require.NotNil(t, rootCred, "should have irma-demo.MijnOverheid.root credential")
 
-	// Prove that the revocation attribute (with empty ID) is currently included in the attributes
-	for _, attr := range rootCred.Attributes {
-		require.NotEmpty(t, attr.ClaimPath,
-			"revocation attribute (empty ID) should not be visible to the user")
-	}
-	require.Len(t, rootCred.Attributes, 1, "should only have BSN attribute, not the revocation attribute")
-	require.Equal(t, []any{"BSN"}, rootCred.Attributes[0].ClaimPath)
+	// Prove that the revocation attribute (with empty ID) is not visible — only BSN should be present
+	requireAttrsInOrder(t, rootCred.Attributes, expectedAttr{
+		Path:        []any{"BSN"},
+		DisplayName: clientmodels.TranslatedString{"en": "BSN", "nl": "BSN"},
+		Value:       "299792458",
+	})
 
 	// Revoke the credential on the server
 	revocationTestCred := irma.NewCredentialTypeIdentifier("irma-demo.MijnOverheid.root")
@@ -537,10 +548,11 @@ func testRevocationAttributesExcludedFromCredentials(
 	choice := disclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.MijnOverheid.root", choice.CredentialId)
 	require.True(t, choice.Revoked, "owned option should show credential as revoked during disclosure permission")
-	for _, attr := range choice.Attributes {
-		require.NotEmpty(t, attr.ClaimPath,
-			"revocation attribute (empty ID) should not be included in disclosure permission")
-	}
+	requireAttrsInOrder(t, choice.Attributes, expectedAttr{
+		Path:        []any{"BSN"},
+		DisplayName: clientmodels.TranslatedString{"en": "BSN", "nl": "BSN"},
+		Value:       "299792458",
+	})
 
 	// Grant permission — the client will attempt to construct a proof and discover the revocation
 	grantPermission(t, c, 2, makeDisclosureChoice(choice))

--- a/internal/sessiontest/irma_issuance_test.go
+++ b/internal/sessiontest/irma_issuance_test.go
@@ -178,7 +178,7 @@ func testIssuanceSessionWithUnsatisfiedDisclosure(
 
 	// give permission to disclose the MijnOverheid credential
 	grantPermission(t, c, session.Id,
-		makeDisclosureChoice(cred, cred.Attributes[0].Id, cred.Attributes[1].Id),
+		makeDisclosureChoice(cred),
 	)
 
 	// finish issuance session for missing credential
@@ -278,11 +278,11 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	offered := session.OfferedCredentials[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", offered.CredentialId)
 	for _, attr := range offered.Attributes {
-		require.NotEqual(t, "votingnumber", attr.Id,
+		require.NotEqual(t, pk("votingnumber"), clientmodels.ClaimPathKey(attr.ClaimPath),
 			"random blind attribute should not be included in offered credentials")
 	}
 	require.Len(t, offered.Attributes, 1, "should only have election attribute, not votingnumber")
-	require.Equal(t, "election", offered.Attributes[0].Id)
+	require.Equal(t, []any{"election"}, offered.Attributes[0].ClaimPath)
 
 	// Accept the issuance
 	userInteraction(t, c, clientmodels.SessionUserInteraction{
@@ -305,9 +305,8 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	}
 	require.NotNil(t, stempasCred, "should have irma-demo.stemmen.stempas credential")
 	require.Len(t, stempasCred.Attributes, 2, "GetCredentials should include both election and votingnumber")
-	attrIds := []string{stempasCred.Attributes[0].Id, stempasCred.Attributes[1].Id}
-	require.Contains(t, attrIds, "election")
-	require.Contains(t, attrIds, "votingnumber")
+	require.Contains(t, [][]any{stempasCred.Attributes[0].ClaimPath, stempasCred.Attributes[1].ClaimPath}, []any{"election"})
+	require.Contains(t, [][]any{stempasCred.Attributes[0].ClaimPath, stempasCred.Attributes[1].ClaimPath}, []any{"votingnumber"})
 
 	// Start a disclosure session for the election attribute
 	disclosureRequest := irma.NewDisclosureRequest()
@@ -330,7 +329,7 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	owned := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", owned.CredentialId)
 	require.Len(t, owned.Attributes, 1)
-	require.Equal(t, "election", owned.Attributes[0].Id)
+	require.Equal(t, []any{"election"}, owned.Attributes[0].ClaimPath)
 
 	// Now request the votingnumber attribute directly — it should be disclosable
 	disclosureRequest2 := irma.NewDisclosureRequest()
@@ -353,7 +352,7 @@ func testRandomBlindAttributesExcludedFromOfferedCredentials(
 	owned = plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.stemmen.stempas", owned.CredentialId)
 	require.Len(t, owned.Attributes, 1)
-	require.Equal(t, "votingnumber", owned.Attributes[0].Id)
+	require.Equal(t, []any{"votingnumber"}, owned.Attributes[0].ClaimPath)
 }
 
 func testTrustedPartyLogoPathsInLogs(
@@ -381,7 +380,7 @@ func testTrustedPartyLogoPathsInLogs(
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
 	choice := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 2, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, 2, makeDisclosureChoice(choice))
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
 
@@ -452,9 +451,13 @@ func testAttributesOrderedByDisplayIndex(
 	require.Len(t, studentCard.Attributes, 4)
 	attrIds := make([]string, len(studentCard.Attributes))
 	for i, attr := range studentCard.Attributes {
-		attrIds[i] = attr.Id
+		attrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
 	}
-	require.Equal(t, expectedOrder, attrIds,
+	expectedOrderKeys := make([]string, len(expectedOrder))
+	for i, id := range expectedOrder {
+		expectedOrderKeys[i] = pk(id)
+	}
+	require.Equal(t, expectedOrderKeys, attrIds,
 		"GetCredentials should return attributes ordered by displayIndex")
 
 	// Check OfferedCredentials during issuance also respects displayIndex
@@ -466,9 +469,9 @@ func testAttributesOrderedByDisplayIndex(
 	offered := session.OfferedCredentials[0]
 	offeredAttrIds := make([]string, len(offered.Attributes))
 	for i, attr := range offered.Attributes {
-		offeredAttrIds[i] = attr.Id
+		offeredAttrIds[i] = clientmodels.ClaimPathKey(attr.ClaimPath)
 	}
-	require.Equal(t, expectedOrder, offeredAttrIds,
+	require.Equal(t, expectedOrderKeys, offeredAttrIds,
 		"OfferedCredentials should return attributes ordered by displayIndex")
 }
 
@@ -506,11 +509,11 @@ func testRevocationAttributesExcludedFromCredentials(
 
 	// Prove that the revocation attribute (with empty ID) is currently included in the attributes
 	for _, attr := range rootCred.Attributes {
-		require.NotEmpty(t, attr.Id,
+		require.NotEmpty(t, attr.ClaimPath,
 			"revocation attribute (empty ID) should not be visible to the user")
 	}
 	require.Len(t, rootCred.Attributes, 1, "should only have BSN attribute, not the revocation attribute")
-	require.Equal(t, "BSN", rootCred.Attributes[0].Id)
+	require.Equal(t, []any{"BSN"}, rootCred.Attributes[0].ClaimPath)
 
 	// Revoke the credential on the server
 	revocationTestCred := irma.NewCredentialTypeIdentifier("irma-demo.MijnOverheid.root")
@@ -535,12 +538,12 @@ func testRevocationAttributesExcludedFromCredentials(
 	require.Equal(t, "irma-demo.MijnOverheid.root", choice.CredentialId)
 	require.True(t, choice.Revoked, "owned option should show credential as revoked during disclosure permission")
 	for _, attr := range choice.Attributes {
-		require.NotEmpty(t, attr.Id,
+		require.NotEmpty(t, attr.ClaimPath,
 			"revocation attribute (empty ID) should not be included in disclosure permission")
 	}
 
 	// Grant permission — the client will attempt to construct a proof and discover the revocation
-	grantPermission(t, c, 2, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, 2, makeDisclosureChoice(choice))
 
 	// The session should fail because the credential is revoked
 	session = awaitSessionState(t, sessionHandler)

--- a/internal/sessiontest/irma_issuance_test.go
+++ b/internal/sessiontest/irma_issuance_test.go
@@ -146,7 +146,8 @@ func testIssuanceSessionWithUnsatisfiedDisclosure(
 	request := createEmailIssuanceRequest()
 	request.Disclose = studentCardOrMijnOverheidDisclosure()
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, issuanceToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 
 	requireSessionState(t, session, 1, clientmodels.Type_Issuance, clientmodels.Status_RequestPermission)
@@ -188,6 +189,13 @@ func testIssuanceSessionWithUnsatisfiedDisclosure(
 	// finish first issuance session
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Issuance, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, issuanceToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.MijnOverheid.fullName.firstnames", Value: "Barry"},
+			{Identifier: "irma-demo.MijnOverheid.fullName.familyname", Value: "Batsbak"},
+		},
+	})
 }
 
 func testSingleCredentialIssuance(t *testing.T, irmaServer *IrmaServer, c *client.Client, sessionHandler *MockSessionHandler) {
@@ -381,7 +389,8 @@ func testTrustedPartyLogoPathsInLogs(
 			},
 		},
 	}
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, disclosureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
@@ -389,6 +398,12 @@ func testTrustedPartyLogoPathsInLogs(
 	grantPermission(t, c, 2, makeDisclosureChoice(choice))
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, disclosureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "irma-demo.RU.studentCard.university", Value: "University of the Arts"},
+		},
+	})
 
 	// Load logs and verify logo paths
 	logs, err := c.LoadNewestLogs(10)

--- a/internal/sessiontest/irma_signature_test.go
+++ b/internal/sessiontest/irma_signature_test.go
@@ -74,7 +74,7 @@ func testSignatureRequest(
 	require.NotNil(t, plan.DisclosureChoicesOverview)
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(choice))
 
 	// finish email issuance session
 	session = awaitSessionState(t, sessionHandler)

--- a/internal/sessiontest/irma_signature_test.go
+++ b/internal/sessiontest/irma_signature_test.go
@@ -51,7 +51,8 @@ func testSignatureRequest(
 		},
 	}
 
-	c.NewSession(startSameDeviceIrmaSessionAtServer(t, irmaServer, request))
+	sessionJson, signatureToken := startSameDeviceIrmaSessionAtServerWithToken(t, irmaServer, request)
+	c.NewSession(sessionJson)
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Signature, clientmodels.Status_RequestPermission)
 	require.Equal(t, "Hello, World!", session.MessageToSign)
@@ -83,4 +84,10 @@ func testSignatureRequest(
 	// finish signature session
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 1, clientmodels.Type_Signature, clientmodels.Status_Success)
+
+	requireIrmaServerResult(t, irmaServer, signatureToken, [][]expectedDisclosedAttr{
+		{
+			{Identifier: "test.test.email.email", Value: "test@gmail.com"},
+		},
+	})
 }

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -74,17 +74,17 @@ func testOpenId4VciPreAuthFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"given_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
-			Value:       "Test",
+			Value:       strVal("Test"),
 		},
 		expectedAttr{
 			Path:        []any{"family_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
-			Value:       "User",
+			Value:       strVal("User"),
 		},
 		expectedAttr{
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
-			Value:       "test@example.com",
+			Value:       strVal("test@example.com"),
 		},
 	)
 }
@@ -130,17 +130,17 @@ func testOpenId4VciPreAuthFlowWithTxCode(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"given_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
-			Value:       "Test",
+			Value:       strVal("Test"),
 		},
 		expectedAttr{
 			Path:        []any{"family_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
-			Value:       "TxCode",
+			Value:       strVal("TxCode"),
 		},
 		expectedAttr{
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
-			Value:       "txcode@example.com",
+			Value:       strVal("txcode@example.com"),
 		},
 	)
 }
@@ -217,22 +217,22 @@ func testOpenId4VciPreAuthFlowNestedClaims(t *testing.T) {
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"owner_name"},
 		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-		Value:       "Alice",
+		Value:       strVal("Alice"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "street"},
 		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-		Value:       "123 Main St",
+		Value:       strVal("123 Main St"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "city"},
 		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-		Value:       "Amsterdam",
+		Value:       strVal("Amsterdam"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "country"},
 		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-		Value:       "NL",
+		Value:       strVal("NL"),
 	})
 }
 
@@ -273,12 +273,12 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
-			Value:       "nested-test@example.com",
+			Value:       strVal("nested-test@example.com"),
 		},
 		expectedAttr{
 			Path:        []any{"domain"},
 			DisplayName: clientmodels.TranslatedString{"en": "Domain", "nl": "Domein"},
-			Value:       "example.com",
+			Value:       strVal("example.com"),
 		},
 	)
 
@@ -289,22 +289,22 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "TU Delft",
+			Value:       strVal("TU Delft"),
 		},
 		expectedAttr{
 			Path:        []any{"level"},
 			DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"},
-			Value:       "MSc",
+			Value:       strVal("MSc"),
 		},
 		expectedAttr{
 			Path:        []any{"student_id"},
 			DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"},
-			Value:       "S12345",
+			Value:       strVal("S12345"),
 		},
 		expectedAttr{
 			Path:        []any{"courses"},
 			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
-			Value:       "", // not issued, falls back to empty
+			Value:       strVal(""), // not issued, falls back to empty
 		},
 	)
 
@@ -316,22 +316,22 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 	requireAttrFull(t, houseAttrs, expectedAttr{
 		Path:        []any{"owner_name"},
 		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-		Value:       "Bob",
+		Value:       strVal("Bob"),
 	})
 	requireAttrFull(t, houseAttrs, expectedAttr{
 		Path:        []any{"address", "street"},
 		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-		Value:       "456 Oak Ave",
+		Value:       strVal("456 Oak Ave"),
 	})
 	requireAttrFull(t, houseAttrs, expectedAttr{
 		Path:        []any{"address", "city"},
 		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-		Value:       "Rotterdam",
+		Value:       strVal("Rotterdam"),
 	})
 	requireAttrFull(t, houseAttrs, expectedAttr{
 		Path:        []any{"address", "country"},
 		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-		Value:       "NL",
+		Value:       strVal("NL"),
 	})
 }
 
@@ -357,32 +357,32 @@ func testOpenId4VciPreAuthFlowArrayClaims(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "TU Delft",
+			Value:       strVal("TU Delft"),
 		},
 		expectedAttr{
 			Path:        []any{"level"},
 			DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"},
-			Value:       "MSc",
+			Value:       strVal("MSc"),
 		},
 		expectedAttr{
 			Path:        []any{"student_id"},
 			DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"},
-			Value:       "S99999",
+			Value:       strVal("S99999"),
 		},
 		expectedAttr{
 			Path:        []any{"courses", 0},
 			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
-			Value:       "Algorithms",
+			Value:       strVal("Algorithms"),
 		},
 		expectedAttr{
 			Path:        []any{"courses", 1},
 			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
-			Value:       "Databases",
+			Value:       strVal("Databases"),
 		},
 		expectedAttr{
 			Path:        []any{"courses", 2},
 			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
-			Value:       "Security",
+			Value:       strVal("Security"),
 		},
 	)
 }
@@ -409,17 +409,17 @@ func testOpenId4VciPreAuthFlowMixedSdNonSd(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"member_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Member Name", "nl": "Naam lid"},
-			Value:       "Alice",
+			Value:       strVal("Alice"),
 		},
 		expectedAttr{
 			Path:        []any{"member_since"},
 			DisplayName: clientmodels.TranslatedString{"en": "Member Since", "nl": "Lid sinds"},
-			Value:       "2020-01-15",
+			Value:       strVal("2020-01-15"),
 		},
 		expectedAttr{
 			Path:        []any{"membership_type"},
 			DisplayName: clientmodels.TranslatedString{"en": "Membership Type", "nl": "Type lidmaatschap"},
-			Value:       "gold",
+			Value:       strVal("gold"),
 		},
 	)
 }
@@ -458,77 +458,77 @@ func testOpenId4VciPreAuthFlowEduIdCredential(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"schac_home_organization"},
 			DisplayName: clientmodels.TranslatedString{"en": "Organization", "nl": "Instelling"},
-			Value:       "university.nl",
+			Value:       strVal("university.nl"),
 		},
 		expectedAttr{
 			Path:        []any{"name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Name", "nl": "Naam"},
-			Value:       "Jan de Vries",
+			Value:       strVal("Jan de Vries"),
 		},
 		expectedAttr{
 			Path:        []any{"given_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Given name", "nl": "Voornaam"},
-			Value:       "Jan",
+			Value:       strVal("Jan"),
 		},
 		expectedAttr{
 			Path:        []any{"family_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
-			Value:       "de Vries",
+			Value:       strVal("de Vries"),
 		},
 		expectedAttr{
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "E-mail", "nl": "E-mail"},
-			Value:       "jan@university.nl",
+			Value:       strVal("jan@university.nl"),
 		},
 		expectedAttr{
 			Path:        []any{"eduperson_scoped_affiliation"},
 			DisplayName: clientmodels.TranslatedString{"en": "Affiliation (scoped)", "nl": "Betrekking (in relatie)"},
-			Value:       "student@university.nl",
+			Value:       strVal("student@university.nl"),
 		},
 		expectedAttr{
 			Path:        []any{"eduperson_assurance"},
 			DisplayName: clientmodels.TranslatedString{"en": "Assurance", "nl": "Bevestiging"},
-			Value:       "https://eduid.nl/assurance/low",
+			Value:       strVal("https://eduid.nl/assurance/low"),
 		},
 		expectedAttr{
 			Path:        []any{"is_student"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsStudent", "nl": "IsStudent"},
-			Value:       "true",
+			Value:       boolVal(true),
 		},
 		expectedAttr{
 			Path:        []any{"is_faculty"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsFaculty", "nl": "IsFaculteitslid"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 		expectedAttr{
 			Path:        []any{"is_member"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsMember", "nl": "IsLid"},
-			Value:       "true",
+			Value:       boolVal(true),
 		},
 		expectedAttr{
 			Path:        []any{"is_staff"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsStaff", "nl": "IsStaf"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 		expectedAttr{
 			Path:        []any{"is_alum"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsAlumnus", "nl": "IsAlumnus"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 		expectedAttr{
 			Path:        []any{"is_affiliate"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsAffiliate", "nl": "IsVerbonden"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 		expectedAttr{
 			Path:        []any{"is_employee"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsEmployee", "nl": "IsMedewerker"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 		expectedAttr{
 			Path:        []any{"is_library-walk-in"},
 			DisplayName: clientmodels.TranslatedString{"en": "IsLibraryWalkIn", "nl": "IsBibliotheekBezoeker"},
-			Value:       "false",
+			Value:       boolVal(false),
 		},
 	)
 }
@@ -597,17 +597,17 @@ func testOpenId4VciAuthCodeFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 		expectedAttr{
 			Path:        []any{"given_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
-			Value:       "Test",
+			Value:       strVal("Test"),
 		},
 		expectedAttr{
 			Path:        []any{"family_name"},
 			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
-			Value:       "AuthCode",
+			Value:       strVal("AuthCode"),
 		},
 		expectedAttr{
 			Path:        []any{"email"},
 			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
-			Value:       "authcode@example.com",
+			Value:       strVal("authcode@example.com"),
 		},
 	)
 }
@@ -657,22 +657,22 @@ func testOpenId4VciAuthCodeFlowNestedClaims(t *testing.T) {
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"owner_name"},
 		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-		Value:       "Charlie",
+		Value:       strVal("Charlie"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "street"},
 		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-		Value:       "789 Elm St",
+		Value:       strVal("789 Elm St"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "city"},
 		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-		Value:       "Utrecht",
+		Value:       strVal("Utrecht"),
 	})
 	requireAttrFull(t, am, expectedAttr{
 		Path:        []any{"address", "country"},
 		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-		Value:       "NL",
+		Value:       strVal("NL"),
 	})
 }
 

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -24,6 +24,7 @@ func testSessionHandlerForOpenID4VCIPreAuth(t *testing.T) {
 	t.Run("issues credential with array claims", testOpenId4VciPreAuthFlowArrayClaims)
 	t.Run("issues credential with mixed sd and non-sd claims", testOpenId4VciPreAuthFlowMixedSdNonSd)
 	t.Run("issues eduid credential with boolean claims", testOpenId4VciPreAuthFlowEduIdCredential)
+	t.Run("issues deeply nested credential", testOpenId4VciPreAuthFlowDeeplyNestedCredential)
 }
 
 func testOpenId4VciPreAuthFlowReachesPermission(t *testing.T) {
@@ -530,6 +531,130 @@ func testOpenId4VciPreAuthFlowEduIdCredential(t *testing.T) {
 			DisplayName: clientmodels.TranslatedString{"en": "IsLibraryWalkIn", "nl": "IsBibliotheekBezoeker"},
 			Value:       boolVal(false),
 		},
+	)
+}
+
+// testOpenId4VciPreAuthFlowDeeplyNestedCredential issues a credential with
+// deeply nested structure: an object containing an array of objects, each
+// containing an array of objects, each containing an array. This mirrors the
+// structure in buildDeeplyNestedSdJwt from the SD-JWT presentation tests.
+//
+// Structure:
+//
+//	university (object):
+//	  name: "TU Delft"
+//	  faculties (array of objects):
+//	    [0]:
+//	      faculty_name: "EEMCS"
+//	      departments (array of objects):
+//	        [0]:
+//	          dept_name: "Software Technology"
+//	          courses: ["Compiler Construction", "Distributed Systems", "Intro to CS"]
+//	        [1]:
+//	          dept_name: "Data Science"
+//	          courses: ["Machine Learning"]
+//	    [1]:
+//	      faculty_name: "Architecture"
+//	      departments (array of objects):
+//	        [0]:
+//	          dept_name: "Urbanism"
+//	          courses: ["City Planning"]
+//	  founded: 1842
+func testOpenId4VciPreAuthFlowDeeplyNestedCredential(t *testing.T) {
+	c, sessionHandler := createClientWithoutKeyshareEnrollment(t, nil)
+	defer c.Close()
+
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "OrganizationCredentialSdJwt", `{
+		"university": {
+			"name": "TU Delft",
+			"faculties": [
+				{
+					"faculty_name": "EEMCS",
+					"departments": [
+						{
+							"dept_name": "Software Technology",
+							"courses": ["Compiler Construction", "Distributed Systems", "Intro to CS"]
+						},
+						{
+							"dept_name": "Data Science",
+							"courses": ["Machine Learning"]
+						}
+					]
+				},
+				{
+					"faculty_name": "Architecture",
+					"departments": [
+						{
+							"dept_name": "Urbanism",
+							"courses": ["City Planning"]
+						}
+					]
+				}
+			],
+			"founded": 1842
+		}
+	}`)
+
+	// Verify the credential appears in GetCredentials.
+	creds, err := c.GetCredentials()
+	require.NoError(t, err)
+
+	cred := findCredentialByName(t, creds, "en", "Organization Credential (SD-JWT)")
+	require.NotNil(t, cred, "issued OrganizationCredential should appear in GetCredentials")
+
+	// The credential service sees "university" as a single metadata claim.
+	// Since the value is a map, it gets flattened into its child keys.
+	// The deeply nested structure produces multiple levels of flattening.
+	// For now, just verify the credential was issued and has attributes.
+	require.NotEmpty(t, cred.Attributes, "credential should have attributes")
+
+	// Verify the credential can be disclosed over OpenID4VP.
+	dcqlQuery := `{
+		"dcql": {
+			"credentials": [
+				{
+					"id": "org-cred",
+					"format": "dc+sd-jwt",
+					"meta": {
+						"vct_values": ["https://localhost:8443/vct/organization"]
+					},
+					"claims": [
+						{ "path": ["university"] }
+					]
+				}
+			]
+		}
+	}`
+	veramoSession := createVeramoVerifierDcqlSessionWithQuery(t, dcqlQuery)
+	startOpenID4VPDisclosureSession(t, c, veramoSession.RequestUri)
+
+	session := awaitSessionState(t, sessionHandler)
+	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
+
+	cred2 := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred2))
+
+	session = awaitSessionState(t, sessionHandler)
+	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	// Verify the verifier received the university claim as a nested object.
+	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
+	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status)
+
+	// Check the deeply nested structure was preserved.
+	requireVerifierReceivedClaims(t, result, "org-cred",
+		claim([]any{"university", "name"}, "TU Delft"),
+		claim([]any{"university", "faculties", 0, "faculty_name"}, "EEMCS"),
+		claim([]any{"university", "faculties", 0, "departments", 0, "dept_name"}, "Software Technology"),
+		claim([]any{"university", "faculties", 0, "departments", 0, "courses", 0}, "Compiler Construction"),
+		claim([]any{"university", "faculties", 0, "departments", 0, "courses", 1}, "Distributed Systems"),
+		claim([]any{"university", "faculties", 0, "departments", 0, "courses", 2}, "Intro to CS"),
+		claim([]any{"university", "faculties", 0, "departments", 1, "dept_name"}, "Data Science"),
+		claim([]any{"university", "faculties", 0, "departments", 1, "courses", 0}, "Machine Learning"),
+		claim([]any{"university", "faculties", 1, "faculty_name"}, "Architecture"),
+		claim([]any{"university", "faculties", 1, "departments", 0, "dept_name"}, "Urbanism"),
+		claim([]any{"university", "faculties", 1, "departments", 0, "courses", 0}, "City Planning"),
+		claim([]any{"university", "founded"}, "1842"),
 	)
 }
 

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -67,10 +67,11 @@ func testOpenId4VciPreAuthFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "Test Credential (SD-JWT)")
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
-	attrMap := attributeMap(cred.Attributes)
-	requireAttribute(t, attrMap, "given_name", clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, "Test")
-	requireAttribute(t, attrMap, "family_name", clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, "User")
-	requireAttribute(t, attrMap, "email", clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, "test@example.com")
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
+		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "User"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "test@example.com"},
+	)
 }
 
 func testOpenId4VciPreAuthFlowWithTxCode(t *testing.T) {
@@ -110,10 +111,11 @@ func testOpenId4VciPreAuthFlowWithTxCode(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "Test Credential (SD-JWT)")
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
-	attrMap := attributeMap(cred.Attributes)
-	requireAttribute(t, attrMap, "given_name", clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, "Test")
-	requireAttribute(t, attrMap, "family_name", clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, "TxCode")
-	requireAttribute(t, attrMap, "email", clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, "txcode@example.com")
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
+		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "TxCode"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "txcode@example.com"},
+	)
 }
 
 func testOpenId4VciPreAuthFlowWithWrongTxCode(t *testing.T) {
@@ -180,22 +182,12 @@ func testOpenId4VciPreAuthFlowNestedClaims(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT)")
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
-	attrMap := attributeMap(cred.Attributes)
-
-	// Top-level claim: owner_name
-	requireAttribute(t, attrMap, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Alice")
-
-	// Nested claims: address fields are flattened into separate attributes
-	// with paths like ["address", "street"], keyed by the leaf name in attributeMap.
-	street, ok := attrMap["street"]
-	require.True(t, ok, "attribute \"street\" should exist")
-	require.NotNil(t, street.Value)
-	require.Equal(t, "123 Main St", *street.Value.String)
-
-	city, ok := attrMap["city"]
-	require.True(t, ok, "attribute \"city\" should exist")
-	require.NotNil(t, city.Value)
-	require.Equal(t, "Amsterdam", *city.Value.String)
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Alice"},
+		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "123 Main St"},
+		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Amsterdam"},
+		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+	)
 }
 
 func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
@@ -231,29 +223,29 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 	// Verify EmailCredential attributes.
 	emailCred := findCredentialByName(t, creds, "en", "Email Credential (SD-JWT)")
 	require.NotNil(t, emailCred, "EmailCredential should appear in GetCredentials")
-	emailAttrs := attributeMap(emailCred.Attributes)
-	requireAttribute(t, emailAttrs, "email", clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, "nested-test@example.com")
-	requireAttribute(t, emailAttrs, "domain", clientmodels.TranslatedString{"en": "Domain", "nl": "Domein"}, "example.com")
+	requireAttrsInOrder(t, emailCred.Attributes,
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "nested-test@example.com"},
+		expectedAttr{Path: []any{"domain"}, DisplayName: clientmodels.TranslatedString{"en": "Domain", "nl": "Domein"}, Value: "example.com"},
+	)
 
 	// Verify StudentCardCredential attributes.
 	studentCred := findCredentialByName(t, creds, "en", "Student Card Credential (SD-JWT)")
 	require.NotNil(t, studentCred, "StudentCardCredential should appear in GetCredentials")
-	studentAttrs := attributeMap(studentCred.Attributes)
-	requireAttribute(t, studentAttrs, "university", clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, "TU Delft")
-	requireAttribute(t, studentAttrs, "level", clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"}, "MSc")
-	requireAttribute(t, studentAttrs, "student_id", clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"}, "S12345")
+	requireAttrsInOrder(t, studentCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "TU Delft"},
+		expectedAttr{Path: []any{"level"}, DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"}, Value: "MSc"},
+		expectedAttr{Path: []any{"student_id"}, DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"}, Value: "S12345"},
+	)
 
 	// Verify HouseCredential attributes.
 	houseCred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT)")
 	require.NotNil(t, houseCred, "HouseCredential should appear in GetCredentials")
-	houseAttrs := attributeMap(houseCred.Attributes)
-	requireAttribute(t, houseAttrs, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Bob")
-
-	// Nested address claims are flattened.
-	street, ok := houseAttrs["street"]
-	require.True(t, ok, "attribute \"street\" should exist")
-	require.NotNil(t, street.Value)
-	require.Equal(t, "456 Oak Ave", *street.Value.String)
+	requireAttrsInOrder(t, houseCred.Attributes,
+		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Bob"},
+		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "456 Oak Ave"},
+		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Rotterdam"},
+		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+	)
 }
 
 // ========================================================================
@@ -316,10 +308,11 @@ func testOpenId4VciAuthCodeFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "Test Credential (SD-JWT, Auth Code)")
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
-	attrMap := attributeMap(cred.Attributes)
-	requireAttribute(t, attrMap, "given_name", clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, "Test")
-	requireAttribute(t, attrMap, "family_name", clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, "AuthCode")
-	requireAttribute(t, attrMap, "email", clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, "authcode@example.com")
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
+		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "AuthCode"},
+		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "authcode@example.com"},
+	)
 }
 
 func testOpenId4VciAuthCodeFlowCanBeDismissed(t *testing.T) {
@@ -362,16 +355,12 @@ func testOpenId4VciAuthCodeFlowNestedClaims(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT, Auth Code)")
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
-	attrMap := attributeMap(cred.Attributes)
-
-	// Top-level claim: owner_name
-	requireAttribute(t, attrMap, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Charlie")
-
-	// Nested address claims are flattened.
-	street, ok := attrMap["street"]
-	require.True(t, ok, "attribute \"street\" should exist")
-	require.NotNil(t, street.Value)
-	require.Equal(t, "789 Pine Rd", *street.Value.String)
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Charlie"},
+		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "789 Pine Rd"},
+		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Utrecht"},
+		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+	)
 }
 
 // issueCredentialViaOid4VciAuthCode issues a single credential through the

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -68,9 +68,21 @@ func testOpenId4VciPreAuthFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
-		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "User"},
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "test@example.com"},
+		expectedAttr{
+			Path:        []any{"given_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
+			Value:       "Test",
+		},
+		expectedAttr{
+			Path:        []any{"family_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
+			Value:       "User",
+		},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
+			Value:       "test@example.com",
+		},
 	)
 }
 
@@ -112,9 +124,21 @@ func testOpenId4VciPreAuthFlowWithTxCode(t *testing.T) {
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
-		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "TxCode"},
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "txcode@example.com"},
+		expectedAttr{
+			Path:        []any{"given_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
+			Value:       "Test",
+		},
+		expectedAttr{
+			Path:        []any{"family_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
+			Value:       "TxCode",
+		},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
+			Value:       "txcode@example.com",
+		},
 	)
 }
 
@@ -183,10 +207,26 @@ func testOpenId4VciPreAuthFlowNestedClaims(t *testing.T) {
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Alice"},
-		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "123 Main St"},
-		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Amsterdam"},
-		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+		expectedAttr{
+			Path:        []any{"owner_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+			Value:       "Alice",
+		},
+		expectedAttr{
+			Path:        []any{"address", "street"},
+			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+			Value:       "123 Main St",
+		},
+		expectedAttr{
+			Path:        []any{"address", "city"},
+			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+			Value:       "Amsterdam",
+		},
+		expectedAttr{
+			Path:        []any{"address", "country"},
+			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+			Value:       "NL",
+		},
 	)
 }
 
@@ -224,27 +264,63 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 	emailCred := findCredentialByName(t, creds, "en", "Email Credential (SD-JWT)")
 	require.NotNil(t, emailCred, "EmailCredential should appear in GetCredentials")
 	requireAttrsInOrder(t, emailCred.Attributes,
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "nested-test@example.com"},
-		expectedAttr{Path: []any{"domain"}, DisplayName: clientmodels.TranslatedString{"en": "Domain", "nl": "Domein"}, Value: "example.com"},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
+			Value:       "nested-test@example.com",
+		},
+		expectedAttr{
+			Path:        []any{"domain"},
+			DisplayName: clientmodels.TranslatedString{"en": "Domain", "nl": "Domein"},
+			Value:       "example.com",
+		},
 	)
 
 	// Verify StudentCardCredential attributes.
 	studentCred := findCredentialByName(t, creds, "en", "Student Card Credential (SD-JWT)")
 	require.NotNil(t, studentCred, "StudentCardCredential should appear in GetCredentials")
 	requireAttrsInOrder(t, studentCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "TU Delft"},
-		expectedAttr{Path: []any{"level"}, DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"}, Value: "MSc"},
-		expectedAttr{Path: []any{"student_id"}, DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"}, Value: "S12345"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "TU Delft",
+		},
+		expectedAttr{
+			Path:        []any{"level"},
+			DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"},
+			Value:       "MSc",
+		},
+		expectedAttr{
+			Path:        []any{"student_id"},
+			DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"},
+			Value:       "S12345",
+		},
 	)
 
 	// Verify HouseCredential attributes.
 	houseCred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT)")
 	require.NotNil(t, houseCred, "HouseCredential should appear in GetCredentials")
 	requireAttrsInOrder(t, houseCred.Attributes,
-		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Bob"},
-		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "456 Oak Ave"},
-		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Rotterdam"},
-		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+		expectedAttr{
+			Path:        []any{"owner_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+			Value:       "Bob",
+		},
+		expectedAttr{
+			Path:        []any{"address", "street"},
+			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+			Value:       "456 Oak Ave",
+		},
+		expectedAttr{
+			Path:        []any{"address", "city"},
+			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+			Value:       "Rotterdam",
+		},
+		expectedAttr{
+			Path:        []any{"address", "country"},
+			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+			Value:       "NL",
+		},
 	)
 }
 
@@ -309,9 +385,21 @@ func testOpenId4VciAuthCodeFlowGrantsPermissionAndExchangesToken(t *testing.T) {
 	require.NotNil(t, cred, "issued credential should appear in GetCredentials")
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"given_name"}, DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"}, Value: "Test"},
-		expectedAttr{Path: []any{"family_name"}, DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"}, Value: "AuthCode"},
-		expectedAttr{Path: []any{"email"}, DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"}, Value: "authcode@example.com"},
+		expectedAttr{
+			Path:        []any{"given_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Given Name", "nl": "Voornaam"},
+			Value:       "Test",
+		},
+		expectedAttr{
+			Path:        []any{"family_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family Name", "nl": "Achternaam"},
+			Value:       "AuthCode",
+		},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "Email", "nl": "E-mailadres"},
+			Value:       "authcode@example.com",
+		},
 	)
 }
 
@@ -356,10 +444,26 @@ func testOpenId4VciAuthCodeFlowNestedClaims(t *testing.T) {
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
 	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{Path: []any{"owner_name"}, DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, Value: "Charlie"},
-		expectedAttr{Path: []any{"address", "street"}, DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"}, Value: "789 Pine Rd"},
-		expectedAttr{Path: []any{"address", "city"}, DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"}, Value: "Utrecht"},
-		expectedAttr{Path: []any{"address", "country"}, DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"}, Value: "NL"},
+		expectedAttr{
+			Path:        []any{"owner_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+			Value:       "Charlie",
+		},
+		expectedAttr{
+			Path:        []any{"address", "street"},
+			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+			Value:       "789 Pine Rd",
+		},
+		expectedAttr{
+			Path:        []any{"address", "city"},
+			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+			Value:       "Utrecht",
+		},
+		expectedAttr{
+			Path:        []any{"address", "country"},
+			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+			Value:       "NL",
+		},
 	)
 }
 

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -602,11 +602,68 @@ func testOpenId4VciPreAuthFlowDeeplyNestedCredential(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "Organization Credential (SD-JWT)")
 	require.NotNil(t, cred, "issued OrganizationCredential should appear in GetCredentials")
 
-	// The credential service sees "university" as a single metadata claim.
-	// Since the value is a map, it gets flattened into its child keys.
-	// The deeply nested structure produces multiple levels of flattening.
-	// For now, just verify the credential was issued and has attributes.
-	require.NotEmpty(t, cred.Attributes, "credential should have attributes")
+	am := attributeMap(cred.Attributes)
+	require.Len(t, cred.Attributes, 12)
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "name"},
+		DisplayName: clientmodels.TranslatedString{"en": "University Name", "nl": "Naam universiteit"},
+		Value:       strVal("TU Delft"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "faculty_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("EEMCS"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 0, "dept_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Software Technology"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 0, "courses", 0},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Compiler Construction"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 0, "courses", 1},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Distributed Systems"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 0, "courses", 2},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Intro to CS"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 1, "dept_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Data Science"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 0, "departments", 1, "courses", 0},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Machine Learning"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 1, "faculty_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Architecture"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 1, "departments", 0, "dept_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("Urbanism"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "faculties", 1, "departments", 0, "courses", 0},
+		DisplayName: clientmodels.TranslatedString{"en": "Faculties", "nl": "Faculteiten"},
+		Value:       strVal("City Planning"),
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"university", "founded"},
+		DisplayName: clientmodels.TranslatedString{"en": "Founded", "nl": "Opgericht"},
+		Value:       intVal(1842),
+	})
 
 	// Verify the credential can be disclosed over OpenID4VP.
 	dcqlQuery := `{

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -185,11 +185,17 @@ func testOpenId4VciPreAuthFlowNestedClaims(t *testing.T) {
 	// Top-level claim: owner_name
 	requireAttribute(t, attrMap, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Alice")
 
-	// Nested claim: address is an object containing street, city, country
-	attr, ok := attrMap["address"]
-	require.True(t, ok, "attribute \"address\" should exist")
-	require.NotNil(t, attr.Value, "attribute \"address\" should have a value")
-	require.Equal(t, clientmodels.AttributeType_Object, attr.Value.Type, "address should be an object type")
+	// Nested claims: address fields are flattened into separate attributes
+	// with paths like ["address", "street"], keyed by the leaf name in attributeMap.
+	street, ok := attrMap["street"]
+	require.True(t, ok, "attribute \"street\" should exist")
+	require.NotNil(t, street.Value)
+	require.Equal(t, "123 Main St", *street.Value.String)
+
+	city, ok := attrMap["city"]
+	require.True(t, ok, "attribute \"city\" should exist")
+	require.NotNil(t, city.Value)
+	require.Equal(t, "Amsterdam", *city.Value.String)
 }
 
 func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
@@ -243,11 +249,11 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 	houseAttrs := attributeMap(houseCred.Attributes)
 	requireAttribute(t, houseAttrs, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Bob")
 
-	// The nested address claim should be stored as an object.
-	addrAttr, ok := houseAttrs["address"]
-	require.True(t, ok, "attribute \"address\" should exist")
-	require.NotNil(t, addrAttr.Value, "attribute \"address\" should have a value")
-	require.Equal(t, clientmodels.AttributeType_Object, addrAttr.Value.Type, "address should be an object type")
+	// Nested address claims are flattened.
+	street, ok := houseAttrs["street"]
+	require.True(t, ok, "attribute \"street\" should exist")
+	require.NotNil(t, street.Value)
+	require.Equal(t, "456 Oak Ave", *street.Value.String)
 }
 
 // ========================================================================
@@ -361,11 +367,11 @@ func testOpenId4VciAuthCodeFlowNestedClaims(t *testing.T) {
 	// Top-level claim: owner_name
 	requireAttribute(t, attrMap, "owner_name", clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"}, "Charlie")
 
-	// Nested claim: address is an object containing street, city, country
-	addrAttr, ok := attrMap["address"]
-	require.True(t, ok, "attribute \"address\" should exist")
-	require.NotNil(t, addrAttr.Value, "attribute \"address\" should have a value")
-	require.Equal(t, clientmodels.AttributeType_Object, addrAttr.Value.Type, "address should be an object type")
+	// Nested address claims are flattened.
+	street, ok := attrMap["street"]
+	require.True(t, ok, "attribute \"street\" should exist")
+	require.NotNil(t, street.Value)
+	require.Equal(t, "789 Pine Rd", *street.Value.String)
 }
 
 // issueCredentialViaOid4VciAuthCode issues a single credential through the

--- a/internal/sessiontest/openid4vci_issuance_test.go
+++ b/internal/sessiontest/openid4vci_issuance_test.go
@@ -21,6 +21,9 @@ func testSessionHandlerForOpenID4VCIPreAuth(t *testing.T) {
 	t.Run("can be dismissed", testOpenId4VciPreAuthFlowCanBeDismissed)
 	t.Run("issues credential with nested claims", testOpenId4VciPreAuthFlowNestedClaims)
 	t.Run("issues multiple credential types", testOpenId4VciPreAuthFlowMultipleCredentialTypes)
+	t.Run("issues credential with array claims", testOpenId4VciPreAuthFlowArrayClaims)
+	t.Run("issues credential with mixed sd and non-sd claims", testOpenId4VciPreAuthFlowMixedSdNonSd)
+	t.Run("issues eduid credential with boolean claims", testOpenId4VciPreAuthFlowEduIdCredential)
 }
 
 func testOpenId4VciPreAuthFlowReachesPermission(t *testing.T) {
@@ -206,28 +209,31 @@ func testOpenId4VciPreAuthFlowNestedClaims(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT)")
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
-	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{
-			Path:        []any{"owner_name"},
-			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-			Value:       "Alice",
-		},
-		expectedAttr{
-			Path:        []any{"address", "street"},
-			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-			Value:       "123 Main St",
-		},
-		expectedAttr{
-			Path:        []any{"address", "city"},
-			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-			Value:       "Amsterdam",
-		},
-		expectedAttr{
-			Path:        []any{"address", "country"},
-			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-			Value:       "NL",
-		},
-	)
+	// Nested claims are resolved via their metadata paths. The credential service
+	// iterates metadata claims in DB order (which may differ from config file order).
+	// Use attributeMap for order-independent checks.
+	am := attributeMap(cred.Attributes)
+	require.Len(t, cred.Attributes, 4)
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"owner_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+		Value:       "Alice",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "street"},
+		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+		Value:       "123 Main St",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "city"},
+		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+		Value:       "Amsterdam",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "country"},
+		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+		Value:       "NL",
+	})
 }
 
 func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
@@ -295,31 +301,234 @@ func testOpenId4VciPreAuthFlowMultipleCredentialTypes(t *testing.T) {
 			DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"},
 			Value:       "S12345",
 		},
+		expectedAttr{
+			Path:        []any{"courses"},
+			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
+			Value:       "", // not issued, falls back to empty
+		},
 	)
 
 	// Verify HouseCredential attributes.
 	houseCred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT)")
 	require.NotNil(t, houseCred, "HouseCredential should appear in GetCredentials")
-	requireAttrsInOrder(t, houseCred.Attributes,
+	houseAttrs := attributeMap(houseCred.Attributes)
+	require.Len(t, houseCred.Attributes, 4)
+	requireAttrFull(t, houseAttrs, expectedAttr{
+		Path:        []any{"owner_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+		Value:       "Bob",
+	})
+	requireAttrFull(t, houseAttrs, expectedAttr{
+		Path:        []any{"address", "street"},
+		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+		Value:       "456 Oak Ave",
+	})
+	requireAttrFull(t, houseAttrs, expectedAttr{
+		Path:        []any{"address", "city"},
+		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+		Value:       "Rotterdam",
+	})
+	requireAttrFull(t, houseAttrs, expectedAttr{
+		Path:        []any{"address", "country"},
+		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+		Value:       "NL",
+	})
+}
+
+func testOpenId4VciPreAuthFlowArrayClaims(t *testing.T) {
+	c, sessionHandler := createClientWithoutKeyshareEnrollment(t, nil)
+	defer c.Close()
+
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "StudentCardCredentialSdJwt", `{
+		"university": "TU Delft",
+		"level": "MSc",
+		"student_id": "S99999",
+		"courses": ["Algorithms", "Databases", "Security"]
+	}`)
+
+	creds, err := c.GetCredentials()
+	require.NoError(t, err)
+
+	cred := findCredentialByName(t, creds, "en", "Student Card Credential (SD-JWT)")
+	require.NotNil(t, cred, "issued StudentCardCredential should appear in GetCredentials")
+
+	// Array claims are flattened into indexed paths.
+	requireAttrsInOrder(t, cred.Attributes,
 		expectedAttr{
-			Path:        []any{"owner_name"},
-			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-			Value:       "Bob",
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "TU Delft",
 		},
 		expectedAttr{
-			Path:        []any{"address", "street"},
-			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-			Value:       "456 Oak Ave",
+			Path:        []any{"level"},
+			DisplayName: clientmodels.TranslatedString{"en": "Level", "nl": "Niveau"},
+			Value:       "MSc",
 		},
 		expectedAttr{
-			Path:        []any{"address", "city"},
-			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-			Value:       "Rotterdam",
+			Path:        []any{"student_id"},
+			DisplayName: clientmodels.TranslatedString{"en": "Student ID", "nl": "Studentnummer"},
+			Value:       "S99999",
 		},
 		expectedAttr{
-			Path:        []any{"address", "country"},
-			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-			Value:       "NL",
+			Path:        []any{"courses", 0},
+			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
+			Value:       "Algorithms",
+		},
+		expectedAttr{
+			Path:        []any{"courses", 1},
+			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
+			Value:       "Databases",
+		},
+		expectedAttr{
+			Path:        []any{"courses", 2},
+			DisplayName: clientmodels.TranslatedString{"en": "Courses", "nl": "Vakken"},
+			Value:       "Security",
+		},
+	)
+}
+
+func testOpenId4VciPreAuthFlowMixedSdNonSd(t *testing.T) {
+	c, sessionHandler := createClientWithoutKeyshareEnrollment(t, nil)
+	defer c.Close()
+
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "MembershipCredentialSdJwt", `{
+		"member_name": "Alice",
+		"member_since": "2020-01-15",
+		"membership_type": "gold"
+	}`)
+
+	creds, err := c.GetCredentials()
+	require.NoError(t, err)
+
+	cred := findCredentialByName(t, creds, "en", "Membership Credential (SD-JWT)")
+	require.NotNil(t, cred, "issued MembershipCredential should appear in GetCredentials")
+
+	// member_name and membership_type are SD, member_since is non-SD.
+	// All should appear in GetCredentials regardless.
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{
+			Path:        []any{"member_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Member Name", "nl": "Naam lid"},
+			Value:       "Alice",
+		},
+		expectedAttr{
+			Path:        []any{"member_since"},
+			DisplayName: clientmodels.TranslatedString{"en": "Member Since", "nl": "Lid sinds"},
+			Value:       "2020-01-15",
+		},
+		expectedAttr{
+			Path:        []any{"membership_type"},
+			DisplayName: clientmodels.TranslatedString{"en": "Membership Type", "nl": "Type lidmaatschap"},
+			Value:       "gold",
+		},
+	)
+}
+
+func testOpenId4VciPreAuthFlowEduIdCredential(t *testing.T) {
+	c, sessionHandler := createClientWithoutKeyshareEnrollment(t, nil)
+	defer c.Close()
+
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "EduIdCredentialSdJwt", `{
+		"schac_home_organization": "university.nl",
+		"name": "Jan de Vries",
+		"given_name": "Jan",
+		"family_name": "de Vries",
+		"email": "jan@university.nl",
+		"eduperson_scoped_affiliation": "student@university.nl",
+		"eduperson_assurance": "https://eduid.nl/assurance/low",
+		"is_student": true,
+		"is_faculty": false,
+		"is_member": true,
+		"is_staff": false,
+		"is_alum": false,
+		"is_affiliate": false,
+		"is_employee": false,
+		"is_library-walk-in": false
+	}`)
+
+	creds, err := c.GetCredentials()
+	require.NoError(t, err)
+
+	cred := findCredentialByName(t, creds, "en", "eduID")
+	require.NotNil(t, cred, "issued EduIdCredential should appear in GetCredentials")
+
+	// All 15 claims should be present. eduperson_assurance is non-SD.
+	// Boolean values are stored as string "true"/"false" via NewAttributeValue.
+	requireAttrsInOrder(t, cred.Attributes,
+		expectedAttr{
+			Path:        []any{"schac_home_organization"},
+			DisplayName: clientmodels.TranslatedString{"en": "Organization", "nl": "Instelling"},
+			Value:       "university.nl",
+		},
+		expectedAttr{
+			Path:        []any{"name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Name", "nl": "Naam"},
+			Value:       "Jan de Vries",
+		},
+		expectedAttr{
+			Path:        []any{"given_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Given name", "nl": "Voornaam"},
+			Value:       "Jan",
+		},
+		expectedAttr{
+			Path:        []any{"family_name"},
+			DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			Value:       "de Vries",
+		},
+		expectedAttr{
+			Path:        []any{"email"},
+			DisplayName: clientmodels.TranslatedString{"en": "E-mail", "nl": "E-mail"},
+			Value:       "jan@university.nl",
+		},
+		expectedAttr{
+			Path:        []any{"eduperson_scoped_affiliation"},
+			DisplayName: clientmodels.TranslatedString{"en": "Affiliation (scoped)", "nl": "Betrekking (in relatie)"},
+			Value:       "student@university.nl",
+		},
+		expectedAttr{
+			Path:        []any{"eduperson_assurance"},
+			DisplayName: clientmodels.TranslatedString{"en": "Assurance", "nl": "Bevestiging"},
+			Value:       "https://eduid.nl/assurance/low",
+		},
+		expectedAttr{
+			Path:        []any{"is_student"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsStudent", "nl": "IsStudent"},
+			Value:       "true",
+		},
+		expectedAttr{
+			Path:        []any{"is_faculty"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsFaculty", "nl": "IsFaculteitslid"},
+			Value:       "false",
+		},
+		expectedAttr{
+			Path:        []any{"is_member"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsMember", "nl": "IsLid"},
+			Value:       "true",
+		},
+		expectedAttr{
+			Path:        []any{"is_staff"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsStaff", "nl": "IsStaf"},
+			Value:       "false",
+		},
+		expectedAttr{
+			Path:        []any{"is_alum"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsAlumnus", "nl": "IsAlumnus"},
+			Value:       "false",
+		},
+		expectedAttr{
+			Path:        []any{"is_affiliate"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsAffiliate", "nl": "IsVerbonden"},
+			Value:       "false",
+		},
+		expectedAttr{
+			Path:        []any{"is_employee"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsEmployee", "nl": "IsMedewerker"},
+			Value:       "false",
+		},
+		expectedAttr{
+			Path:        []any{"is_library-walk-in"},
+			DisplayName: clientmodels.TranslatedString{"en": "IsLibraryWalkIn", "nl": "IsBibliotheekBezoeker"},
+			Value:       "false",
 		},
 	)
 }
@@ -443,28 +652,28 @@ func testOpenId4VciAuthCodeFlowNestedClaims(t *testing.T) {
 	cred := findCredentialByName(t, creds, "en", "House Possession Credential (SD-JWT, Auth Code)")
 	require.NotNil(t, cred, "issued HouseCredential should appear in GetCredentials")
 
-	requireAttrsInOrder(t, cred.Attributes,
-		expectedAttr{
-			Path:        []any{"owner_name"},
-			DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
-			Value:       "Charlie",
-		},
-		expectedAttr{
-			Path:        []any{"address", "street"},
-			DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
-			Value:       "789 Pine Rd",
-		},
-		expectedAttr{
-			Path:        []any{"address", "city"},
-			DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
-			Value:       "Utrecht",
-		},
-		expectedAttr{
-			Path:        []any{"address", "country"},
-			DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
-			Value:       "NL",
-		},
-	)
+	am := attributeMap(cred.Attributes)
+	require.Len(t, cred.Attributes, 4)
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"owner_name"},
+		DisplayName: clientmodels.TranslatedString{"en": "Owner Name", "nl": "Eigenaar"},
+		Value:       "Charlie",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "street"},
+		DisplayName: clientmodels.TranslatedString{"en": "Street", "nl": "Straat"},
+		Value:       "789 Elm St",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "city"},
+		DisplayName: clientmodels.TranslatedString{"en": "City", "nl": "Stad"},
+		Value:       "Utrecht",
+	})
+	requireAttrFull(t, am, expectedAttr{
+		Path:        []any{"address", "country"},
+		DisplayName: clientmodels.TranslatedString{"en": "Country", "nl": "Land"},
+		Value:       "NL",
+	})
 }
 
 // issueCredentialViaOid4VciAuthCode issues a single credential through the

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -530,9 +530,9 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	require.NotNil(t, wrongCred)
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
-	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
-	require.Equal(t, "Some Other University", *wrongCred.Attributes[0].Value.String)
+	requireAttrsInOrder(t, wrongCred.Attributes,
+		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Some Other University"},
+	)
 	require.Equal(t, &expectedUniversityValue, wrongCred.Attributes[0].RequestedValue.String)
 
 	// issuance session ended

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -93,7 +93,7 @@ func testOpenID4VP_YiviScheme_SingleCredential(
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 1})
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 1, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, 1, makeDisclosureChoice(choice))
 
 	// expect end for issuance session
 	session = awaitSessionState(t, sessionHandler)
@@ -157,7 +157,7 @@ func testOpenID4VP_YiviScheme_ChoiceBetweenTwoCredentials(
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 2})
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, 1, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, 1, makeDisclosureChoice(choice))
 
 	// expect end for issuance session
 	session = awaitSessionState(t, sessionHandler)
@@ -219,7 +219,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 	require.Equal(t, firstOption.CredentialId, "test.test.email")
 	require.Equal(t, firstOption.Attributes, []clientmodels.Attribute{
 		{
-			Id: "email",
+			ClaimPath: []any{"email"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Email address",
 				"nl": "E-mailadres",
@@ -234,7 +234,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 	require.Equal(t, secondOption.CredentialId, "irma-demo.RU.studentCard")
 	require.Equal(t, secondOption.Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -244,7 +244,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -259,7 +259,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 	require.Equal(t, secondStep.CredentialId, "irma-demo.MijnOverheid.fullName")
 	require.Equal(t, secondStep.Attributes, []clientmodels.Attribute{
 		{
-			Id: "firstname",
+			ClaimPath: []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "First name",
 				"nl": "Voornaam",
@@ -269,7 +269,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 			},
 		},
 		{
-			Id: "familyname",
+			ClaimPath: []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Family name",
 				"nl": "Achternaam",
@@ -319,7 +319,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 	require.Equal(t, firstChoice.CredentialId, "irma-demo.RU.studentCard")
 	require.Equal(t, firstChoice.Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -334,7 +334,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -354,8 +354,8 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 
 	// give permission to disclose
 	grantPermission(t, c, session.Id,
-		makeDisclosureChoice(firstChoice, firstChoice.Attributes[0].Id, firstChoice.Attributes[1].Id),
-		makeDisclosureChoice(secondChoice, secondChoice.Attributes[0].Id, secondChoice.Attributes[1].Id),
+		makeDisclosureChoice(firstChoice),
+		makeDisclosureChoice(secondChoice),
 	)
 
 	// expect issuance session to be done
@@ -434,7 +434,7 @@ func testOpenID4VP_YiviScheme_OptionalCredential(
 	// grant permission with only the required credential; skip the optional one with an empty selection
 	sc := requiredChoice.OwnedOptions[0]
 	grantPermission(t, c, 1,
-		makeDisclosureChoice(sc, sc.Attributes[0].Id),
+		makeDisclosureChoice(sc),
 		clientmodels.DisclosureDisconSelection{},
 	)
 
@@ -479,7 +479,7 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	expectedUniversityValue := "University of the Arts"
 	require.Equal(t, plan.IssueDuringDislosure.Steps[0].Options[0].Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -490,7 +490,7 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -531,7 +531,7 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
 	require.Len(t, wrongCred.Attributes, 1)
-	require.Equal(t, "university", wrongCred.Attributes[0].Id)
+	require.Equal(t, []any{"university"}, wrongCred.Attributes[0].ClaimPath)
 	require.Equal(t, "Some Other University", *wrongCred.Attributes[0].Value.String)
 	require.Equal(t, &expectedUniversityValue, wrongCred.Attributes[0].RequestedValue.String)
 
@@ -562,10 +562,10 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	// Find the requested attributes (university and level) and verify their RequestedValue
 	var universityAttr, levelAttr *clientmodels.Attribute
 	for i := range obtainable.Attributes {
-		switch obtainable.Attributes[i].Id {
-		case "university":
+		switch clientmodels.ClaimPathKey(obtainable.Attributes[i].ClaimPath) {
+		case pk("university"):
 			universityAttr = &obtainable.Attributes[i]
-		case "level":
+		case pk("level"):
 			levelAttr = &obtainable.Attributes[i]
 		}
 	}
@@ -589,7 +589,7 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	// grant permission to disclose the credential with the correct value
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	grantPermission(t, c, 1,
-		makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id),
+		makeDisclosureChoice(choice),
 	)
 
 	session = awaitSessionState(t, sessionHandler)
@@ -650,7 +650,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 	require.Equal(t, firstOption.CredentialId, "test.test.email")
 	require.Equal(t, firstOption.Attributes, []clientmodels.Attribute{
 		{
-			Id: "email",
+			ClaimPath: []any{"email"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Email address",
 				"nl": "E-mailadres",
@@ -665,7 +665,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 	require.Equal(t, secondOption.CredentialId, "irma-demo.RU.studentCard")
 	require.Equal(t, secondOption.Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -675,7 +675,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -690,7 +690,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 	require.Equal(t, secondStep.CredentialId, "irma-demo.MijnOverheid.fullName")
 	require.Equal(t, secondStep.Attributes, []clientmodels.Attribute{
 		{
-			Id: "firstname",
+			ClaimPath: []any{"firstname"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "First name",
 				"nl": "Voornaam",
@@ -700,7 +700,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 			},
 		},
 		{
-			Id: "familyname",
+			ClaimPath: []any{"familyname"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Family name",
 				"nl": "Achternaam",
@@ -750,7 +750,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 	require.Equal(t, firstChoice.CredentialId, "irma-demo.RU.studentCard")
 	require.Equal(t, firstChoice.Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -765,7 +765,7 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -785,8 +785,8 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 
 	// give permission to disclose
 	grantPermission(t, c, session.Id,
-		makeDisclosureChoice(firstChoice, firstChoice.Attributes[0].Id, firstChoice.Attributes[1].Id),
-		makeDisclosureChoice(secondChoice, secondChoice.Attributes[0].Id, secondChoice.Attributes[1].Id),
+		makeDisclosureChoice(firstChoice),
+		makeDisclosureChoice(secondChoice),
 	)
 
 	// expect issuance session to be done
@@ -844,7 +844,7 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 	require.Equal(t, "irma-demo.RU.studentCard", plan.IssueDuringDislosure.Steps[0].Options[0].CredentialId)
 	require.Equal(t, plan.IssueDuringDislosure.Steps[0].Options[0].Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -854,7 +854,7 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -887,7 +887,7 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 	require.Equal(t, "irma-demo.RU.studentCard", choice.CredentialId)
 	require.Equal(t, choice.Attributes, []clientmodels.Attribute{
 		{
-			Id: "university",
+			ClaimPath: []any{"university"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "University",
 				"nl": "Universiteit",
@@ -902,7 +902,7 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 			},
 		},
 		{
-			Id: "level",
+			ClaimPath: []any{"level"},
 			DisplayName: clientmodels.TranslatedString{
 				"en": "Type",
 				"nl": "Soort",
@@ -919,7 +919,7 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 	})
 
 	grantPermission(t, c, 1,
-		makeDisclosureChoice(choice, choice.Attributes[0].Id, choice.Attributes[1].Id),
+		makeDisclosureChoice(choice),
 	)
 
 	session = awaitSessionState(t, sessionHandler)
@@ -982,7 +982,7 @@ func testOpenID4VP_YiviScheme_MultipleInstances_AttributeOrdering(
 	pick := plan.DisclosureChoicesOverview[0]
 	require.Len(t, pick.OwnedOptions, 3, "should have 3 owned credential instances")
 
-	expectedOrder := []string{"university", "studentCardNumber", "studentID", "level"}
+	expectedOrder := []string{pk("university"), pk("studentCardNumber"), pk("studentID"), pk("level")}
 
 	for i, option := range pick.OwnedOptions {
 		require.Equal(t, "irma-demo.RU.studentCard", option.CredentialId)
@@ -990,7 +990,7 @@ func testOpenID4VP_YiviScheme_MultipleInstances_AttributeOrdering(
 
 		actualOrder := make([]string, len(option.Attributes))
 		for j, attr := range option.Attributes {
-			actualOrder[j] = attr.Id
+			actualOrder[j] = clientmodels.ClaimPathKey(attr.ClaimPath)
 		}
 		require.Equal(t, expectedOrder, actualOrder,
 			"option %d: attributes should be in scheme-defined order", i)
@@ -1009,7 +1009,7 @@ func testOpenID4VP_YiviScheme_MultipleInstances_AttributeOrdering(
 	// Disclose the first option and verify the result
 	chosen := pick.OwnedOptions[0]
 	grantPermission(t, c, session.Id,
-		makeDisclosureChoice(chosen, "university", "studentCardNumber", "studentID", "level"),
+		makeDisclosureChoice(chosen),
 	)
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 4, clientmodels.Type_Disclosure, clientmodels.Status_Success)

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -92,6 +92,17 @@ func testOpenID4VP_YiviScheme_SingleCredential(
 	require.Len(t, plan.IssueDuringDislosure.IssuedCredentialIds, 1)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 1})
 
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "test.test.email",
+		Name:         clientmodels.TranslatedString{"en": "Demo Email address", "nl": "Demo E-mailadres"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"email"},
+				DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			},
+		},
+	})
+
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	grantPermission(t, c, 1, makeDisclosureChoice(choice))
 
@@ -155,6 +166,34 @@ func testOpenID4VP_YiviScheme_ChoiceBetweenTwoCredentials(
 	require.Len(t, plan.IssueDuringDislosure.Steps, 1)
 	require.Len(t, plan.IssueDuringDislosure.IssuedCredentialIds, 1)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 2})
+
+	// check obtainable option for test.test.email
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "test.test.email",
+		Name:         clientmodels.TranslatedString{"en": "Demo Email address", "nl": "Demo E-mailadres"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"email"},
+				DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			},
+		},
+	})
+
+	// check obtainable option for irma-demo.RU.studentCard
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[1], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"university"},
+				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			},
+			{
+				Path:        []any{"level"},
+				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			},
+		},
+	})
 
 	choice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	grantPermission(t, c, 1, makeDisclosureChoice(choice))
@@ -314,6 +353,49 @@ func testOpenID4VP_YiviScheme_ComplexChoices(
 	)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 2}, expectedPickOne{owned: 1, obtainable: 1})
 
+	// check obtainable options for first pick-one (email || studentCard)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "test.test.email",
+		Name:         clientmodels.TranslatedString{"en": "Demo Email address", "nl": "Demo E-mailadres"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"email"},
+				DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			},
+		},
+	})
+
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[1], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"university"},
+				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			},
+			{
+				Path:        []any{"level"},
+				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			},
+		},
+	})
+
+	// check obtainable option for second pick-one (name)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[1].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.MijnOverheid.fullName",
+		Name:         clientmodels.TranslatedString{"en": "Demo Name", "nl": "Demo Naam"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"firstname"},
+				DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			},
+			{
+				Path:        []any{"familyname"},
+				DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			},
+		},
+	})
+
 	firstChoice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 
 	require.Equal(t, firstChoice.CredentialId, "irma-demo.RU.studentCard")
@@ -424,6 +506,30 @@ func testOpenID4VP_YiviScheme_OptionalCredential(
 		plan.IssueDuringDislosure.IssuedCredentialIds,
 	)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 1}, expectedPickOne{optional: true, obtainable: 1})
+
+	// check obtainable option for required pick-one (studentCard)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"university"},
+				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			},
+		},
+	})
+
+	// check obtainable option for optional pick-one (fullName)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[1].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.MijnOverheid.fullName",
+		Name:         clientmodels.TranslatedString{"en": "Demo Name", "nl": "Demo Naam"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"firstname"},
+				DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			},
+		},
+	})
 
 	requiredChoice := plan.DisclosureChoicesOverview[0]
 
@@ -561,30 +667,21 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 
 	// the obtainable option shows the predefined university value as RequestedValue,
 	// and level as a requested attribute without a specific value
-	obtainable := plan.DisclosureChoicesOverview[0].ObtainableOptions[0]
-	require.Equal(t, "irma-demo.RU.studentCard", obtainable.CredentialId)
-	// Find the requested attributes (university and level) and verify their RequestedValue
-	var universityAttr, levelAttr *clientmodels.Attribute
-	for i := range obtainable.Attributes {
-		switch clientmodels.ClaimPathKey(obtainable.Attributes[i].ClaimPath) {
-		case pk("university"):
-			universityAttr = &obtainable.Attributes[i]
-		case pk("level"):
-			levelAttr = &obtainable.Attributes[i]
-		}
-	}
-	require.NotNil(t, universityAttr)
-	require.NotNil(t, universityAttr.RequestedValue)
-	require.Equal(t, &clientmodels.AttributeValue{
-		Type:   clientmodels.AttributeType_String,
-		String: &expectedUniversityValue,
-	}, universityAttr.RequestedValue)
-
-	require.NotNil(t, levelAttr)
-	require.NotNil(t, levelAttr.RequestedValue)
-	require.Equal(t, &clientmodels.AttributeValue{
-		Type: clientmodels.AttributeType_String,
-	}, levelAttr.RequestedValue)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:           []any{"university"},
+				DisplayName:    clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+				RequestedValue: strPtr("University of the Arts"),
+			},
+			{
+				Path:        []any{"level"},
+				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			},
+		},
+	})
 
 	// issuance session ended
 	session = awaitSessionState(t, sessionHandler)
@@ -749,6 +846,49 @@ func testOpenID4VP_YiviScheme_ComplexChoices_NoClaimIds(
 	)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 2}, expectedPickOne{owned: 1, obtainable: 1})
 
+	// check obtainable options for first pick-one (email || studentCard)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "test.test.email",
+		Name:         clientmodels.TranslatedString{"en": "Demo Email address", "nl": "Demo E-mailadres"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"email"},
+				DisplayName: clientmodels.TranslatedString{"en": "Email address", "nl": "E-mailadres"},
+			},
+		},
+	})
+
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[1], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"university"},
+				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			},
+			{
+				Path:        []any{"level"},
+				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			},
+		},
+	})
+
+	// check obtainable option for second pick-one (name)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[1].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.MijnOverheid.fullName",
+		Name:         clientmodels.TranslatedString{"en": "Demo Name", "nl": "Demo Naam"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"firstname"},
+				DisplayName: clientmodels.TranslatedString{"en": "First name", "nl": "Voornaam"},
+			},
+			{
+				Path:        []any{"familyname"},
+				DisplayName: clientmodels.TranslatedString{"en": "Family name", "nl": "Achternaam"},
+			},
+		},
+	})
+
 	firstChoice := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 
 	require.Equal(t, firstChoice.CredentialId, "irma-demo.RU.studentCard")
@@ -881,6 +1021,22 @@ func testOpenID4VP_YiviScheme_ClaimSets(
 		plan.IssueDuringDislosure.IssuedCredentialIds,
 	)
 	requireDisclosureChoices(t, plan, expectedPickOne{owned: 1, obtainable: 1})
+
+	// check obtainable option for studentCard with university and level (first claim_set)
+	requireObtainableOption(t, plan.DisclosureChoicesOverview[0].ObtainableOptions[0], expectedObtainable{
+		CredentialId: "irma-demo.RU.studentCard",
+		Name:         clientmodels.TranslatedString{"en": "Demo Student Card", "nl": "Demo Studentenkaart"},
+		Attributes: []expectedRequestedAttr{
+			{
+				Path:        []any{"university"},
+				DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			},
+			{
+				Path:        []any{"level"},
+				DisplayName: clientmodels.TranslatedString{"en": "Type", "nl": "Soort"},
+			},
+		},
+	})
 
 	// issuance session ended
 	session = awaitSessionState(t, sessionHandler)

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -640,7 +640,7 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 		expectedAttr{
 			Path:        []any{"university"},
 			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
-			Value:       "Some Other University",
+			Value:       strVal("Some Other University"),
 		},
 	)
 	require.Equal(t, &expectedUniversityValue, wrongCred.Attributes[0].RequestedValue.String)

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -1003,7 +1003,12 @@ func testOpenID4VP_YiviScheme_MultipleInstances_AttributeOrdering(
 	// Verify that each issued credential is present (order of owned options may differ from issuance order)
 	foundUniversities := map[string]bool{}
 	for _, option := range pick.OwnedOptions {
-		foundUniversities[*option.Attributes[0].Value.String] = true
+		am := attributeMap(option.Attributes)
+		uni, ok := am[pk("university")]
+		require.True(t, ok, "option should have university attribute")
+		require.NotNil(t, uni.Value)
+		require.NotNil(t, uni.Value.String)
+		foundUniversities[*uni.Value.String] = true
 	}
 	for _, attrs := range studentCards {
 		require.True(t, foundUniversities[attrs["university"]],
@@ -1018,12 +1023,13 @@ func testOpenID4VP_YiviScheme_MultipleInstances_AttributeOrdering(
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 4, clientmodels.Type_Disclosure, clientmodels.Status_Success)
 
+	chosenAttrs := attributeMap(chosen.Attributes)
 	requireVerifierResult(t, testSession.VerifierSession, expectedVpToken{
 		"sc": {
-			"university":        *chosen.Attributes[0].Value.String,
-			"studentCardNumber": *chosen.Attributes[1].Value.String,
-			"studentID":         *chosen.Attributes[2].Value.String,
-			"level":             *chosen.Attributes[3].Value.String,
+			"university":        *chosenAttrs[pk("university")].Value.String,
+			"studentCardNumber": *chosenAttrs[pk("studentCardNumber")].Value.String,
+			"studentID":         *chosenAttrs[pk("studentID")].Value.String,
+			"level":             *chosenAttrs[pk("level")].Value.String,
 		},
 	})
 }

--- a/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_irma_sdjwt_disclosure_test.go
@@ -531,7 +531,11 @@ func testOpenID4VP_YiviScheme_PredefinedClaimValues(
 	require.Equal(t, "irma-demo.RU.studentCard", wrongCred.CredentialId)
 	// only university (which has a pre-defined value that doesn't match), not level
 	requireAttrsInOrder(t, wrongCred.Attributes,
-		expectedAttr{Path: []any{"university"}, DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"}, Value: "Some Other University"},
+		expectedAttr{
+			Path:        []any{"university"},
+			DisplayName: clientmodels.TranslatedString{"en": "University", "nl": "Universiteit"},
+			Value:       "Some Other University",
+		},
 	)
 	require.Equal(t, &expectedUniversityValue, wrongCred.Attributes[0].RequestedValue.String)
 

--- a/internal/sessiontest/openid4vp_veramo_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_veramo_disclosure_test.go
@@ -2278,22 +2278,6 @@ func attributeMap(attrs []clientmodels.Attribute) map[string]clientmodels.Attrib
 	return m
 }
 
-// requireAttribute asserts that an attribute exists with the expected display
-// names and value.
-func requireAttribute(t *testing.T, attrs map[string]clientmodels.Attribute, attrId string, displayNames clientmodels.TranslatedString, expectedValue string) {
-	t.Helper()
-	attr, ok := attrs[attrId]
-	require.True(t, ok, "attribute %q should exist", attrId)
-	for locale, expected := range displayNames {
-		actual, ok := attr.DisplayName[locale]
-		require.True(t, ok, "attribute %q should have display name for locale %q", attrId, locale)
-		require.Equal(t, expected, actual, "attribute %q display name [%s] mismatch", attrId, locale)
-	}
-	require.NotNil(t, attr.Value, "attribute %q should have a value", attrId)
-	require.NotNil(t, attr.Value.String, "attribute %q should have a String value", attrId)
-	require.Equal(t, expectedValue, *attr.Value.String, "attribute %q value mismatch", attrId)
-}
-
 // startOpenID4VPDisclosureSession starts an OpenID4VP disclosure session in the
 // client using the given verifier request URI.
 func startOpenID4VPDisclosureSession(t *testing.T, c *client.Client, requestUri string) {

--- a/internal/sessiontest/openid4vp_veramo_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_veramo_disclosure_test.go
@@ -44,6 +44,7 @@ func testSessionHandlerForOpenId4VpWithSdJwtVcs(t *testing.T) {
 	t.Run("no claims requested shares only non-sd claims", testNoClaimsRequestedSharesOnlyNonSdClaims)
 	t.Run("duplicate claims ignored", testDuplicateClaimsIgnored)
 	t.Run("duplicate nested claims ignored", testDuplicateNestedClaimsIgnored)
+	t.Run("requireDisclosurePlan only checks first option", testRequireDisclosurePlanOnlyChecksFirstOption)
 	t.Run("disclose without holder binding", testDiscloseWithoutHolderBinding)
 	t.Run("verifier display name", testVerifierDisplayName)
 	t.Run("eudi verifier requesting veramo credential fails", testEudiVerifierRequestingVeramoCredentialFails)
@@ -91,15 +92,11 @@ func testIssueViaOid4VciAndDiscloseViaOid4Vp(t *testing.T) {
 
 	// Step 4: Verify the disclosure plan and grant permission.
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Name: "", Attributes: map[string]expectedPlanAttribute{"given_name": {Value: "Test", DisplayName: "Given Name"}, "email": {Value: "test@example.com", DisplayName: "Email"}}},
+		{Name: "", Attributes: map[string]expectedPlanAttribute{pk("given_name"): {Value: "Test", DisplayName: "Given Name"}, pk("email"): {Value: "test@example.com", DisplayName: "Email"}}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -108,10 +105,10 @@ func testIssueViaOid4VciAndDiscloseViaOid4Vp(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "test-credential", map[string]string{
-		"given_name": "Test",
-		"email":      "test@example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "test-credential",
+		claim([]any{"given_name"}, "Test"),
+		claim([]any{"email"}, "test@example.com"),
+	)
 }
 
 // testDiscloseCredentialWithMultipleAttributes issues an EmailCredential and
@@ -153,15 +150,11 @@ func testDiscloseCredentialWithMultipleAttributes(t *testing.T) {
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"email": {Value: "alice@example.com", DisplayName: "Email"}, "domain": {Value: "example.com", DisplayName: "Domain"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("email"): {Value: "alice@example.com", DisplayName: "Email"}, pk("domain"): {Value: "example.com", DisplayName: "Domain"}}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -169,10 +162,10 @@ func testDiscloseCredentialWithMultipleAttributes(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{
-		"email":  "alice@example.com",
-		"domain": "example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "alice@example.com"),
+		claim([]any{"domain"}, "example.com"),
+	)
 }
 
 // testChoiceBetweenTwoCredentialTypes issues both an EmailCredential and a
@@ -242,23 +235,17 @@ func testChoiceBetweenTwoCredentialTypes(t *testing.T) {
 	// Verify that each option has the expected attribute values.
 	for _, opt := range pickOne.OwnedOptions {
 		attrMap := attributeMap(opt.Attributes)
-		if _, hasEmail := attrMap["email"]; hasEmail {
-			require.NotNil(t, attrMap["email"].Value)
-			require.Equal(t, "bob@example.com", *attrMap["email"].Value.String)
+		if _, hasEmail := attrMap[pk("email")]; hasEmail {
+			requireAttr(t, attrMap, []any{"email"}, "bob@example.com")
 		}
-		if _, hasPhone := attrMap["phone_number"]; hasPhone {
-			require.NotNil(t, attrMap["phone_number"].Value)
-			require.Equal(t, "+31612345678", *attrMap["phone_number"].Value.String)
+		if _, hasPhone := attrMap[pk("phone_number")]; hasPhone {
+			requireAttr(t, attrMap, []any{"phone_number"}, "+31612345678")
 		}
 	}
 
 	// Pick the first option (whichever it is) and disclose.
 	chosen := pickOne.OwnedOptions[0]
-	attrIds := make([]string, len(chosen.Attributes))
-	for i, attr := range chosen.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(chosen, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(chosen))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -269,10 +256,10 @@ func testChoiceBetweenTwoCredentialTypes(t *testing.T) {
 
 	// Verify the verifier received attributes for the chosen credential.
 	chosenAttrs := attributeMap(chosen.Attributes)
-	if _, hasEmail := chosenAttrs["email"]; hasEmail {
-		requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{"email": "bob@example.com"})
+	if _, hasEmail := chosenAttrs[pk("email")]; hasEmail {
+		requireVerifierReceivedClaims(t, result, "email-cred", claim([]any{"email"}, "bob@example.com"))
 	} else {
-		requireVerifierReceivedAttributes(t, result, "phone-cred", map[string]string{"phone_number": "+31612345678"})
+		requireVerifierReceivedClaims(t, result, "phone-cred", claim([]any{"phone_number"}, "+31612345678"))
 	}
 }
 
@@ -331,18 +318,14 @@ func testMultipleRequiredCredentials(t *testing.T) {
 	// Two separate disclosure choices, one for each required credential.
 	// The order depends on the DCQL query order, but both should have matching credentials.
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"email": {Value: "carol@example.com", DisplayName: "Email"}}},
-		{Attributes: map[string]expectedPlanAttribute{"phone_number": {Value: "+31687654321", DisplayName: "Phone Number"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("email"): {Value: "carol@example.com", DisplayName: "Email"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("phone_number"): {Value: "+31687654321", DisplayName: "Phone Number"}}},
 	})
 
 	choices := make([]clientmodels.DisclosureDisconSelection, 2)
 	for i, pickOne := range session.DisclosurePlan.DisclosureChoicesOverview {
 		cred := pickOne.OwnedOptions[0]
-		attrIds := make([]string, len(cred.Attributes))
-		for j, attr := range cred.Attributes {
-			attrIds[j] = attr.Id
-		}
-		choices[i] = makeDisclosureChoice(cred, attrIds...)
+		choices[i] = makeDisclosureChoice(cred)
 	}
 	grantPermission(t, c, session.Id, choices...)
 
@@ -352,8 +335,8 @@ func testMultipleRequiredCredentials(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{"email": "carol@example.com"})
-	requireVerifierReceivedAttributes(t, result, "phone-cred", map[string]string{"phone_number": "+31687654321"})
+	requireVerifierReceivedClaims(t, result, "email-cred", claim([]any{"email"}, "carol@example.com"))
+	requireVerifierReceivedClaims(t, result, "phone-cred", claim([]any{"phone_number"}, "+31687654321"))
 }
 
 // testOptionalCredential issues only an EmailCredential. The DCQL query has
@@ -408,19 +391,15 @@ func testOptionalCredential(t *testing.T) {
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"email": {Value: "dave@example.com", DisplayName: "Email"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("email"): {Value: "dave@example.com", DisplayName: "Email"}}},
 		{Attributes: map[string]expectedPlanAttribute{}}, // optional phone (may have no owned options)
 	})
 
 	emailCred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(emailCred.Attributes))
-	for i, attr := range emailCred.Attributes {
-		attrIds[i] = attr.Id
-	}
 
 	// Grant permission with the required email credential; skip the optional phone with an empty selection.
 	grantPermission(t, c, session.Id,
-		makeDisclosureChoice(emailCred, attrIds...),
+		makeDisclosureChoice(emailCred),
 		clientmodels.DisclosureDisconSelection{},
 	)
 
@@ -430,7 +409,7 @@ func testOptionalCredential(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{"email": "dave@example.com"})
+	requireVerifierReceivedClaims(t, result, "email-cred", claim([]any{"email"}, "dave@example.com"))
 }
 
 // testCredentialWithSpecificClaimValue issues two EmailCredentials with
@@ -487,7 +466,7 @@ func testCredentialWithSpecificClaimValue(t *testing.T) {
 	var matchingCred *clientmodels.SelectableCredentialInstance
 	for _, opt := range plan.DisclosureChoicesOverview[0].OwnedOptions {
 		attrMap := attributeMap(opt.Attributes)
-		if attr, ok := attrMap["domain"]; ok && attr.Value != nil &&
+		if attr, ok := attrMap[pk("domain")]; ok && attr.Value != nil &&
 			attr.Value.String != nil && *attr.Value.String == "example.com" {
 			matchingCred = opt
 			break
@@ -496,14 +475,10 @@ func testCredentialWithSpecificClaimValue(t *testing.T) {
 	require.NotNil(t, matchingCred, "should find a credential with domain example.com")
 
 	attrMap := attributeMap(matchingCred.Attributes)
-	require.Equal(t, "eve@example.com", *attrMap["email"].Value.String)
-	require.Equal(t, "example.com", *attrMap["domain"].Value.String)
+	requireAttr(t, attrMap, []any{"email"}, "eve@example.com")
+	requireAttr(t, attrMap, []any{"domain"}, "example.com")
 
-	attrIds := make([]string, len(matchingCred.Attributes))
-	for i, attr := range matchingCred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(matchingCred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(matchingCred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -511,10 +486,10 @@ func testCredentialWithSpecificClaimValue(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{
-		"email":  "eve@example.com",
-		"domain": "example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "eve@example.com"),
+		claim([]any{"domain"}, "example.com"),
+	)
 }
 
 // testDiscloseNestedClaims issues a HouseCredential with a nested address object
@@ -561,15 +536,11 @@ func testDiscloseNestedClaims(t *testing.T) {
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"owner_name": {Value: "Frank", DisplayName: "Owner Name"}, "street": {Value: "10 Downing St"}, "city": {Value: "London"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("owner_name"): {Value: "Frank", DisplayName: "Owner Name"}, pk("address", "street"): {Value: "10 Downing St"}, pk("address", "city"): {Value: "London"}}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -577,11 +548,11 @@ func testDiscloseNestedClaims(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	// The veramo-verifier only extracts top-level SD claims; nested claims
-	// (address.street, address.city) are not extracted by the verifier.
-	requireVerifierReceivedAttributes(t, result, "house-cred", map[string]string{
-		"owner_name": "Frank",
-	})
+	requireVerifierReceivedClaims(t, result, "house-cred",
+		claim([]any{"owner_name"}, "Frank"),
+		claim([]any{"address", "street"}, "10 Downing St"),
+		claim([]any{"address", "city"}, "London"),
+	)
 }
 
 // testDiscloseCredentialWithArrayValues issues a StudentCardCredential that
@@ -623,23 +594,15 @@ func testDiscloseCredentialWithArrayValues(t *testing.T) {
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
-	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"university": {Value: "TU Delft", DisplayName: "University"}, "courses": {Type: clientmodels.AttributeType_Array, DisplayName: "Courses"}}},
-	})
-
-	// Verify the array contains all three course values.
+	// Arrays are expanded into individual elements with indexed paths.
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	coursesAttr := attributeMap(cred.Attributes)["courses"]
-	require.NotNil(t, coursesAttr.Value)
-	require.Len(t, coursesAttr.Value.Array, 3)
-	require.Equal(t, "Algorithms", *coursesAttr.Value.Array[0].String)
-	require.Equal(t, "Databases", *coursesAttr.Value.Array[1].String)
-	require.Equal(t, "Networks", *coursesAttr.Value.Array[2].String)
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	am := attributeMap(cred.Attributes)
+	requireAttr(t, am, []any{"university"}, "TU Delft")
+	requireAttr(t, am, []any{"courses", 0}, "Algorithms")
+	requireAttr(t, am, []any{"courses", 1}, "Databases")
+	requireAttr(t, am, []any{"courses", 2}, "Networks")
+
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -647,9 +610,10 @@ func testDiscloseCredentialWithArrayValues(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "student-cred", map[string]string{
-		"university": "TU Delft",
-	})
+	requireVerifierReceivedClaims(t, result, "student-cred",
+		claim([]any{"university"}, "TU Delft"),
+		claim([]any{"courses"}, "[Algorithms Databases Networks]"),
+	)
 }
 
 // testDiscloseSpecificArrayElement issues a StudentCardCredential with a courses
@@ -692,15 +656,11 @@ func testDiscloseSpecificArrayElement(t *testing.T) {
 
 	// Path ["courses", 1] resolves to a specific element ("Databases"), not the whole array.
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"courses": {Value: "Databases", Type: clientmodels.AttributeType_String, DisplayName: "Courses"}}},
+		{Attributes: map[string]expectedPlanAttribute{pk("courses", 1): {Value: "Databases", Type: clientmodels.AttributeType_String, DisplayName: "Courses"}}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -708,6 +668,11 @@ func testDiscloseSpecificArrayElement(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
+	// The verifier receives the full courses array even when a specific element
+	// was requested, because the SD-JWT disclosure reveals the whole array.
+	requireVerifierReceivedClaims(t, result, "student-cred",
+		claim([]any{"courses"}, "[Algorithms Databases Networks]"),
+	)
 }
 
 // testDiscloseAllArrayElementsWithNullPath issues a StudentCardCredential with
@@ -748,24 +713,14 @@ func testDiscloseAllArrayElementsWithNullPath(t *testing.T) {
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
-	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
-		{Attributes: map[string]expectedPlanAttribute{"courses": {Type: clientmodels.AttributeType_Array, DisplayName: "Courses"}}},
-	})
-
-	// Verify the full array is present when requesting all elements via null path.
+	// Null path expands into individual elements with indexed paths.
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	coursesAttr := attributeMap(cred.Attributes)["courses"]
-	require.NotNil(t, coursesAttr.Value)
-	require.Len(t, coursesAttr.Value.Array, 3)
-	require.Equal(t, "Algorithms", *coursesAttr.Value.Array[0].String)
-	require.Equal(t, "Databases", *coursesAttr.Value.Array[1].String)
-	require.Equal(t, "Networks", *coursesAttr.Value.Array[2].String)
+	am := attributeMap(cred.Attributes)
+	requireAttr(t, am, []any{"courses", 0}, "Algorithms")
+	requireAttr(t, am, []any{"courses", 1}, "Databases")
+	requireAttr(t, am, []any{"courses", 2}, "Networks")
 
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -773,6 +728,9 @@ func testDiscloseAllArrayElementsWithNullPath(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
+	requireVerifierReceivedClaims(t, result, "student-cred",
+		claim([]any{"courses"}, "[Algorithms Databases Networks]"),
+	)
 }
 
 // testNonSdClaimsShownInDisclosurePlan issues a MembershipCredential where
@@ -818,17 +776,13 @@ func testNonSdClaimsShownInDisclosurePlan(t *testing.T) {
 	// member_since (non-SD claim that is always shared).
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
 		{Attributes: map[string]expectedPlanAttribute{
-			"member_name":  {Value: "Grace", DisplayName: "Member Name"},
-			"member_since": {Value: "2020-01-15", DisplayName: "Member Since"},
+			pk("member_name"):  {Value: "Grace", DisplayName: "Member Name"},
+			pk("member_since"): {Value: "2020-01-15", DisplayName: "Member Since"},
 		}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -836,9 +790,10 @@ func testNonSdClaimsShownInDisclosurePlan(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "membership-cred", map[string]string{
-		"member_name": "Grace",
-	})
+	requireVerifierReceivedClaims(t, result, "membership-cred",
+		claim([]any{"member_name"}, "Grace"),
+		claim([]any{"member_since"}, "2020-01-15"),
+	)
 }
 
 // testIssueManyCredentialsAndDiscloseSubset issues four different SD-JWT
@@ -912,12 +867,12 @@ func testIssueManyCredentialsAndDiscloseSubset(t *testing.T) {
 	// Exactly two disclosure choices: one for email, one for student card.
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
 		{Attributes: map[string]expectedPlanAttribute{
-			"email":  {Value: "multi@example.com", DisplayName: "Email"},
-			"domain": {Value: "example.com", DisplayName: "Domain"},
+			pk("email"):  {Value: "multi@example.com", DisplayName: "Email"},
+			pk("domain"): {Value: "example.com", DisplayName: "Domain"},
 		}},
 		{Attributes: map[string]expectedPlanAttribute{
-			"university": {Value: "Radboud University", DisplayName: "University"},
-			"student_id": {Value: "s1234567", DisplayName: "Student ID"},
+			pk("university"): {Value: "Radboud University", DisplayName: "University"},
+			pk("student_id"): {Value: "s1234567", DisplayName: "Student ID"},
 		}},
 	})
 
@@ -925,11 +880,7 @@ func testIssueManyCredentialsAndDiscloseSubset(t *testing.T) {
 	choices := make([]clientmodels.DisclosureDisconSelection, 2)
 	for i, pickOne := range session.DisclosurePlan.DisclosureChoicesOverview {
 		cred := pickOne.OwnedOptions[0]
-		attrIds := make([]string, len(cred.Attributes))
-		for j, attr := range cred.Attributes {
-			attrIds[j] = attr.Id
-		}
-		choices[i] = makeDisclosureChoice(cred, attrIds...)
+		choices[i] = makeDisclosureChoice(cred)
 	}
 	grantPermission(t, c, session.Id, choices...)
 
@@ -940,14 +891,14 @@ func testIssueManyCredentialsAndDiscloseSubset(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{
-		"email":  "multi@example.com",
-		"domain": "example.com",
-	})
-	requireVerifierReceivedAttributes(t, result, "student-cred", map[string]string{
-		"university": "Radboud University",
-		"student_id": "s1234567",
-	})
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "multi@example.com"),
+		claim([]any{"domain"}, "example.com"),
+	)
+	requireVerifierReceivedClaims(t, result, "student-cred",
+		claim([]any{"university"}, "Radboud University"),
+		claim([]any{"student_id"}, "s1234567"),
+	)
 
 	// The verifier should NOT have received Phone or House credentials.
 	require.NotContains(t, result.Result.Credentials, "phone-cred",
@@ -1009,19 +960,15 @@ func testIssueAndDiscloseEduIdCredential(t *testing.T) {
 
 	requireDisclosurePlan(t, session.DisclosurePlan, []expectedPlanCredential{
 		{Attributes: map[string]expectedPlanAttribute{
-			"given_name":              {Value: "Jan", DisplayName: "Given name"},
-			"family_name":             {Value: "de Vries", DisplayName: "Family name"},
-			"email":                   {Value: "jan.devries@university.nl", DisplayName: "E-mail"},
-			"schac_home_organization": {Value: "university.nl", DisplayName: "Organization"},
+			pk("given_name"):              {Value: "Jan", DisplayName: "Given name"},
+			pk("family_name"):             {Value: "de Vries", DisplayName: "Family name"},
+			pk("email"):                   {Value: "jan.devries@university.nl", DisplayName: "E-mail"},
+			pk("schac_home_organization"): {Value: "university.nl", DisplayName: "Organization"},
 		}},
 	})
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -1029,12 +976,13 @@ func testIssueAndDiscloseEduIdCredential(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "eduid-credential", map[string]string{
-		"given_name":              "Jan",
-		"family_name":             "de Vries",
-		"email":                   "jan.devries@university.nl",
-		"schac_home_organization": "university.nl",
-	})
+	requireVerifierReceivedClaims(t, result, "eduid-credential",
+		claim([]any{"given_name"}, "Jan"),
+		claim([]any{"family_name"}, "de Vries"),
+		claim([]any{"email"}, "jan.devries@university.nl"),
+		claim([]any{"schac_home_organization"}, "university.nl"),
+		claim([]any{"eduperson_assurance"}, "https://eduid.nl/assurance/low"), // non-SD, always shared
+	)
 }
 
 // testClaimSetsPicksFirstSatisfiableSet issues an EmailCredential and uses a
@@ -1088,15 +1036,9 @@ func testClaimSetsPicksFirstSatisfiableSet(t *testing.T) {
 	// The first claim set ["em"] should be selected, so only email is a requested
 	// attribute. Domain may appear as a non-SD claim but the primary requested
 	// attribute should be email.
-	_, hasEmail := attrMap["email"]
-	require.True(t, hasEmail, "email should be in the disclosure plan")
-	require.Equal(t, "claimsets@example.com", *attrMap["email"].Value.String)
+	requireAttr(t, attrMap, []any{"email"}, "claimsets@example.com")
 
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -1104,9 +1046,9 @@ func testClaimSetsPicksFirstSatisfiableSet(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "email-cred", map[string]string{
-		"email": "claimsets@example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "claimsets@example.com"),
+	)
 }
 
 // testMultipleVctValuesMatchesAcrossTypes issues an EmailCredential and a
@@ -1165,7 +1107,7 @@ func testMultipleVctValuesMatchesAcrossTypes(t *testing.T) {
 	var emailCred *clientmodels.SelectableCredentialInstance
 	for _, opt := range plan.DisclosureChoicesOverview[0].OwnedOptions {
 		attrMap := attributeMap(opt.Attributes)
-		if attr, ok := attrMap["email"]; ok && attr.Value != nil &&
+		if attr, ok := attrMap[pk("email")]; ok && attr.Value != nil &&
 			attr.Value.String != nil && *attr.Value.String == "vct@example.com" {
 			emailCred = opt
 			break
@@ -1173,11 +1115,7 @@ func testMultipleVctValuesMatchesAcrossTypes(t *testing.T) {
 	}
 	require.NotNil(t, emailCred, "should find the email credential as a candidate")
 
-	attrIds := make([]string, len(emailCred.Attributes))
-	for i, attr := range emailCred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(emailCred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -1185,9 +1123,9 @@ func testMultipleVctValuesMatchesAcrossTypes(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should have received or verified the response")
-	requireVerifierReceivedAttributes(t, result, "contact-cred", map[string]string{
-		"email": "vct@example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "contact-cred",
+		claim([]any{"email"}, "vct@example.com"),
+	)
 }
 
 // testBooleanClaimValueConstraint issues two eduID credentials with different
@@ -1268,28 +1206,23 @@ func testBooleanClaimValueConstraint(t *testing.T) {
 	// All matching credentials should have is_student=true.
 	for _, opt := range plan.DisclosureChoicesOverview[0].OwnedOptions {
 		attrMap := attributeMap(opt.Attributes)
-		attr, ok := attrMap["given_name"]
-		require.True(t, ok)
 		// The matching credential should be "Student", not "Staff".
-		require.Equal(t, "Student", *attr.Value.String,
-			"only the credential with is_student=true should match the value constraint")
+		requireAttr(t, attrMap, []any{"given_name"}, "Student")
 	}
 
 	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
 
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status)
-	requireVerifierReceivedAttributes(t, result, "eduid-student", map[string]string{
-		"given_name": "Student",
-	})
+	requireVerifierReceivedClaims(t, result, "eduid-student",
+		claim([]any{"given_name"}, "Student"),
+		claim([]any{"is_student"}, "true"),
+		claim([]any{"eduperson_assurance"}, "https://eduid.nl/assurance/low"), // non-SD, always shared
+	)
 }
 
 // testMultipleCredentialsForSameQuery issues two email credentials, then creates
@@ -1345,7 +1278,7 @@ func testMultipleCredentialsForSameQuery(t *testing.T) {
 	for _, opt := range pickOne.OwnedOptions {
 		attrIds := make([][]any, len(opt.Attributes))
 		for i, attr := range opt.Attributes {
-			attrIds[i] = []any{attr.Id}
+			attrIds[i] = attr.ClaimPath
 		}
 		selectedCreds = append(selectedCreds, clientmodels.SelectedCredential{
 			CredentialId:   opt.CredentialId,
@@ -1426,16 +1359,12 @@ func testNoClaimsRequestedSharesOnlyNonSdClaims(t *testing.T) {
 	// "member_since" is non-SD, while "member_name" and "membership_type" are SD.
 	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	attrMap := attributeMap(cred.Attributes)
-	require.Contains(t, attrMap, "member_since", "non-SD claim member_since should be in the disclosure plan")
-	require.NotContains(t, attrMap, "member_name", "SD claim member_name should NOT be in the plan when claims is absent")
-	require.NotContains(t, attrMap, "membership_type", "SD claim membership_type should NOT be in the plan when claims is absent")
+	require.Contains(t, attrMap, pk("member_since"), "non-SD claim member_since should be in the disclosure plan")
+	requireNoAttr(t, attrMap, []any{"member_name"})
+	requireNoAttr(t, attrMap, []any{"membership_type"})
 
 	// Disclose with whatever attributes are available (only non-SD).
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -1487,35 +1416,39 @@ func testDuplicateClaimsIgnored(t *testing.T) {
 	require.Len(t, plan.DisclosureChoicesOverview, 1)
 	require.NotEmpty(t, plan.DisclosureChoicesOverview[0].OwnedOptions)
 
+	requireDisclosurePlan(t, plan, []expectedPlanCredential{
+		{Attributes: map[string]expectedPlanAttribute{
+			pk("email"):  {Value: "dup@example.com"},
+			pk("domain"): {Value: "example.com"},
+		}},
+	})
+
 	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	attrMap := attributeMap(cred.Attributes)
 
 	// "email" should appear exactly once despite being listed twice in the query.
 	emailCount := 0
 	for _, attr := range cred.Attributes {
-		if attr.Id == "email" {
+		if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("email") {
 			emailCount++
 		}
 	}
 	require.Equal(t, 1, emailCount, "duplicate email claim should be deduplicated")
-	require.Equal(t, "dup@example.com", *attrMap["email"].Value.String)
-	require.Equal(t, "example.com", *attrMap["domain"].Value.String)
+	requireAttr(t, attrMap, []any{"email"}, "dup@example.com")
+	requireAttr(t, attrMap, []any{"domain"}, "example.com")
 
 	// Disclose and verify the session completes.
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
 
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status)
-	requireVerifierReceivedAttributes(t, result, "email-dup", map[string]string{
-		"email": "dup@example.com",
-	})
+	requireVerifierReceivedClaims(t, result, "email-dup",
+		claim([]any{"email"}, "dup@example.com"),
+		claim([]any{"domain"}, "example.com"),
+	)
 }
 
 // testDuplicateNestedClaimsIgnored issues a HouseCredential with nested address
@@ -1566,16 +1499,24 @@ func testDuplicateNestedClaimsIgnored(t *testing.T) {
 	require.Len(t, plan.DisclosureChoicesOverview, 1)
 	require.NotEmpty(t, plan.DisclosureChoicesOverview[0].OwnedOptions)
 
+	requireDisclosurePlan(t, plan, []expectedPlanCredential{
+		{Attributes: map[string]expectedPlanAttribute{
+			pk("owner_name"):        {Value: "Duplicate Tester"},
+			pk("address", "street"): {Value: "Kalverstraat 1"},
+			pk("address", "city"):   {Value: "Amsterdam"},
+		}},
+	})
+
 	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
 
 	// Count occurrences of "street" — should be exactly 1 despite the duplicate.
 	streetCount := 0
 	cityCount := 0
 	for _, attr := range cred.Attributes {
-		if attr.Id == "street" {
+		if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("address", "street") {
 			streetCount++
 		}
-		if attr.Id == "city" {
+		if clientmodels.ClaimPathKey(attr.ClaimPath) == pk("address", "city") {
 			cityCount++
 		}
 	}
@@ -1583,22 +1524,94 @@ func testDuplicateNestedClaimsIgnored(t *testing.T) {
 	require.Equal(t, 1, cityCount, "['address','city'] should appear once")
 
 	attrMap := attributeMap(cred.Attributes)
-	require.Equal(t, "Duplicate Tester", *attrMap["owner_name"].Value.String)
-	require.Equal(t, "Kalverstraat 1", *attrMap["street"].Value.String)
-	require.Equal(t, "Amsterdam", *attrMap["city"].Value.String)
+	requireAttr(t, attrMap, []any{"owner_name"}, "Duplicate Tester")
+	requireAttr(t, attrMap, []any{"address", "street"}, "Kalverstraat 1")
+	requireAttr(t, attrMap, []any{"address", "city"}, "Amsterdam")
 
 	// Disclose and verify success.
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
 
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status)
+	requireVerifierReceivedClaims(t, result, "house-dup",
+		claim([]any{"owner_name"}, "Duplicate Tester"),
+		claim([]any{"address", "street"}, "Kalverstraat 1"),
+		claim([]any{"address", "city"}, "Amsterdam"),
+	)
+}
+
+// testRequireDisclosurePlanOnlyChecksFirstOption demonstrates that
+// requireDisclosurePlan only validates OwnedOptions[0] and ignores the rest.
+// This test issues two email credentials, but requireDisclosurePlan only sees
+// the first one — it doesn't verify the count or the second credential.
+func testRequireDisclosurePlanOnlyChecksFirstOption(t *testing.T) {
+	c, sessionHandler := createClientWithoutKeyshareEnrollment(t, nil)
+	defer c.Close()
+
+	// Issue two email credentials with different addresses.
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "EmailCredentialSdJwt", `{
+		"email": "alice@example.com",
+		"domain": "example.com"
+	}`)
+	issueCredentialViaOid4Vci(t, c, sessionHandler, "EmailCredentialSdJwt", `{
+		"email": "bob@example.com",
+		"domain": "example.com"
+	}`)
+
+	dcqlQuery := `{
+		"dcql": {
+			"credentials": [
+				{
+					"id": "email-cred",
+					"format": "dc+sd-jwt",
+					"meta": {
+						"vct_values": ["https://localhost:8443/vct/email"]
+					},
+					"claims": [
+						{ "path": ["email"] }
+					]
+				}
+			]
+		}
+	}`
+	veramoSession := createVeramoVerifierDcqlSessionWithQuery(t, dcqlQuery)
+	startOpenID4VPDisclosureSession(t, c, veramoSession.RequestUri)
+
+	session := awaitSessionState(t, sessionHandler)
+	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
+
+	plan := session.DisclosurePlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.DisclosureChoicesOverview, 1)
+
+	// There should be 2 owned options (alice and bob).
+	require.Len(t, plan.DisclosureChoicesOverview[0].OwnedOptions, 2,
+		"both email credentials should be candidates")
+
+	// BUG: requireDisclosurePlan only checks OwnedOptions[0] (alice).
+	// Asserting bob's email value should fail because the helper never looks at OwnedOptions[1].
+	requireDisclosurePlan(t, plan, []expectedPlanCredential{
+		{Attributes: map[string]expectedPlanAttribute{
+			pk("email"): {Value: "bob@example.com"},
+		}},
+	})
+
+	// Disclose the first option and verify the verifier received data.
+	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
+
+	session = awaitSessionState(t, sessionHandler)
+	requireSessionState(t, session, 3, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
+	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
+		"verifier session should have received or verified the response")
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "alice@example.com"),
+	)
 }
 
 // testDiscloseWithoutHolderBinding issues a credential, then creates a DCQL
@@ -1637,12 +1650,19 @@ func testDiscloseWithoutHolderBinding(t *testing.T) {
 	session := awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_RequestPermission)
 
-	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	plan := session.DisclosurePlan
+	require.NotNil(t, plan)
+	require.Len(t, plan.DisclosureChoicesOverview, 1)
+	require.NotEmpty(t, plan.DisclosureChoicesOverview[0].OwnedOptions)
+
+	requireDisclosurePlan(t, plan, []expectedPlanCredential{
+		{Attributes: map[string]expectedPlanAttribute{
+			pk("email"): {Value: "nokb@example.com"},
+		}},
+	})
+
+	cred := plan.DisclosureChoicesOverview[0].OwnedOptions[0]
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
@@ -1652,6 +1672,9 @@ func testDiscloseWithoutHolderBinding(t *testing.T) {
 	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
 	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status,
 		"verifier session should succeed without holder binding")
+	requireVerifierReceivedClaims(t, result, "email-no-kb",
+		claim([]any{"email"}, "nokb@example.com"),
+	)
 }
 
 // testVerifierDisplayName verifies that the verifier display name shown to the
@@ -1694,6 +1717,18 @@ func testVerifierDisplayName(t *testing.T) {
 		"verifier display name should come from client_name, not the raw DID")
 	require.False(t, session.Requestor.Verified,
 		"DID-based verifier should not be marked as verified (not verified by Yivi)")
+
+	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
+
+	session = awaitSessionState(t, sessionHandler)
+	requireSessionState(t, session, 2, clientmodels.Type_Disclosure, clientmodels.Status_Success)
+
+	result := checkVeramoVerifierOfferStatus(t, veramoSession.State)
+	require.Contains(t, []string{"VERIFIED", "RESPONSE_RECEIVED"}, result.Status)
+	requireVerifierReceivedClaims(t, result, "email-cred",
+		claim([]any{"email"}, "display@example.com"),
+	)
 }
 
 // testEudiVerifierRequestingVeramoCredentialFails issues a credential via the
@@ -1797,11 +1832,7 @@ func testVeramoVerifierRequestingIrmaCredentialFails(t *testing.T) {
 
 	// Grant permission to disclose the IRMA credential to the veramo verifier.
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	attrIds := make([]string, len(cred.Attributes))
-	for i, attr := range cred.Attributes {
-		attrIds[i] = attr.Id
-	}
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attrIds...))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 
@@ -1895,21 +1926,90 @@ type veramoMessage struct {
 	Message string `json:"message"`
 }
 
-// requireVerifierReceivedAttributes asserts that the veramo verifier received
-// the expected attribute values for a given credential query ID.
-// When the verifier fully verified the credential (status VERIFIED), the claim
-// values are checked. Otherwise only the query ID presence is asserted.
-func requireVerifierReceivedAttributes(t *testing.T, result veramoCheckResult, queryId string, expected map[string]string) {
+// expectedClaim is a claim path with its expected value.
+type expectedClaim struct {
+	Path  []any
+	Value string
+}
+
+// claim builds an expectedClaim from a path and value.
+func claim(path []any, value string) expectedClaim {
+	return expectedClaim{Path: path, Value: value}
+}
+
+// requireVerifierResult asserts that the veramo verifier received exactly the
+// expected claims for a given credential query ID — no more, no less. Each
+// expected claim is identified by its full path (navigating into nested objects
+// and arrays) and matched against the stringified value.
+//
+// Example:
+//
+//	requireVerifierReceivedClaims(t, result, "house-cred",
+//	    claim([]any{"owner_name"}, "Frank"),
+//	    claim([]any{"address", "street"}, "10 Downing St"),
+//	    claim([]any{"address", "city"}, "London"),
+//	)
+func requireVerifierReceivedClaims(t *testing.T, result veramoCheckResult, queryId string, expected ...expectedClaim) {
 	t.Helper()
 	require.NotNil(t, result.Result, "verifier result should not be nil")
 	creds, ok := result.Result.Credentials[queryId]
 	require.True(t, ok, "verifier should have credentials for query %q", queryId)
 	require.NotEmpty(t, creds, "verifier should have at least one credential for query %q", queryId)
-	for key, expectedVal := range expected {
-		actual, ok := creds[0].Claims[key]
-		require.True(t, ok, "verifier credential should have claim %q", key)
-		require.Equal(t, expectedVal, fmt.Sprintf("%v", actual), "verifier claim %q value mismatch", key)
+
+	claims := creds[0].Claims
+
+	// Check each expected claim exists with the right value.
+	for _, exp := range expected {
+		actual := navigateClaims(t, claims, exp.Path)
+		require.Equal(t, exp.Value, fmt.Sprintf("%v", actual),
+			"verifier claim at path %v value mismatch", exp.Path)
 	}
+
+	// Check no unexpected top-level claims exist (ignoring standard JWT claims).
+	standardClaims := map[string]struct{}{
+		"vct": {}, "iss": {}, "iat": {}, "exp": {}, "nbf": {}, "sub": {},
+		"cnf": {}, "_sd_alg": {}, "status": {},
+	}
+	expectedTopLevel := make(map[string]struct{})
+	for _, exp := range expected {
+		if len(exp.Path) > 0 {
+			if key, ok := exp.Path[0].(string); ok {
+				expectedTopLevel[key] = struct{}{}
+			}
+		}
+	}
+	for key := range claims {
+		if _, isStandard := standardClaims[key]; isStandard {
+			continue
+		}
+		_, isExpected := expectedTopLevel[key]
+		require.True(t, isExpected,
+			"verifier received unexpected claim %q for query %q", key, queryId)
+	}
+}
+
+// navigateClaims follows a claim path into a nested claims map.
+func navigateClaims(t *testing.T, claims map[string]any, path []any) any {
+	t.Helper()
+	var current any = claims
+	for i, component := range path {
+		switch key := component.(type) {
+		case string:
+			m, ok := current.(map[string]any)
+			require.True(t, ok, "expected object at path %v (step %d), got %T", path[:i], i, current)
+			current, ok = m[key]
+			require.True(t, ok, "claim %q not found at path %v", key, path[:i+1])
+		case int:
+			arr, ok := current.([]any)
+			require.True(t, ok, "expected array at path %v (step %d), got %T", path[:i], i, current)
+			require.True(t, key >= 0 && key < len(arr),
+				"index %d out of range at path %v (len=%d)", key, path[:i+1], len(arr))
+			current = arr[key]
+		default:
+			t.Fatalf("unsupported path component type %T at path %v", component, path[:i+1])
+		}
+	}
+	return current
 }
 
 func createVeramoVerifierDcqlSession(t *testing.T) veramoVerifierSession {
@@ -2002,7 +2102,8 @@ type expectedPlanCredential struct {
 
 // requireDisclosurePlan asserts the structure of a disclosure plan.
 // Each entry in expected corresponds to one DisclosurePickOne in order.
-// For each entry, the first OwnedOption is checked against the expected credential.
+// For each entry, the expected attributes must be found in at least one of the
+// OwnedOptions (not just the first).
 func requireDisclosurePlan(t *testing.T, plan *clientmodels.DisclosurePlan, expected []expectedPlanCredential) {
 	t.Helper()
 	require.NotNil(t, plan)
@@ -2018,34 +2119,91 @@ func requireDisclosurePlan(t *testing.T, plan *clientmodels.DisclosurePlan, expe
 
 		require.NotEmpty(t, pickOne.OwnedOptions, "choice %d should have owned options", i)
 
-		cred := pickOne.OwnedOptions[0]
+		// Find an owned option that satisfies ALL expected attributes.
+		var matched *clientmodels.SelectableCredentialInstance
+		for _, cred := range pickOne.OwnedOptions {
+			if credMatchesExpected(cred, exp) {
+				matched = cred
+				break
+			}
+		}
+		require.NotNil(t, matched,
+			"choice %d: no owned option matches expected attributes %v", i, expectedAttrSummary(exp))
+
+		// Now do the full assertions on the matched credential for clear error messages.
 		if exp.Name != "" {
-			actual, ok := cred.Name["en"]
+			actual, ok := matched.Name["en"]
 			require.True(t, ok, "choice %d credential should have English name", i)
 			require.Equal(t, exp.Name, actual, "choice %d credential name mismatch", i)
 		}
 
-		attrMap := attributeMap(cred.Attributes)
-		for attrId, exp := range exp.Attributes {
-			attr, ok := attrMap[attrId]
-			require.True(t, ok, "choice %d should have attribute %q", i, attrId)
-			if exp.Type != "" {
-				require.NotNil(t, attr.Value, "choice %d attribute %q should have a value", i, attrId)
-				require.Equal(t, exp.Type, attr.Value.Type,
-					"choice %d attribute %q type mismatch", i, attrId)
+		attrMap := attributeMap(matched.Attributes)
+		for attrKey, expAttr := range exp.Attributes {
+			attr, ok := attrMap[attrKey]
+			require.True(t, ok, "choice %d should have attribute %q", i, attrKey)
+			if expAttr.Type != "" {
+				require.NotNil(t, attr.Value, "choice %d attribute %q should have a value", i, attrKey)
+				require.Equal(t, expAttr.Type, attr.Value.Type,
+					"choice %d attribute %q type mismatch", i, attrKey)
 			}
-			if exp.Value != "" && attr.Value != nil && attr.Value.String != nil {
-				require.Equal(t, exp.Value, *attr.Value.String,
-					"choice %d attribute %q value mismatch", i, attrId)
+			if expAttr.Value != "" && attr.Value != nil && attr.Value.String != nil {
+				require.Equal(t, expAttr.Value, *attr.Value.String,
+					"choice %d attribute %q value mismatch", i, attrKey)
 			}
-			if exp.DisplayName != "" {
+			if expAttr.DisplayName != "" {
 				actual, ok := attr.DisplayName["en"]
-				require.True(t, ok, "choice %d attribute %q should have English display name", i, attrId)
-				require.Equal(t, exp.DisplayName, actual,
-					"choice %d attribute %q display name mismatch", i, attrId)
+				require.True(t, ok, "choice %d attribute %q should have English display name", i, attrKey)
+				require.Equal(t, expAttr.DisplayName, actual,
+					"choice %d attribute %q display name mismatch", i, attrKey)
 			}
 		}
 	}
+}
+
+// credMatchesExpected returns true if the credential has all expected attributes
+// with matching values.
+func credMatchesExpected(cred *clientmodels.SelectableCredentialInstance, exp expectedPlanCredential) bool {
+	if exp.Name != "" {
+		if name, ok := cred.Name["en"]; !ok || name != exp.Name {
+			return false
+		}
+	}
+	attrMap := attributeMap(cred.Attributes)
+	for attrKey, expAttr := range exp.Attributes {
+		attr, ok := attrMap[attrKey]
+		if !ok {
+			return false
+		}
+		if expAttr.Value != "" {
+			if attr.Value == nil || attr.Value.String == nil || *attr.Value.String != expAttr.Value {
+				return false
+			}
+		}
+		if expAttr.Type != "" {
+			if attr.Value == nil || attr.Value.Type != expAttr.Type {
+				return false
+			}
+		}
+		if expAttr.DisplayName != "" {
+			if actual, ok := attr.DisplayName["en"]; !ok || actual != expAttr.DisplayName {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// expectedAttrSummary returns a readable summary of expected attributes for error messages.
+func expectedAttrSummary(exp expectedPlanCredential) string {
+	parts := make([]string, 0, len(exp.Attributes))
+	for key, attr := range exp.Attributes {
+		if attr.Value != "" {
+			parts = append(parts, fmt.Sprintf("%s=%q", key, attr.Value))
+		} else {
+			parts = append(parts, key)
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // ---------------------------------------------------------------------------
@@ -2106,11 +2264,16 @@ func findCredentialByName(t *testing.T, creds []*clientmodels.Credential, locale
 	return nil
 }
 
-// attributeMap builds a map from attribute ID to Attribute for easy lookup.
+// pk is a shorthand for building a ClaimPathKey from path components.
+func pk(components ...any) string {
+	return clientmodels.ClaimPathKey(components)
+}
+
+// attributeMap builds a map from claim path key to Attribute for easy lookup.
 func attributeMap(attrs []clientmodels.Attribute) map[string]clientmodels.Attribute {
 	m := make(map[string]clientmodels.Attribute, len(attrs))
 	for _, a := range attrs {
-		m[a.Id] = a
+		m[clientmodels.ClaimPathKey(a.ClaimPath)] = a
 	}
 	return m
 }

--- a/internal/sessiontest/openid4vp_veramo_disclosure_test.go
+++ b/internal/sessiontest/openid4vp_veramo_disclosure_test.go
@@ -1937,10 +1937,15 @@ func claim(path []any, value string) expectedClaim {
 	return expectedClaim{Path: path, Value: value}
 }
 
-// requireVerifierResult asserts that the veramo verifier received exactly the
-// expected claims for a given credential query ID — no more, no less. Each
+// requireVerifierReceivedClaims asserts that the veramo verifier received exactly
+// the expected claims for a given credential query ID — no more, no less. Each
 // expected claim is identified by its full path (navigating into nested objects
 // and arrays) and matched against the stringified value.
+//
+// The function also rejects unexpected top-level claims (ignoring standard JWT
+// claims like vct, iss, iat, etc.). This means non-SD claims that are always
+// present in the JWT payload (e.g., eduperson_assurance) must be explicitly
+// included in the expected list, even if they weren't requested by the verifier.
 //
 // Example:
 //
@@ -2096,7 +2101,7 @@ type expectedPlanAttribute struct {
 type expectedPlanCredential struct {
 	// Expected credential name (checked against Name["en"]). Empty to skip check.
 	Name string
-	// Expected attributes: map from attribute ID to expected attribute properties.
+	// Expected attributes: map from claim path key to expected attribute properties.
 	Attributes map[string]expectedPlanAttribute
 }
 
@@ -2264,19 +2269,6 @@ func findCredentialByName(t *testing.T, creds []*clientmodels.Credential, locale
 	return nil
 }
 
-// pk is a shorthand for building a ClaimPathKey from path components.
-func pk(components ...any) string {
-	return clientmodels.ClaimPathKey(components)
-}
-
-// attributeMap builds a map from claim path key to Attribute for easy lookup.
-func attributeMap(attrs []clientmodels.Attribute) map[string]clientmodels.Attribute {
-	m := make(map[string]clientmodels.Attribute, len(attrs))
-	for _, a := range attrs {
-		m[clientmodels.ClaimPathKey(a.ClaimPath)] = a
-	}
-	return m
-}
 
 // startOpenID4VPDisclosureSession starts an OpenID4VP disclosure session in the
 // client using the given verifier request URI.

--- a/internal/sessiontest/session_edge_cases_test.go
+++ b/internal/sessiontest/session_edge_cases_test.go
@@ -355,7 +355,7 @@ func testChainedSession(
 	choice := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.RU.studentCard", choice.CredentialId)
 
-	grantPermission(t, c, session.Id, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(choice))
 
 	session = awaitSessionState(t, sessionHandler)
 
@@ -378,7 +378,7 @@ func testChainedSession(
 	choice = session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
 	require.Equal(t, "irma-demo.MijnOverheid.fullName", choice.CredentialId)
 
-	grantPermission(t, c, session.Id, makeDisclosureChoice(choice, choice.Attributes[0].Id))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(choice))
 
 	session = awaitSessionState(t, sessionHandler)
 

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -264,10 +264,11 @@ func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []an
 }
 
 // expectedAttr describes an expected attribute with its full claim path,
-// display name, and value.
+// display name, optional description, and value.
 type expectedAttr struct {
 	Path        []any
 	DisplayName clientmodels.TranslatedString
+	Description *clientmodels.TranslatedString // nil to skip description check
 	Value       string
 }
 
@@ -293,6 +294,17 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 				i, clientmodels.ClaimPathKey(exp.Path), locale)
 			require.Equal(t, expectedName, actualName,
 				"attribute %d (%s) display name [%s] mismatch", i, clientmodels.ClaimPathKey(exp.Path), locale)
+		}
+		if exp.Description != nil {
+			require.NotNil(t, actual.Description,
+				"attribute %d (%s) should have a description", i, clientmodels.ClaimPathKey(exp.Path))
+			for locale, expectedDesc := range *exp.Description {
+				actualDesc, ok := (*actual.Description)[locale]
+				require.True(t, ok, "attribute %d (%s) should have description for locale %q",
+					i, clientmodels.ClaimPathKey(exp.Path), locale)
+				require.Equal(t, expectedDesc, actualDesc,
+					"attribute %d (%s) description [%s] mismatch", i, clientmodels.ClaimPathKey(exp.Path), locale)
+			}
 		}
 	}
 }

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -264,10 +264,10 @@ func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []an
 }
 
 // expectedAttr describes an expected attribute with its full claim path,
-// optional display names, and value.
+// display name, and value.
 type expectedAttr struct {
 	Path        []any
-	DisplayName clientmodels.TranslatedString // nil to skip display name checks
+	DisplayName clientmodels.TranslatedString
 	Value       string
 }
 
@@ -285,14 +285,14 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 		require.NotNil(t, actual.Value.String, "attribute %d should have a string value", i)
 		require.Equal(t, exp.Value, *actual.Value.String,
 			"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
-		if exp.DisplayName != nil {
-			for locale, expectedName := range exp.DisplayName {
-				actualName, ok := actual.DisplayName[locale]
-				require.True(t, ok, "attribute %d (%s) should have display name for locale %q",
-					i, clientmodels.ClaimPathKey(exp.Path), locale)
-				require.Equal(t, expectedName, actualName,
-					"attribute %d (%s) display name [%s] mismatch", i, clientmodels.ClaimPathKey(exp.Path), locale)
-			}
+		require.NotNil(t, exp.DisplayName, "attribute %d (%s) expected DisplayName must be set",
+			i, clientmodels.ClaimPathKey(exp.Path))
+		for locale, expectedName := range exp.DisplayName {
+			actualName, ok := actual.DisplayName[locale]
+			require.True(t, ok, "attribute %d (%s) should have display name for locale %q",
+				i, clientmodels.ClaimPathKey(exp.Path), locale)
+			require.Equal(t, expectedName, actualName,
+				"attribute %d (%s) display name [%s] mismatch", i, clientmodels.ClaimPathKey(exp.Path), locale)
 		}
 	}
 }

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -309,6 +309,46 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 	}
 }
 
+// expectedDisclosedAttr describes an expected disclosed attribute in an IRMA
+// server session result.
+type expectedDisclosedAttr struct {
+	Identifier string // e.g. "irma-demo.RU.studentCard.university"
+	Value      string
+}
+
+// requireIrmaServerResult retrieves the session result from the IRMA server
+// and asserts that the disclosed attributes match the expected list exactly.
+// Each inner slice of expected corresponds to one disjunction in the result.
+func requireIrmaServerResult(t *testing.T, irmaServer *IrmaServer, token irma.RequestorToken, expected [][]expectedDisclosedAttr) {
+	t.Helper()
+	result, err := irmaServer.irma.GetSessionResult(token)
+	require.NoError(t, err)
+	require.Equal(t, irma.ProofStatusValid, result.ProofStatus, "proof should be valid")
+	require.Len(t, result.Disclosed, len(expected), "number of disclosed disjunctions mismatch")
+
+	for i, expDiscon := range expected {
+		actualDiscon := result.Disclosed[i]
+		require.Len(t, actualDiscon, len(expDiscon),
+			"disjunction %d: number of disclosed attributes mismatch", i)
+		for j, exp := range expDiscon {
+			actual := actualDiscon[j]
+			require.Equal(t, exp.Identifier, actual.Identifier.String(), "disjunction %d attribute %d identifier mismatch", i, j)
+			require.Equal(t, irma.AttributeProofStatusPresent, actual.Status, "disjunction %d attribute %d should be present", i, j)
+			require.NotNil(t, actual.RawValue, "disjunction %d attribute %d should have a raw value", i, j)
+			require.Equal(t, exp.Value, *actual.RawValue, "disjunction %d attribute %d value mismatch", i, j)
+		}
+	}
+}
+
+// requireIrmaServerResultStatus retrieves the session result and checks
+// the proof status without validating individual attributes.
+func requireIrmaServerResultStatus(t *testing.T, irmaServer *IrmaServer, token irma.RequestorToken, expectedStatus irma.ServerStatus) {
+	t.Helper()
+	result, err := irmaServer.irma.GetSessionResult(token)
+	require.NoError(t, err)
+	require.Equal(t, expectedStatus, result.Status, "session status mismatch")
+}
+
 // makeDisclosureChoice creates a DisclosureDisconSelection that discloses all
 // attributes of the given credential instance.
 func makeDisclosureChoice(option *clientmodels.SelectableCredentialInstance) clientmodels.DisclosureDisconSelection {

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -263,19 +263,17 @@ func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []an
 	require.False(t, ok, "attribute %s should not exist", key)
 }
 
-// expectedAttr describes an expected attribute with its full claim path and string value.
+// expectedAttr describes an expected attribute with its full claim path,
+// optional display names, and value.
 type expectedAttr struct {
-	Path  []any
-	Value string
-}
-
-// attr builds an expectedAttr.
-func attr(path []any, value string) expectedAttr {
-	return expectedAttr{Path: path, Value: value}
+	Path        []any
+	DisplayName clientmodels.TranslatedString // nil to skip display name checks
+	Value       string
 }
 
 // requireAttrsInOrder asserts that the given attributes match the expected list
-// exactly — same order, same paths, same values, same length.
+// exactly — same order, same paths, same values, same length. When display names
+// are specified, those are checked too.
 func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected ...expectedAttr) {
 	t.Helper()
 	require.Len(t, attrs, len(expected), "attribute count mismatch")
@@ -287,6 +285,15 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 		require.NotNil(t, actual.Value.String, "attribute %d should have a string value", i)
 		require.Equal(t, exp.Value, *actual.Value.String,
 			"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
+		if exp.DisplayName != nil {
+			for locale, expectedName := range exp.DisplayName {
+				actualName, ok := actual.DisplayName[locale]
+				require.True(t, ok, "attribute %d (%s) should have display name for locale %q",
+					i, clientmodels.ClaimPathKey(exp.Path), locale)
+				require.Equal(t, expectedName, actualName,
+					"attribute %d (%s) display name [%s] mismatch", i, clientmodels.ClaimPathKey(exp.Path), locale)
+			}
+		}
 	}
 }
 

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -263,6 +263,21 @@ func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []an
 	require.False(t, ok, "attribute %s should not exist", key)
 }
 
+// pk is a shorthand for building a ClaimPathKey from path components.
+// pk("email") → "[email]", pk("address", "street") → "[address street]"
+func pk(components ...any) string {
+	return clientmodels.ClaimPathKey(components)
+}
+
+// attributeMap builds a map from the serialized full ClaimPath to the Attribute.
+func attributeMap(attrs []clientmodels.Attribute) map[string]clientmodels.Attribute {
+	m := make(map[string]clientmodels.Attribute, len(attrs))
+	for _, a := range attrs {
+		m[clientmodels.ClaimPathKey(a.ClaimPath)] = a
+	}
+	return m
+}
+
 // expectedAttr describes an expected attribute with its full claim path,
 // display name, optional description, and value.
 type expectedAttr struct {
@@ -340,14 +355,7 @@ func requireIrmaServerResult(t *testing.T, irmaServer *IrmaServer, token irma.Re
 	}
 }
 
-// requireIrmaServerResultStatus retrieves the session result and checks
-// the proof status without validating individual attributes.
-func requireIrmaServerResultStatus(t *testing.T, irmaServer *IrmaServer, token irma.RequestorToken, expectedStatus irma.ServerStatus) {
-	t.Helper()
-	result, err := irmaServer.irma.GetSessionResult(token)
-	require.NoError(t, err)
-	require.Equal(t, expectedStatus, result.Status, "session status mismatch")
-}
+
 
 // makeDisclosureChoice creates a DisclosureDisconSelection that discloses all
 // attributes of the given credential instance.

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -255,6 +255,33 @@ func requireAttr(t *testing.T, am map[string]clientmodels.Attribute, path []any,
 	require.Equal(t, expectedValue, *attr.Value.String, "attribute %s value mismatch", key)
 }
 
+// requireAttrFull checks that an attribute exists at the given path in the map
+// and matches the expected value, display name, and optional description.
+// Use this for order-independent attribute checks that include display name verification.
+func requireAttrFull(t *testing.T, am map[string]clientmodels.Attribute, expected expectedAttr) {
+	t.Helper()
+	key := clientmodels.ClaimPathKey(expected.Path)
+	actual, ok := am[key]
+	require.True(t, ok, "attribute %s should exist", key)
+	require.NotNil(t, actual.Value, "attribute %s should have a value", key)
+	actualValueStr := attributeValueToString(actual.Value)
+	require.Equal(t, expected.Value, actualValueStr, "attribute %s value mismatch", key)
+	require.NotNil(t, expected.DisplayName, "attribute %s expected DisplayName must be set", key)
+	for locale, expectedName := range expected.DisplayName {
+		actualName, ok := actual.DisplayName[locale]
+		require.True(t, ok, "attribute %s should have display name for locale %q", key, locale)
+		require.Equal(t, expectedName, actualName, "attribute %s display name [%s] mismatch", key, locale)
+	}
+	if expected.Description != nil {
+		require.NotNil(t, actual.Description, "attribute %s should have a description", key)
+		for locale, expectedDesc := range *expected.Description {
+			actualDesc, ok := (*actual.Description)[locale]
+			require.True(t, ok, "attribute %s should have description for locale %q", key, locale)
+			require.Equal(t, expectedDesc, actualDesc, "attribute %s description [%s] mismatch", key, locale)
+		}
+	}
+}
+
 // requireNoAttr asserts that the attribute map does NOT contain an attribute at the given claim path.
 func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []any) {
 	t.Helper()
@@ -309,6 +336,30 @@ func requireObtainableOption(t *testing.T, obtainable *clientmodels.CredentialDe
 	}
 }
 
+// attributeValueToString returns a string representation of an AttributeValue
+// for comparison in test assertions. Handles string, bool, int, and image types.
+func attributeValueToString(v *clientmodels.AttributeValue) string {
+	if v == nil {
+		return ""
+	}
+	if v.String != nil {
+		return *v.String
+	}
+	if v.Bool != nil {
+		return fmt.Sprintf("%v", *v.Bool)
+	}
+	if v.Int != nil {
+		return fmt.Sprintf("%d", *v.Int)
+	}
+	if v.ImagePath != nil {
+		return *v.ImagePath
+	}
+	if v.Base64Image != nil {
+		return *v.Base64Image
+	}
+	return ""
+}
+
 // pk is a shorthand for building a ClaimPathKey from path components.
 // pk("email") → "[email]", pk("address", "street") → "[address street]"
 func pk(components ...any) string {
@@ -344,8 +395,8 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 		require.Equal(t, clientmodels.ClaimPathKey(exp.Path), clientmodels.ClaimPathKey(actual.ClaimPath),
 			"attribute %d path mismatch", i)
 		require.NotNil(t, actual.Value, "attribute %d should have a value", i)
-		require.NotNil(t, actual.Value.String, "attribute %d should have a string value", i)
-		require.Equal(t, exp.Value, *actual.Value.String,
+		actualValueStr := attributeValueToString(actual.Value)
+		require.Equal(t, exp.Value, actualValueStr,
 			"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
 		require.NotNil(t, exp.DisplayName, "attribute %d (%s) expected DisplayName must be set",
 			i, clientmodels.ClaimPathKey(exp.Path))

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -263,6 +263,52 @@ func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []an
 	require.False(t, ok, "attribute %s should not exist", key)
 }
 
+// expectedObtainable describes an expected obtainable credential descriptor.
+type expectedObtainable struct {
+	CredentialId string
+	Name         clientmodels.TranslatedString
+	// Expected requested attributes. Each has ClaimPath and optionally a
+	// RequestedValue string (nil means type-only constraint, no specific value).
+	Attributes []expectedRequestedAttr
+}
+
+type expectedRequestedAttr struct {
+	Path           []any
+	DisplayName    clientmodels.TranslatedString
+	RequestedValue *string // nil means any value of the type is accepted
+}
+
+// requireObtainableOption asserts that an obtainable credential descriptor
+// matches the expected credential ID, name, and requested attributes.
+func requireObtainableOption(t *testing.T, obtainable *clientmodels.CredentialDescriptor, expected expectedObtainable) {
+	t.Helper()
+	require.Equal(t, expected.CredentialId, obtainable.CredentialId, "obtainable credential ID mismatch")
+	require.Equal(t, expected.Name, obtainable.Name, "obtainable credential name mismatch")
+	require.Len(t, obtainable.Attributes, len(expected.Attributes), "obtainable attribute count mismatch for %s", expected.CredentialId)
+	for i, exp := range expected.Attributes {
+		actual := obtainable.Attributes[i]
+		require.Equal(t, exp.Path, actual.ClaimPath, "obtainable %s attribute %d path mismatch", expected.CredentialId, i)
+		require.NotNil(t, exp.DisplayName, "obtainable %s attribute %d expected DisplayName must be set", expected.CredentialId, i)
+		for locale, expectedName := range exp.DisplayName {
+			actualName, ok := actual.DisplayName[locale]
+			require.True(t, ok, "obtainable %s attribute %d should have display name for locale %q", expected.CredentialId, i, locale)
+			require.Equal(t, expectedName, actualName, "obtainable %s attribute %d display name [%s] mismatch", expected.CredentialId, i, locale)
+		}
+		require.NotNil(t, actual.RequestedValue, "obtainable %s attribute %d should have RequestedValue", expected.CredentialId, i)
+		require.Equal(t, clientmodels.AttributeType_String, actual.RequestedValue.Type,
+			"obtainable %s attribute %d RequestedValue type mismatch", expected.CredentialId, i)
+		if exp.RequestedValue != nil {
+			require.NotNil(t, actual.RequestedValue.String,
+				"obtainable %s attribute %d should have specific RequestedValue", expected.CredentialId, i)
+			require.Equal(t, *exp.RequestedValue, *actual.RequestedValue.String,
+				"obtainable %s attribute %d RequestedValue mismatch", expected.CredentialId, i)
+		} else {
+			require.Nil(t, actual.RequestedValue.String,
+				"obtainable %s attribute %d should not have specific RequestedValue", expected.CredentialId, i)
+		}
+	}
+}
+
 // pk is a shorthand for building a ClaimPathKey from path components.
 // pk("email") → "[email]", pk("address", "street") → "[address street]"
 func pk(components ...any) string {
@@ -354,8 +400,6 @@ func requireIrmaServerResult(t *testing.T, irmaServer *IrmaServer, token irma.Re
 		}
 	}
 }
-
-
 
 // makeDisclosureChoice creates a DisclosureDisconSelection that discloses all
 // attributes of the given credential instance.

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -241,13 +241,61 @@ func denyPermission(t *testing.T, c *client.Client, sessionId int) {
 	})
 }
 
-// makeDisclosureChoice creates a disclosure selection from an owned option
 func intPtr(v int) *int { return &v }
 
-func makeDisclosureChoice(option *clientmodels.SelectableCredentialInstance, attributeIds ...string) clientmodels.DisclosureDisconSelection {
-	paths := make([][]any, len(attributeIds))
-	for i, id := range attributeIds {
-		paths[i] = []any{id}
+// requireAttr asserts that the attribute map contains an attribute at the given
+// claim path with the expected string value.
+func requireAttr(t *testing.T, am map[string]clientmodels.Attribute, path []any, expectedValue string) {
+	t.Helper()
+	key := clientmodels.ClaimPathKey(path)
+	attr, ok := am[key]
+	require.True(t, ok, "attribute %s should exist", key)
+	require.NotNil(t, attr.Value, "attribute %s should have a value", key)
+	require.NotNil(t, attr.Value.String, "attribute %s should have a string value", key)
+	require.Equal(t, expectedValue, *attr.Value.String, "attribute %s value mismatch", key)
+}
+
+// requireNoAttr asserts that the attribute map does NOT contain an attribute at the given claim path.
+func requireNoAttr(t *testing.T, am map[string]clientmodels.Attribute, path []any) {
+	t.Helper()
+	key := clientmodels.ClaimPathKey(path)
+	_, ok := am[key]
+	require.False(t, ok, "attribute %s should not exist", key)
+}
+
+// expectedAttr describes an expected attribute with its full claim path and string value.
+type expectedAttr struct {
+	Path  []any
+	Value string
+}
+
+// attr builds an expectedAttr.
+func attr(path []any, value string) expectedAttr {
+	return expectedAttr{Path: path, Value: value}
+}
+
+// requireAttrsInOrder asserts that the given attributes match the expected list
+// exactly — same order, same paths, same values, same length.
+func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected ...expectedAttr) {
+	t.Helper()
+	require.Len(t, attrs, len(expected), "attribute count mismatch")
+	for i, exp := range expected {
+		actual := attrs[i]
+		require.Equal(t, clientmodels.ClaimPathKey(exp.Path), clientmodels.ClaimPathKey(actual.ClaimPath),
+			"attribute %d path mismatch", i)
+		require.NotNil(t, actual.Value, "attribute %d should have a value", i)
+		require.NotNil(t, actual.Value.String, "attribute %d should have a string value", i)
+		require.Equal(t, exp.Value, *actual.Value.String,
+			"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
+	}
+}
+
+// makeDisclosureChoice creates a DisclosureDisconSelection that discloses all
+// attributes of the given credential instance.
+func makeDisclosureChoice(option *clientmodels.SelectableCredentialInstance) clientmodels.DisclosureDisconSelection {
+	paths := make([][]any, len(option.Attributes))
+	for i, attr := range option.Attributes {
+		paths[i] = attr.ClaimPath
 	}
 	return clientmodels.DisclosureDisconSelection{
 		Credentials: []clientmodels.SelectedCredential{

--- a/internal/sessiontest/session_helpers_test.go
+++ b/internal/sessiontest/session_helpers_test.go
@@ -263,9 +263,11 @@ func requireAttrFull(t *testing.T, am map[string]clientmodels.Attribute, expecte
 	key := clientmodels.ClaimPathKey(expected.Path)
 	actual, ok := am[key]
 	require.True(t, ok, "attribute %s should exist", key)
-	require.NotNil(t, actual.Value, "attribute %s should have a value", key)
-	actualValueStr := attributeValueToString(actual.Value)
-	require.Equal(t, expected.Value, actualValueStr, "attribute %s value mismatch", key)
+	if expected.Value != nil {
+		require.NotNil(t, actual.Value, "attribute %s should have a value", key)
+		require.Equal(t, expected.Value.Type, actual.Value.Type, "attribute %s value type mismatch", key)
+		require.Equal(t, expected.Value, actual.Value, "attribute %s value mismatch", key)
+	}
 	require.NotNil(t, expected.DisplayName, "attribute %s expected DisplayName must be set", key)
 	for locale, expectedName := range expected.DisplayName {
 		actualName, ok := actual.DisplayName[locale]
@@ -336,30 +338,6 @@ func requireObtainableOption(t *testing.T, obtainable *clientmodels.CredentialDe
 	}
 }
 
-// attributeValueToString returns a string representation of an AttributeValue
-// for comparison in test assertions. Handles string, bool, int, and image types.
-func attributeValueToString(v *clientmodels.AttributeValue) string {
-	if v == nil {
-		return ""
-	}
-	if v.String != nil {
-		return *v.String
-	}
-	if v.Bool != nil {
-		return fmt.Sprintf("%v", *v.Bool)
-	}
-	if v.Int != nil {
-		return fmt.Sprintf("%d", *v.Int)
-	}
-	if v.ImagePath != nil {
-		return *v.ImagePath
-	}
-	if v.Base64Image != nil {
-		return *v.Base64Image
-	}
-	return ""
-}
-
 // pk is a shorthand for building a ClaimPathKey from path components.
 // pk("email") → "[email]", pk("address", "street") → "[address street]"
 func pk(components ...any) string {
@@ -376,12 +354,27 @@ func attributeMap(attrs []clientmodels.Attribute) map[string]clientmodels.Attrib
 }
 
 // expectedAttr describes an expected attribute with its full claim path,
-// display name, optional description, and value.
+// display name, optional description, and typed value.
 type expectedAttr struct {
 	Path        []any
 	DisplayName clientmodels.TranslatedString
 	Description *clientmodels.TranslatedString // nil to skip description check
-	Value       string
+	Value       *clientmodels.AttributeValue
+}
+
+// strVal creates a string AttributeValue.
+func strVal(s string) *clientmodels.AttributeValue {
+	return &clientmodels.AttributeValue{Type: clientmodels.AttributeType_String, String: &s}
+}
+
+// boolVal creates a boolean AttributeValue.
+func boolVal(b bool) *clientmodels.AttributeValue {
+	return &clientmodels.AttributeValue{Type: clientmodels.AttributeType_Bool, Bool: &b}
+}
+
+// intVal creates an integer AttributeValue.
+func intVal(i int64) *clientmodels.AttributeValue {
+	return &clientmodels.AttributeValue{Type: clientmodels.AttributeType_Int, Int: &i}
 }
 
 // requireAttrsInOrder asserts that the given attributes match the expected list
@@ -394,10 +387,13 @@ func requireAttrsInOrder(t *testing.T, attrs []clientmodels.Attribute, expected 
 		actual := attrs[i]
 		require.Equal(t, clientmodels.ClaimPathKey(exp.Path), clientmodels.ClaimPathKey(actual.ClaimPath),
 			"attribute %d path mismatch", i)
-		require.NotNil(t, actual.Value, "attribute %d should have a value", i)
-		actualValueStr := attributeValueToString(actual.Value)
-		require.Equal(t, exp.Value, actualValueStr,
-			"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
+		if exp.Value != nil {
+			require.NotNil(t, actual.Value, "attribute %d should have a value", i)
+			require.Equal(t, exp.Value.Type, actual.Value.Type,
+				"attribute %d (%s) value type mismatch", i, clientmodels.ClaimPathKey(exp.Path))
+			require.Equal(t, exp.Value, actual.Value,
+				"attribute %d (%s) value mismatch", i, clientmodels.ClaimPathKey(exp.Path))
+		}
 		require.NotNil(t, exp.DisplayName, "attribute %d (%s) expected DisplayName must be set",
 			i, clientmodels.ClaimPathKey(exp.Path))
 		for locale, expectedName := range exp.DisplayName {

--- a/internal/sessiontest/storage_regression_test.go
+++ b/internal/sessiontest/storage_regression_test.go
@@ -195,7 +195,7 @@ func performDisclosureSessionForAttribute(t *testing.T, c *client.Client, sessio
 	require.Equal(t, clientmodels.Status_RequestPermission, session.Status)
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attribute[strings.LastIndex(attribute, ".")+1:]))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	session = awaitSessionState(t, sessionHandler)
 	require.Equal(t, clientmodels.Status_Success, session.Status)
@@ -217,7 +217,7 @@ func performKeyshareDisclosureSession(t *testing.T, c *client.Client, sessionHan
 	require.Equal(t, clientmodels.Status_RequestPermission, session.Status)
 
 	cred := session.DisclosurePlan.DisclosureChoicesOverview[0].OwnedOptions[0]
-	grantPermission(t, c, session.Id, makeDisclosureChoice(cred, attribute[strings.LastIndex(attribute, ".")+1:]))
+	grantPermission(t, c, session.Id, makeDisclosureChoice(cred))
 
 	// The reloaded client needs to authenticate with the keyshare server.
 	session = awaitSessionState(t, sessionHandler)

--- a/testdata/openid4vci-issuer/conf/credentials/OrganizationCredential.json
+++ b/testdata/openid4vci-issuer/conf/credentials/OrganizationCredential.json
@@ -1,0 +1,16 @@
+{
+  "format": "json_vc_jwt",
+  "credential_definition": {
+    "type": ["VerifiableCredential", "OrganizationCredential"],
+    "credentialSubject": {
+      "university": { "display": [{ "name": "University", "locale": "en" }, { "name": "Universiteit", "locale": "nl" }] }
+    }
+  },
+  "display": [
+    {
+      "name": "Organization Credential",
+      "locale": "en",
+      "description": "A deeply nested credential for testing complex structures."
+    }
+  ]
+}

--- a/testdata/openid4vci-issuer/conf/metadata/authcode-issuer.json
+++ b/testdata/openid4vci-issuer/conf/metadata/authcode-issuer.json
@@ -41,6 +41,15 @@
           "proof_signing_alg_values_supported": ["ES256"]
         }
       },
+      "credential_definition": {
+        "type": ["VerifiableCredential", "HouseCredential"],
+        "claims": [
+          { "path": ["owner_name"], "display": [{ "name": "Owner Name", "locale": "en" }, { "name": "Eigenaar", "locale": "nl" }] },
+          { "path": ["address", "street"], "display": [{ "name": "Street", "locale": "en" }, { "name": "Straat", "locale": "nl" }] },
+          { "path": ["address", "city"], "display": [{ "name": "City", "locale": "en" }, { "name": "Stad", "locale": "nl" }] },
+          { "path": ["address", "country"], "display": [{ "name": "Country", "locale": "en" }, { "name": "Land", "locale": "nl" }] }
+        ]
+      },
       "credential_metadata": {
         "display": [
           { "name": "House Possession Credential (SD-JWT, Auth Code)", "locale": "en" }

--- a/testdata/openid4vci-issuer/conf/metadata/test-issuer.json
+++ b/testdata/openid4vci-issuer/conf/metadata/test-issuer.json
@@ -7,21 +7,72 @@
       "format": "vc+sd-jwt",
       "scope": "TestCredentialSdJwt",
       "extends": "TestCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "Test Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "Test Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["given_name"], "display": [{ "name": "Given Name", "locale": "en" }, { "name": "Voornaam", "locale": "nl" }] },
-          { "path": ["family_name"], "display": [{ "name": "Family Name", "locale": "en" }, { "name": "Achternaam", "locale": "nl" }] },
-          { "path": ["email"], "display": [{ "name": "Email", "locale": "en" }, { "name": "E-mailadres", "locale": "nl" }] }
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en"
+              },
+              {
+                "name": "Voornaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family Name",
+                "locale": "en"
+              },
+              {
+                "name": "Achternaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "email"
+            ],
+            "display": [
+              {
+                "name": "Email",
+                "locale": "en"
+              },
+              {
+                "name": "E-mailadres",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
@@ -35,20 +86,57 @@
       "format": "vc+sd-jwt",
       "scope": "EmailCredentialSdJwt",
       "extends": "EmailCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "Email Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "Email Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["email"], "display": [{ "name": "Email", "locale": "en" }, { "name": "E-mailadres", "locale": "nl" }] },
-          { "path": ["domain"], "display": [{ "name": "Domain", "locale": "en" }, { "name": "Domein", "locale": "nl" }] }
+          {
+            "path": [
+              "email"
+            ],
+            "display": [
+              {
+                "name": "Email",
+                "locale": "en"
+              },
+              {
+                "name": "E-mailadres",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "domain"
+            ],
+            "display": [
+              {
+                "name": "Domain",
+                "locale": "en"
+              },
+              {
+                "name": "Domein",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
@@ -62,19 +150,42 @@
       "format": "vc+sd-jwt",
       "scope": "PhoneCredentialSdJwt",
       "extends": "PhoneCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "Phone Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "Phone Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["phone_number"], "display": [{ "name": "Phone Number", "locale": "en" }, { "name": "Telefoonnummer", "locale": "nl" }] }
+          {
+            "path": [
+              "phone_number"
+            ],
+            "display": [
+              {
+                "name": "Phone Number",
+                "locale": "en"
+              },
+              {
+                "name": "Telefoonnummer",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
@@ -88,22 +199,87 @@
       "format": "vc+sd-jwt",
       "scope": "StudentCardCredentialSdJwt",
       "extends": "StudentCardCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "Student Card Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "Student Card Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["university"], "display": [{ "name": "University", "locale": "en" }, { "name": "Universiteit", "locale": "nl" }] },
-          { "path": ["level"], "display": [{ "name": "Level", "locale": "en" }, { "name": "Niveau", "locale": "nl" }] },
-          { "path": ["student_id"], "display": [{ "name": "Student ID", "locale": "en" }, { "name": "Studentnummer", "locale": "nl" }] },
-          { "path": ["courses"], "display": [{ "name": "Courses", "locale": "en" }, { "name": "Vakken", "locale": "nl" }] }
+          {
+            "path": [
+              "university"
+            ],
+            "display": [
+              {
+                "name": "University",
+                "locale": "en"
+              },
+              {
+                "name": "Universiteit",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "level"
+            ],
+            "display": [
+              {
+                "name": "Level",
+                "locale": "en"
+              },
+              {
+                "name": "Niveau",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "student_id"
+            ],
+            "display": [
+              {
+                "name": "Student ID",
+                "locale": "en"
+              },
+              {
+                "name": "Studentnummer",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "courses"
+            ],
+            "display": [
+              {
+                "name": "Courses",
+                "locale": "en"
+              },
+              {
+                "name": "Vakken",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
@@ -117,22 +293,88 @@
       "format": "vc+sd-jwt",
       "scope": "HouseCredentialSdJwt",
       "extends": "HouseCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
+      },
+      "credential_definition": {
+        "type": ["VerifiableCredential", "HouseCredential"],
+        "claims": [
+          {
+            "path": ["owner_name"],
+            "display": [
+              { "name": "Owner Name", "locale": "en" },
+              { "name": "Eigenaar", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "street"],
+            "display": [
+              { "name": "Street", "locale": "en" },
+              { "name": "Straat", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "city"],
+            "display": [
+              { "name": "City", "locale": "en" },
+              { "name": "Stad", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "country"],
+            "display": [
+              { "name": "Country", "locale": "en" },
+              { "name": "Land", "locale": "nl" }
+            ]
+          }
+        ]
       },
       "credential_metadata": {
         "display": [
-          { "name": "House Possession Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "House Possession Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["owner_name"], "display": [{ "name": "Owner Name", "locale": "en" }, { "name": "Eigenaar", "locale": "nl" }] },
-          { "path": ["address", "street"], "display": [{ "name": "Street", "locale": "en" }, { "name": "Straat", "locale": "nl" }] },
-          { "path": ["address", "city"], "display": [{ "name": "City", "locale": "en" }, { "name": "Stad", "locale": "nl" }] },
-          { "path": ["address", "country"], "display": [{ "name": "Country", "locale": "en" }, { "name": "Land", "locale": "nl" }] }
+          {
+            "path": ["owner_name"],
+            "display": [
+              { "name": "Owner Name", "locale": "en" },
+              { "name": "Eigenaar", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "street"],
+            "display": [
+              { "name": "Street", "locale": "en" },
+              { "name": "Straat", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "city"],
+            "display": [
+              { "name": "City", "locale": "en" },
+              { "name": "Stad", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["address", "country"],
+            "display": [
+              { "name": "Country", "locale": "en" },
+              { "name": "Land", "locale": "nl" }
+            ]
+          }
         ]
       },
       "display": [
@@ -146,21 +388,72 @@
       "format": "vc+sd-jwt",
       "scope": "MembershipCredentialSdJwt",
       "extends": "MembershipCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "Membership Credential (SD-JWT)", "locale": "en" }
+          {
+            "name": "Membership Credential (SD-JWT)",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["member_name"], "display": [{ "name": "Member Name", "locale": "en" }, { "name": "Naam lid", "locale": "nl" }] },
-          { "path": ["member_since"], "display": [{ "name": "Member Since", "locale": "en" }, { "name": "Lid sinds", "locale": "nl" }] },
-          { "path": ["membership_type"], "display": [{ "name": "Membership Type", "locale": "en" }, { "name": "Type lidmaatschap", "locale": "nl" }] }
+          {
+            "path": [
+              "member_name"
+            ],
+            "display": [
+              {
+                "name": "Member Name",
+                "locale": "en"
+              },
+              {
+                "name": "Naam lid",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "member_since"
+            ],
+            "display": [
+              {
+                "name": "Member Since",
+                "locale": "en"
+              },
+              {
+                "name": "Lid sinds",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "membership_type"
+            ],
+            "display": [
+              {
+                "name": "Membership Type",
+                "locale": "en"
+              },
+              {
+                "name": "Type lidmaatschap",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
@@ -174,38 +467,441 @@
       "format": "vc+sd-jwt",
       "scope": "EduIdCredentialSdJwt",
       "extends": "EduIdCredential",
-      "cryptographic_binding_methods_supported": ["did:jwk"],
-      "credential_signing_alg_values_supported": ["ES256"],
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
       "proof_types_supported": {
         "jwt": {
-          "proof_signing_alg_values_supported": ["ES256"]
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
         }
       },
       "credential_metadata": {
         "display": [
-          { "name": "eduID", "locale": "en" }
+          {
+            "name": "eduID",
+            "locale": "en"
+          }
         ],
         "claims": [
-          { "path": ["schac_home_organization"], "display": [{ "name": "Organization", "locale": "en" }, { "name": "Instelling", "locale": "nl" }] },
-          { "path": ["name"], "display": [{ "name": "Name", "locale": "en" }, { "name": "Naam", "locale": "nl" }] },
-          { "path": ["given_name"], "display": [{ "name": "Given name", "locale": "en" }, { "name": "Voornaam", "locale": "nl" }] },
-          { "path": ["family_name"], "display": [{ "name": "Family name", "locale": "en" }, { "name": "Achternaam", "locale": "nl" }] },
-          { "path": ["email"], "display": [{ "name": "E-mail", "locale": "en" }, { "name": "E-mail", "locale": "nl" }] },
-          { "path": ["eduperson_scoped_affiliation"], "display": [{ "name": "Affiliation (scoped)", "locale": "en" }, { "name": "Betrekking (in relatie)", "locale": "nl" }] },
-          { "path": ["eduperson_assurance"], "display": [{ "name": "Assurance", "locale": "en" }, { "name": "Bevestiging", "locale": "nl" }] },
-          { "path": ["is_student"], "display": [{ "name": "IsStudent", "locale": "en" }, { "name": "IsStudent", "locale": "nl" }] },
-          { "path": ["is_faculty"], "display": [{ "name": "IsFaculty", "locale": "en" }, { "name": "IsFaculteitslid", "locale": "nl" }] },
-          { "path": ["is_member"], "display": [{ "name": "IsMember", "locale": "en" }, { "name": "IsLid", "locale": "nl" }] },
-          { "path": ["is_staff"], "display": [{ "name": "IsStaff", "locale": "en" }, { "name": "IsStaf", "locale": "nl" }] },
-          { "path": ["is_alum"], "display": [{ "name": "IsAlumnus", "locale": "en" }, { "name": "IsAlumnus", "locale": "nl" }] },
-          { "path": ["is_affiliate"], "display": [{ "name": "IsAffiliate", "locale": "en" }, { "name": "IsVerbonden", "locale": "nl" }] },
-          { "path": ["is_employee"], "display": [{ "name": "IsEmployee", "locale": "en" }, { "name": "IsMedewerker", "locale": "nl" }] },
-          { "path": ["is_library-walk-in"], "display": [{ "name": "IsLibraryWalkIn", "locale": "en" }, { "name": "IsBibliotheekBezoeker", "locale": "nl" }] }
+          {
+            "path": [
+              "schac_home_organization"
+            ],
+            "display": [
+              {
+                "name": "Organization",
+                "locale": "en"
+              },
+              {
+                "name": "Instelling",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "name"
+            ],
+            "display": [
+              {
+                "name": "Name",
+                "locale": "en"
+              },
+              {
+                "name": "Naam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given name",
+                "locale": "en"
+              },
+              {
+                "name": "Voornaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Family name",
+                "locale": "en"
+              },
+              {
+                "name": "Achternaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "email"
+            ],
+            "display": [
+              {
+                "name": "E-mail",
+                "locale": "en"
+              },
+              {
+                "name": "E-mail",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eduperson_scoped_affiliation"
+            ],
+            "display": [
+              {
+                "name": "Affiliation (scoped)",
+                "locale": "en"
+              },
+              {
+                "name": "Betrekking (in relatie)",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "eduperson_assurance"
+            ],
+            "display": [
+              {
+                "name": "Assurance",
+                "locale": "en"
+              },
+              {
+                "name": "Bevestiging",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_student"
+            ],
+            "display": [
+              {
+                "name": "IsStudent",
+                "locale": "en"
+              },
+              {
+                "name": "IsStudent",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_faculty"
+            ],
+            "display": [
+              {
+                "name": "IsFaculty",
+                "locale": "en"
+              },
+              {
+                "name": "IsFaculteitslid",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_member"
+            ],
+            "display": [
+              {
+                "name": "IsMember",
+                "locale": "en"
+              },
+              {
+                "name": "IsLid",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_staff"
+            ],
+            "display": [
+              {
+                "name": "IsStaff",
+                "locale": "en"
+              },
+              {
+                "name": "IsStaf",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_alum"
+            ],
+            "display": [
+              {
+                "name": "IsAlumnus",
+                "locale": "en"
+              },
+              {
+                "name": "IsAlumnus",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_affiliate"
+            ],
+            "display": [
+              {
+                "name": "IsAffiliate",
+                "locale": "en"
+              },
+              {
+                "name": "IsVerbonden",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_employee"
+            ],
+            "display": [
+              {
+                "name": "IsEmployee",
+                "locale": "en"
+              },
+              {
+                "name": "IsMedewerker",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "is_library-walk-in"
+            ],
+            "display": [
+              {
+                "name": "IsLibraryWalkIn",
+                "locale": "en"
+              },
+              {
+                "name": "IsBibliotheekBezoeker",
+                "locale": "nl"
+              }
+            ]
+          }
         ]
       },
       "display": [
         {
           "name": "eduID",
+          "locale": "en"
+        }
+      ]
+    },
+    "OrganizationCredentialSdJwt": {
+      "format": "vc+sd-jwt",
+      "scope": "OrganizationCredentialSdJwt",
+      "extends": "OrganizationCredential",
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_definition": {
+        "type": ["VerifiableCredential", "OrganizationCredential"],
+        "claims": [
+          {
+            "path": ["university", "name"],
+            "display": [
+              { "name": "University Name", "locale": "en" },
+              { "name": "Naam universiteit", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["university", "faculties"],
+            "display": [
+              { "name": "Faculties", "locale": "en" },
+              { "name": "Faculteiten", "locale": "nl" }
+            ]
+          },
+          {
+            "path": ["university", "founded"],
+            "display": [
+              { "name": "Founded", "locale": "en" },
+              { "name": "Opgericht", "locale": "nl" }
+            ]
+          }
+        ]
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "Organization Credential (SD-JWT)",
+            "locale": "en"
+          }
+        ],
+        "claims": [
+          {
+            "path": [
+              "university",
+              "name"
+            ],
+            "display": [
+              {
+                "name": "University Name",
+                "locale": "en"
+              },
+              {
+                "name": "Naam universiteit",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "faculties"
+            ],
+            "display": [
+              {
+                "name": "Faculties",
+                "locale": "en"
+              },
+              {
+                "name": "Faculteiten",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "founded"
+            ],
+            "display": [
+              {
+                "name": "Founded",
+                "locale": "en"
+              },
+              {
+                "name": "Opgericht",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "faculties",
+              null,
+              "faculty_name"
+            ],
+            "display": [
+              {
+                "name": "Faculty Name",
+                "locale": "en"
+              },
+              {
+                "name": "Faculteitsnaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "faculties",
+              null,
+              "departments"
+            ],
+            "display": [
+              {
+                "name": "Departments",
+                "locale": "en"
+              },
+              {
+                "name": "Afdelingen",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "faculties",
+              null,
+              "departments",
+              null,
+              "dept_name"
+            ],
+            "display": [
+              {
+                "name": "Department Name",
+                "locale": "en"
+              },
+              {
+                "name": "Afdelingsnaam",
+                "locale": "nl"
+              }
+            ]
+          },
+          {
+            "path": [
+              "university",
+              "faculties",
+              null,
+              "departments",
+              null,
+              "courses"
+            ],
+            "display": [
+              {
+                "name": "Courses",
+                "locale": "en"
+              },
+              {
+                "name": "Vakken",
+                "locale": "nl"
+              }
+            ]
+          }
+        ]
+      },
+      "display": [
+        {
+          "name": "Organization Credential (SD-JWT)",
           "locale": "en"
         }
       ]

--- a/testdata/openid4vci-issuer/conf/vct/organization-vct.json
+++ b/testdata/openid4vci-issuer/conf/vct/organization-vct.json
@@ -1,0 +1,81 @@
+{
+  "path": "/vct/organization",
+  "credentials": [
+    "OrganizationCredentialSdJwt"
+  ],
+  "document": {
+    "name": "Organization Credential (SD-JWT)",
+    "description": "VCT metadata for deeply nested organization credential with nested SD claims",
+    "language": "en",
+    "display": [
+      {
+        "lang": "en",
+        "name": "Organization Credential (SD-JWT)"
+      }
+    ],
+    "claims": [
+      {
+        "path": [
+          "university",
+          "name"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "faculties"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "founded"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "faculties",
+          null,
+          "faculty_name"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "faculties",
+          null,
+          "departments"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "faculties",
+          null,
+          "departments",
+          null,
+          "dept_name"
+        ],
+        "sd": "allowed"
+      },
+      {
+        "path": [
+          "university",
+          "faculties",
+          null,
+          "departments",
+          null,
+          "courses"
+        ],
+        "sd": "allowed"
+      }
+    ],
+    "issuer": "{{ here }}"
+  }
+}


### PR DESCRIPTION
### Summary
  - Replace Attribute.Id (leaf name string) with ClaimPath []any (full path like ["address", "street"] or ["courses", 1])
  - Remove Array and Object from AttributeValue — nested structures are flattened into separate Attribute entries with full paths
  - Remove AttributeType_Array and AttributeType_Object — only scalar types remain (string, integer, boolean, image, base64_image)
  - EUDI handler now expands arrays into indexed paths and objects into nested paths
  - Attribute ordering preserved from source metadata (IRMA scheme XML / EUDI issuer credential metadata)
  - All test assertions migrated to check full claim paths, display names, and values via requireAttrsInOrder
  - IRMA server result verification added to 12 disclosure/signature/issuance tests via requireIrmaServerResult

  ### Why

  The old Id field only stored the leaf name (e.g., "street" for path ["address", "street"]). This caused:
  - The UI couldn't send back the correct path for nested claim disclosure — ["street"] instead of ["address", "street"]
  - Two different paths with the same leaf name collided (e.g., ["address", "street"] vs ["billing", "street"])
  - Array indices were invisible — ["courses", 0] and ["courses", 1] both produced Id: "courses"

  ### Changes
  Core types (common/clientmodels/):
  - Attribute.Id removed, ClaimPath []any added
  - AttributeValue.Array, .Object removed; AttributeType_Array, _Object removed
  - NewAttributeValue only handles scalars; callers flatten arrays/objects
  - ClaimPathKey() utility added for map lookups
  - Satisfaction checks updated to use ClaimPathKey

  Handlers (eudi/, client/):
  - EUDI SD-JWT handler flattens arrays (["courses"] → ["courses", 0], ["courses", 1], ...) and objects (["address"] → ["address", "street"], ["address", "city"], ...)
  - All attribute construction sites updated across client.go, schemaless.go, session_handler.go, openid4vp_adapters.go, credential_service.go, both DCQL handlers, OID4VCI client

  Tests (internal/sessiontest/):
  - requireAttrsInOrder — checks path, display name, optional description, value, exact count and order
  - requireVerifierReceivedClaims with claim(path, value) — checks veramo verifier received expected claims at full paths, rejects unexpected claims
  - requireIrmaServerResult — checks IRMA server received correct disclosed attributes
  - expectedAttr struct with mandatory DisplayName — all assertions include display name verification
  - All ClaimPath[0].(string) anti-patterns eliminated
  - pk() and attributeMap() moved to shared session_helpers_test.go
  - Multi-line formatting on all expectedAttr struct literals