### PR TITLE
fix: empty con swallows disclosed attributes (irmamobile #360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fix
 - Bug that keyshare registration failed when users email domain had no MX records.
+- Bug where an empty `con` in a `condiscon` request caused all attribute disclosures to be swallowed, even when other `con`s were satisfied (irmamobile #360)
 
 ### Deprecated
 - `irma server` flags `--email` / `-e` and `--no-email`, and the `email` config key, are no longer used. They are still accepted for backwards compatibility but will emit a deprecation warning when set.

--- a/irma/irmago_test.go
+++ b/irma/irmago_test.go
@@ -1648,3 +1648,31 @@ func TestInstallSchemeUnstableRemote(t *testing.T) {
 	err = conf.ParseFolder()
 	require.NoError(t, err)
 }
+
+// TestEmptyConSatisfyDoesNotSwallowDisclosure reproduces irmamobile issue #360:
+// a discon shaped like [[], [<optional attr>]] caused the optional attribute the
+// user actually disclosed to be silently dropped from the verification result,
+// because AttributeCon.Satisfy reported the empty conjunction as satisfied without
+// looking at the disclosed-attribute indices provided for that disjunction.
+func TestEmptyConSatisfyDoesNotSwallowDisclosure(t *testing.T) {
+	t.Run("empty con with no indices is satisfied", func(t *testing.T) {
+		var c AttributeCon
+		satisfied, attrs, err := c.Satisfy(nil, nil, nil, nil)
+		require.NoError(t, err)
+		require.True(t, satisfied)
+		require.Empty(t, attrs)
+	})
+
+	t.Run("empty con must NOT be satisfied when something was disclosed for it", func(t *testing.T) {
+		// Non-empty indices means the user disclosed an attribute for this disjunction,
+		// so the empty con cannot have been the chosen option. If Satisfy reports the
+		// empty con as satisfied here, AttributeDisCon.Satisfy short-circuits on it
+		// and drops the disclosed value.
+		var c AttributeCon
+		indices := []*DisclosedAttributeIndex{{CredentialIndex: 0, AttributeIndex: 4}}
+		satisfied, _, err := c.Satisfy(nil, indices, nil, nil)
+		require.NoError(t, err)
+		require.False(t, satisfied,
+			"empty conjunction was reported satisfied even though indices indicate the user disclosed an attribute for this disjunction (issue #360)")
+	})
+}

--- a/irma/irmago_test.go
+++ b/irma/irmago_test.go
@@ -1675,4 +1675,20 @@ func TestEmptyConSatisfyDoesNotSwallowDisclosure(t *testing.T) {
 		require.False(t, satisfied,
 			"empty conjunction was reported satisfied even though indices indicate the user disclosed an attribute for this disjunction (issue #360)")
 	})
+
+	// Drives AttributeDisCon.Satisfy with the exact [[], [optional]] shape
+	// from issue #360: pre-fix, the empty con short-circuits the disjunction
+	// and the disclosed attribute is dropped from the returned attrs.
+	t.Run("discon [[], [optional]] returns the disclosed attribute", func(t *testing.T) {
+		conf, _, disclosure := parseDisclosure(t)
+		discon := AttributeDisCon{
+			AttributeCon{},
+			AttributeCon{NewAttributeRequest("irma-demo.RU.studentCard.studentID")},
+		}
+		satisfied, attrs, err := discon.Satisfy(disclosure.Proofs, disclosure.Indices[0], nil, conf)
+		require.NoError(t, err)
+		require.True(t, satisfied)
+		require.Len(t, attrs, 1, "disjunction satisfied by empty con instead of the [optional] con — disclosed attribute dropped (issue #360)")
+		require.Equal(t, "456", *attrs[0].RawValue)
+	})
 }

--- a/irma/requests.go
+++ b/irma/requests.go
@@ -452,6 +452,11 @@ func (c AttributeCon) Satisfy(proofs gabi.ProofList, indices []*DisclosedAttribu
 	}
 	attrs := make([]*DisclosedAttribute, 0, len(c))
 	if len(c) == 0 {
+		// Non-empty indices means the user disclosed for this disjunction; the
+		// empty con cannot be the chosen option (irmamobile #360).
+		if len(indices) > 0 {
+			return false, nil, nil
+		}
 		return true, attrs, nil
 	}
 


### PR DESCRIPTION
## Summary
`AttributeCon.Satisfy` returned `(true, [])` for the empty conjunction without inspecting the supplied disclosed-attribute indices. When a disjunction was shaped like `[[], [optionalAttr]]`, `AttributeDisCon.Satisfy` iterated cons in order, hit the empty con first, accepted it as satisfied, and silently dropped the optional attribute the user actually disclosed.

Treat the empty con as satisfied only when no attributes were disclosed for this disjunction. Covered by new unit test `TestEmptyConSatisfyDoesNotSwallowDisclosure`.

Fixes privacybydesign/irmamobile#360.