### PR TITLE
Make pre-authorized code flow the preferred method

### DIFF
--- a/eudi/openid4vci/session.go
+++ b/eudi/openid4vci/session.go
@@ -323,11 +323,11 @@ func claimDisplayToTranslatedString(displays []metadata.Display) clientmodels.Tr
 }
 
 func (s *session) configureIssuerSettings() error {
-	// Determine which grant-type to use (Authorization Code is preferred over Pre-Authorized Code)
-	if s.credentialOffer.Grants.AuthorizationCodeGrant != nil {
-		s.issuerSettings.grantType = s.credentialOffer.Grants.AuthorizationCodeGrant
-	} else if s.credentialOffer.Grants.PreAuthorizedCodeGrant != nil {
+	// Determine which grant-type to use (Pre-Authorized Code is preferred over Authorization Code).
+	if s.credentialOffer.Grants.PreAuthorizedCodeGrant != nil {
 		s.issuerSettings.grantType = s.credentialOffer.Grants.PreAuthorizedCodeGrant
+	} else if s.credentialOffer.Grants.AuthorizationCodeGrant != nil {
+		s.issuerSettings.grantType = s.credentialOffer.Grants.AuthorizationCodeGrant
 	} else {
 		return fmt.Errorf("no supported grant type found in credential offer")
 	}

--- a/eudi/openid4vci/session_test.go
+++ b/eudi/openid4vci/session_test.go
@@ -371,6 +371,69 @@ func Test_openid4vciSession_configureIssuerSettings_credentialRequestEncryption(
 	}
 }
 
+func Test_openid4vciSession_configureIssuerSettings_grantSelection(t *testing.T) {
+	authGrant := &AuthorizationCodeGrant{}
+	preAuthGrant := &PreAuthorizedCodeGrant{PreAuthorizedCode: "pre-auth-code"}
+
+	tests := []struct {
+		name        string
+		grants      *Grants
+		expectGrant GrantType
+		expectErr   string
+	}{
+		{
+			name:        "both grants offered prefers pre-authorized code",
+			grants:      &Grants{AuthorizationCodeGrant: authGrant, PreAuthorizedCodeGrant: preAuthGrant},
+			expectGrant: GrantType_PreAuthorizedCode,
+		},
+		{
+			name:        "only authorization code uses authorization code",
+			grants:      &Grants{AuthorizationCodeGrant: authGrant},
+			expectGrant: GrantType_AuthorizationCode,
+		},
+		{
+			name:        "only pre-authorized code uses pre-authorized code",
+			grants:      &Grants{PreAuthorizedCodeGrant: preAuthGrant},
+			expectGrant: GrantType_PreAuthorizedCode,
+		},
+		{
+			name:      "no grants returns error",
+			grants:    &Grants{},
+			expectErr: "no supported grant type found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer asServer.Close()
+
+			s := &session{
+				credentialOffer: &CredentialOffer{
+					CredentialIssuer: asServer.URL,
+					Grants:           tt.grants,
+				},
+				credentialIssuerMetadata: &metadata.CredentialIssuerMetadata{},
+				issuerSettings:           openid4vciSessionIssuerSettings{},
+			}
+
+			err := s.configureIssuerSettings()
+
+			if tt.expectErr != "" {
+				require.ErrorContains(t, err, tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, s.issuerSettings.grantType)
+			require.Equal(t, tt.expectGrant, s.issuerSettings.grantType.GetGrantType())
+		})
+	}
+}
+
 func Test_openid4vciSession_obtainCredential_sendsEncryptedRequest(t *testing.T) {
 	ecPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)


### PR DESCRIPTION
When an issuer offers both grants, prefer the the pre-authorized code flow for better UX.