### PR TITLE
Increase the client context deadline timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fix
 - Bug that keyshare regisration failed when users email domain had no MX records.
 
+### Changed
+- Requests using irma.HTTPTransport have a doubled response timeout (20 seconds) to accomodate for slow and/or foreign connections
+
 ## [0.19.2] - 2026-02-26
 ### Fix
 - Bug that caused HTTP request body to not be sent upon retransmission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug that keyshare regisration failed when users email domain had no MX records.
 
 ### Changed
-- Requests using irma.HTTPTransport have a doubled response timeout (20 seconds) to accomodate for slow and/or foreign connections
+- Requests using irma.HTTPTransport have a doubled response timeout (20 seconds) to accommodate for slow and/or foreign connections
 
 ## [0.19.2] - 2026-02-26
 ### Fix

--- a/transport.go
+++ b/transport.go
@@ -27,7 +27,7 @@ import (
 	"github.com/privacybydesign/irmago/internal/disable_sigpipe"
 )
 
-const responseDeadline = 10 * time.Second
+const responseDeadline = 20 * time.Second
 
 // HTTPTransport sends and receives JSON messages to a HTTP server.
 type HTTPTransport struct {


### PR DESCRIPTION
Especially users from abroad are having issues with `context deadline exceeded (Client.Timeout or context cancellation while reading body)` errors.
Increasing the context timeout should help a little.