### PR TITLE
docs: ISO/IEC 18013-5 mdoc implementation plan + EU Age Verification profile compliance plan

### DIFF
--- a/docs/av-profile-compliance-plan.md
+++ b/docs/av-profile-compliance-plan.md
@@ -1,0 +1,271 @@
+# EU Age Verification profile compliance plan
+
+Cross-check of the [mdoc implementation plan](./mdoc-implementation-plan.md) (issues
+[#562](https://github.com/privacybydesign/irmago/issues/562)–[#569](https://github.com/privacybydesign/irmago/issues/569))
+against the **EU Age Verification (AV) technical specification**, plus a delivery plan for
+making **go-passport-issuer** an AV-compliant Attestation Provider issuing over OpenID4VCI.
+
+Sources:
+
+- [AV architecture & technical specifications](https://ageverification.dev/av-doc-technical-specification/docs/architecture-and-technical-specifications/)
+- [Annex A — AV profile](https://ageverification.dev/av-doc-technical-specification/docs/annexes/annex-A/annex-A-av-profile/)
+- Local reference issuer: `~/code/go-passport-issuer` (currently issues passport/idcard/eDL
+  credentials over the IRMA protocol via signed IRMA session-request JWTs)
+
+Spec versions are pre-1.0 and several items are marked "TBD" in Annex A; re-verify
+identifiers against the published profile before each milestone lands.
+
+---
+
+## 1. What the AV profile requires (normative summary)
+
+**Credential** (Annex A):
+
+| Item | Value |
+|---|---|
+| Format | ISO/IEC 18013-5 mdoc (`mso_mdoc`) — *only* format; no SD-JWT VC option |
+| DocType | `eu.europa.ec.av.1` |
+| Namespace | `eu.europa.ec.av.1` |
+| Attributes | `age_over_18` (bool, mandatory); optional further `age_over_NN` (bool). **"SHALL NOT include any other attribute"** |
+| Crypto | P-256 / ES256 mandatory everywhere; SHA-256 for MSO value digests |
+| Validity | Single-use attestations, max ~3 months validity (main spec §3.4.3); revocation explicitly **not required** |
+| Privacy | Batch issuance (recommended batch size **30**, main spec §3.4.1); ValidityInfo timestamps with reduced precision (hh:mm:ss set to the same value) to limit linkability |
+
+**Issuance — OpenID4VCI** (Annex A):
+
+- Grant types: **both** `authorization_code` *and* `urn:ietf:params:oauth:grant-type:pre-authorized_code` are mandatory for the Attestation Provider (AP).
+- PKCE (RFC 7636) with `S256` MUST be supported and used by both wallet (AVI) and AP.
+- Authorization request scope: `proof_of_age`; `credential_configuration_ids` is an array with the single element `proof_of_age`.
+- Credential endpoint: `proofs` parameter, array of proofs of type **JWT** (→ batch issuance via multiple proofs in one request).
+- Credential offer invocation: custom URL scheme **`av://`** MUST be supported.
+- Enrolment at LoA *substantial*: via eID/IdP (auth-code flow) or document-based ICAO 9303 NFC verification (pre-auth flow) — the latter is exactly what go-passport-issuer does.
+- AP metadata profile: marked **TBD** in Annex A.
+
+**Presentation** (Annex A):
+
+- **Primary**: W3C **Digital Credentials API** with protocol `org-iso-mdoc` per ISO/IEC 18013-7 Annex C — request carries base64url CBOR `DeviceRequest` + `EncryptionInfo`; response is a CBOR `EncryptedResponse` (`enc`, `cipherText`) using **HPKE (RFC 9180)**. Reader authentication out of scope.
+- **Fallback**: OpenID4VP when the DC API is unavailable:
+  - response type `vp_token`, response mode **`direct_post`** (explicitly *not* `direct_post.jwt`),
+  - request passed **by value, unsigned** (no JAR), client identifier scheme **`redirect_uri`**, no client authentication,
+  - **DCQL** query language, mandatory `nonce`, optional `state`.
+- Proximity presentation: out of scope.
+
+**Trust model**:
+
+- APs register on an AV **trusted list** (ETSI TS 119 612, published on the eIDAS dashboard `av-tl`); document signer certificate per **ETSI EN 319 411-1 (NCP)** or AP-operated trust anchor CA.
+- No trusted lists / registration for wallets or relying parties; RP authentication relies on TLS/Web PKI.
+- Out of scope in the current profile: device-bound attestations (hardware key attestation / WSCD), re-issuance via refresh tokens, revocation, LoA high.
+
+**ZKP** (SHOULD, not MUST): wallets SHOULD support ZK presentations using "Anonymous
+credentials from ECDSA" (Frigo & shelat; google/longfellow-zk); RPs SHOULD verify them.
+
+---
+
+## 2. Cross-check against the mdoc implementation plan
+
+### 2.1 Already aligned — no changes needed
+
+| AV requirement | Where the plan covers it |
+|---|---|
+| `mso_mdoc` format, ES256/P-256, SHA-256 digests | M1/M2 (#563, #564) — ES256-first is already the stated default |
+| DocType `eu.europa.ec.av.1`, `age_over_NN` claims | Plan is docType/namespace-agnostic; pure configuration, no code change. Boolean CBOR values are part of the M4 claims-projection mapping |
+| Pre-authorized code + authorization code flows | M5 (#567) covers both; irmago's OpenID4VCI client already implements both incl. PKCE |
+| JWT proofs, `proofs` array → batch issuance | M5; matches the existing SD-JWT batch pattern (one key per instance) |
+| Single-use attestations, batch bookkeeping | M4 (#566) reuses `RemainingCount` single-use semantics; batch size 30 is configuration |
+| DCQL with `[namespace, element]` claim paths | M6 (#568) |
+| `direct_post` response mode | M6 — already in scope (the *plain* variant is what AV mandates) |
+| No revocation requirement | Plan already defers status lists — now confirmed acceptable for AV |
+| No proximity / BLE-NFC | Plan already out of scope — confirmed acceptable for AV |
+| Device keys without hardware attestation | The profile keeps JWT proofs and the ZKP spec references "the attestation public key", so the MSO `deviceKeyInfo`/DeviceAuth machinery from M2/M3/M6 stays; WSCD-grade key attestation is explicitly out of scope. ⚠️ Verify against the AV reference apps during interop whether their attestations are actually device-bound (Annex A's "device bound … out of scope" wording is ambiguous) |
+
+### 2.2 Amendments to existing milestones (small deltas)
+
+1. **M3 (#565) — timestamp precision reduction.** The MSO builder must support the
+   linkability mitigation from main spec §3.4.1: `signed`/`validFrom`/`validUntil` with
+   hh:mm:ss forced to a fixed value (per the ISO 18013-5 recommendation). Add a
+   `ValidityInfo` truncation option + tests asserting equal time-of-day across a batch.
+2. **M3/M5 — validity window policy.** Make max validity configurable and add an AV
+   preset (≤ 3 months). Wallet-side (M5) only needs to *not reject* short-lived
+   credentials; issuer-side enforcement lands in go-passport-issuer (§3 below).
+3. **M5 (#567) — AV credential configuration fixture.** Add a `proof_of_age` /
+   `eu.europa.ec.av.1` credential configuration (scope `proof_of_age`, single-element
+   `credential_configuration_ids`, claims metadata for `age_over_18`) to the hermetic
+   test issuer and the metadata-validator tests, so AV compliance is continuously
+   tested rather than assumed. Batch test should include size 30.
+4. **M5/M6 — `av://` invocation scheme.** Credential-offer and authorization-request
+   parsing must accept the `av://` custom scheme in addition to `openid-credential-offer://`
+   / `openid4vp://` / https links. Mostly app-level URL routing, but irmago's
+   offer/request URI parsing should be scheme-lenient; add unit tests.
+5. **M6 (#568) — unsigned requests with `client_id` scheme `redirect_uri`.** Gap found
+   during cross-check: irmago's OpenID4VP client currently *requires* a signed request
+   JWT (`ParseAndVerifyAuthorizationRequest(requestJwt)` in
+   `eudi/openid4vp/verifier_validator.go:15`, with X.509/DID verifier validation).
+   The AV fallback profile mandates plain, unsigned, by-value authorization requests
+   with the `redirect_uri` client-id scheme and **no** client authentication. Add a
+   trust-policy-gated request path (e.g. only for queries targeting AV docTypes, or an
+   explicit "web-PKI verifier" mode) that accepts unsigned requests; the
+   SessionTranscript handover must then bind `client_id = redirect_uri value`. Update
+   the `DisclosureContext` design in M6 accordingly.
+6. **M2/M7 — AV trusted list as trust-anchor source.** Extend the IACA trust-anchor
+   configuration (M2 verification) with an ETSI TS 119 612 trusted-list (XML TSL)
+   fetcher/parser feeding `eudi/trustmodel.go`, pointed at the eIDAS `av-tl` dashboard
+   list. Cache + signature validation of the TSL itself. Can land as part of M7 or as
+   its own small milestone; verification tests with a self-built TSL fixture.
+
+### 2.3 New features required by the AV profile (proposed new milestones)
+
+**M8 — Digital Credentials API presentation (ISO/IEC 18013-7 Annex C).** The AV profile
+makes the DC API the *primary* presentation channel; OpenID4VP is only the fallback. The
+original plan explicitly scoped DC API out. New milestone, depends on M2/M3 (+M6 for the
+shared selective-disclosure machinery):
+
+- Parse `org-iso-mdoc` protocol requests: base64url CBOR `DeviceRequest`
+  (ISO 18013-5 §8.3.2.1.2.1 — itemsRequest with docType + namespace/element map +
+  intentToRetain) and `EncryptionInfo`.
+- Build the Annex C SessionTranscript / DC-API handover (distinct from
+  `OpenID4VPHandover`; keep both in the one isolated handover-construction function
+  already planned in M6).
+- Encrypt the `DeviceResponse` as `EncryptedResponse{enc, cipherText}` with **HPKE
+  (RFC 9180)** — new dependency (e.g. `github.com/cisco/go-hpke` or x/crypto HPKE),
+  P-256/HKDF-SHA256/AES-GCM suite.
+- Wallet-app plumbing (Android/iOS DC API registration, `av://`) is out of irmago's
+  scope but the irmago API must expose a "answer this DeviceRequest" entry point that
+  the app can call from the OS credential-provider callback.
+- Tests: hermetic request→encrypted-response→decrypt→verify round trip; ISO 18013-7
+  Annex C test vectors if available; interop against the AV reference verifier service.
+
+**M9 (optional, SHOULD) — ZK presentations.** Annex A recommends "Anonymous credentials
+from ECDSA" (longfellow-zk). Treat as an exploratory follow-up: track upstream Go
+support, do not block AV compliance on it (it is a SHOULD for wallets). Out of plan
+until the profile hardens.
+
+---
+
+## 3. go-passport-issuer: becoming an AV Attestation Provider
+
+Current state (from code review): a Go service that performs ICAO 9303 passive + active
+authentication of passports/ID cards/eDLs (via `gmrtd`), extracts attributes incl.
+ready-made `Over12/16/18/21/65` age predicates, and issues credentials by returning a
+**signed IRMA session-request JWT** (`jwt_creator.go`, `irma.SignSessionRequest`, RS256)
+that the app redeems at a Yivi IRMA server. No OAuth2/OpenID4VCI/COSE code today; the
+document-validation side is cleanly separated from issuance and reusable as-is.
+
+go-passport-issuer maps onto the AV architecture as an **AP doing document-based
+enrolment** (main spec §3.3.2: ICAO 9303 MRZ+NFC, which it already implements) — the
+pre-authorized code flow is the natural fit, with the auth-code flow added for profile
+completeness (both grants are mandatory).
+
+Phases, each independently deliverable and automatically tested:
+
+### P1 — proof_of_age mdoc minting
+
+Depends on irmago M3 (#565); go-passport-issuer already depends on irmago, so consume
+`eudi/credentials/mdoc` as a library (bump to the branch/tag that ships it).
+
+- New `backend/mdocissuer/` package: build an `eu.europa.ec.av.1` mdoc from a validated
+  document: `age_over_18` (+ configurable extra `age_over_NN`) computed from DOB at
+  issuance time — reuse the existing age-predicate logic, but emit **only** age claims
+  (Annex A forbids any other attribute, so this is a *separate* credential from the
+  existing full passport credential).
+- ES256/P-256 DS key + IACA chain handling: new key material alongside the existing RSA
+  IRMA-JWT key; config entries for DS cert/key and IACA chain paths.
+- AV policy knobs: validity ≤ 3 months, ValidityInfo timestamp truncation, batch size
+  (default 30).
+- Tests: unit tests minting from fixture `PassportData`; verification with irmago's M2
+  verifier; golden-file CBOR fixture; negative test that non-age attributes are rejected.
+
+### P2 — OpenID4VCI issuer core
+
+- New `backend/openid4vci/` package implementing the AP endpoints:
+  - `/.well-known/openid-credential-issuer` + `/.well-known/oauth-authorization-server`
+    metadata with the `proof_of_age` credential configuration (`format: mso_mdoc`,
+    `doctype: eu.europa.ec.av.1`, claims, `cryptographic_binding_methods_supported:
+    [cose_key]`, `credential_signing_alg_values_supported: [ES256]`, batch size). AP
+    metadata details are TBD in Annex A — keep this table config-driven.
+  - Token endpoint: `pre-authorized_code` grant (+ optional tx_code) and
+    `authorization_code` grant, PKCE `S256` enforced on both per the profile.
+  - Nonce endpoint (`c_nonce`) and credential endpoint: validate `proofs` JWT array
+    (nonce freshness, ES256, `cnf` key extraction), mint one mdoc per proof via P1,
+    return base64url CBOR credentials.
+  - Credential-offer generation: `openid-credential-offer://` and **`av://`** URIs + QR.
+- Reuse the existing `TokenStorage` (memory/Redis/Sentinel) for pre-auth codes, auth
+  codes, nonces and PKCE challenges (same TTL semantics as today's session nonces).
+- Tests: httptest-level unit tests per endpoint; **hermetic end-to-end test using the
+  irmago OpenID4VCI wallet client (M5) as the harness** — the same client the Yivi app
+  uses, giving continuous wallet↔issuer interop coverage in CI.
+
+### P3 — wire into the document-validation flow
+
+- Extend the validation API: after successful passive+active authentication, offer the
+  result over either protocol, config-driven per deployment:
+  - existing: IRMA session-request JWT (unchanged),
+  - new: `POST /api/issue-proof-of-age` → credential offer (pre-auth code bound to the
+    validated session's derived age predicates in `TokenStorage`; the full
+    `PassportData` need not be retained — data minimisation).
+- Session hygiene: one credential offer per validated session, single redemption,
+  existing session-reuse protections extended to the pre-auth code.
+- Tests: extend `integration_test.go` to cover validate→offer→token→credential against
+  the in-process OID4VCI server with the irmago client; negative tests for replayed
+  sessions/codes and expired offers.
+
+### P4 — authorization code flow (eID/IdP-less variant)
+
+Annex A makes the `authorization_code` grant mandatory for APs. Implement a minimal
+authorization endpoint that drives the existing browser-based NFC validation UI as the
+"authorization" interaction (user lands on the frontend, scans the document, the
+completed validation redeems the auth code), with PKCE. An eIDAS/IdP connector (the
+other enrolment path from main spec §3.3.1) is out of scope for this service.
+
+- Tests: full auth-code+PKCE flow with the irmago client and a fake validator.
+
+### P5 — AV trust & operational compliance
+
+- DS certificate per **ETSI EN 319 411-1 (NCP)** or an own IACA; document the chosen
+  PKI path and key ceremony; config validation that refuses non-P-256 keys for AV.
+- Registration of the AP on the AV trusted list (eIDAS dashboard `av-tl`) — operational
+  task; track in deployment runbooks. Test environments use a self-signed IACA + local
+  TSL fixture (shared with the irmago trusted-list work, §2.2 item 6).
+- Privacy review against main-spec §2.4: confirm no PII beyond `age_over_NN` leaves the
+  issuance path, batch unlinkability (fresh salts/digestIDs per mdoc — guaranteed by
+  the M3 builder), truncated timestamps, no retention of passport data after issuance.
+
+### P6 — AV interop & conformance
+
+- Interop against the AV reference implementation (white-label app + verification
+  service from ageverification.dev / GitHub): issue from go-passport-issuer into the
+  reference AVI; present from the Yivi app to the reference verifier (OpenID4VP
+  fallback first, DC API once irmago M8 lands).
+- Add a docker-compose profile with the AV reference verifier for CI, mirroring the
+  existing veramo/python-issuer interop setup in irmago.
+
+```
+P1 (minting) → P2 (OID4VCI core) → P3 (flow wiring) → P5 (trust/ops) → P6 (interop)
+                                  └→ P4 (auth-code flow, parallel with P3)
+irmago prerequisites: M3 for P1; M5 for the P2/P3/P4 test harness; M6 (+ amendments) and M8 for P6 presentation interop.
+```
+
+---
+
+## 4. Open questions / risks
+
+1. **Device binding ambiguity.** Annex A lists "device bound Proof of Age attestations"
+   as out of scope, yet mandates JWT proofs at issuance and the ZKP section references
+   the attestation public key. Working assumption: MSO carries a device key and
+   DeviceAuth works as in 18013-5, but hardware-backed key attestation is not required.
+   Confirm against the AV reference issuer's actual MSOs during P6 — if reference
+   attestations carry **no** device key, irmago M2/M6 must tolerate MSOs without
+   `deviceKeyInfo` and DeviceResponses without DeviceAuth, which is a (small) data-model
+   delta worth knowing early.
+2. **Unversioned spec references.** Annex A pins neither the OID4VCI nor the OID4VP
+   draft, and AP metadata is "TBD". The M6 handover-isolation decision and the
+   config-driven AP metadata in P2 are the mitigations; re-check the profile before
+   each milestone.
+3. **`direct_post` without response encryption** means the age signal travels in a
+   plain POST (TLS only). That follows the profile, but keep `direct_post.jwt` support
+   (already in the plan) for non-AV deployments.
+4. **DC API dependency on app/platform work.** irmago M8 delivers the protocol layer,
+   but AV-primary-path compliance also needs Android/iOS credential-provider
+   integration in the Yivi app — track that in the app repos, it is not covered here.
+5. **Trusted-list operational dependency.** P5 registration on the `av-tl` list is a
+   process with the Commission, not code; start it early since P6 interop against
+   production-profile verifiers may depend on it (test lists exist for development).

--- a/docs/mdoc-implementation-plan.md
+++ b/docs/mdoc-implementation-plan.md
@@ -1,0 +1,329 @@
+# ISO/IEC 18013-5 mdoc support in irmago
+
+Implementation plan for landing the `mso_mdoc` credential format in irmago, covering
+**issuance to the wallet via OpenID4VCI** and **disclosure via OpenID4VP (DCQL)**.
+
+Reference implementation used throughout this plan: [multipaz](https://github.com/openwallet-foundation-labs/identity-credential)
+(local checkout: `~/code/multipaz`). Relevant specs:
+
+- ISO/IEC 18013-5:2021 — mdoc data model, MSO, DeviceResponse, selective disclosure
+- ISO/IEC TS 18013-7 — mdoc over OpenID4VP (SessionTranscript / OID4VP handover)
+- OpenID4VCI — `mso_mdoc` credential configuration format
+- OpenID4VP — DCQL queries with format `mso_mdoc`, vp_token encoding
+- RFC 9052/9053 (COSE), RFC 8949 (CBOR)
+
+---
+
+## 1. Current state of irmago
+
+The `openid4vci` branch already contains most of the *format-agnostic* plumbing. mdoc is
+recognized but not implemented anywhere:
+
+| Area | Status | Location |
+|---|---|---|
+| Format identifier `mso_mdoc` | exists | `eudi/metadata/metadata.go:142` |
+| Client credential format enum | only `dc+sd-jwt`, `idemix` | `common/clientmodels/enums.go:26` |
+| OpenID4VCI metadata validation | `MdocFormatVerifier` is a **stub** (accepts anything); `ValidateSupportedFeatures()` **rejects** anything that is not SD-JWT VC | `eudi/openid4vci/metadata_validators.go:161,176` |
+| OpenID4VP vp_formats | `MdocClientMedataVpFormat` (COSE alg list) parsed but unused | `eudi/openid4vp/openid4vp.go:47` |
+| DCQL dispatch | pluggable `DcqlCredentialQueryHandler` interface; only SD-JWT handlers registered | `eudi/openid4vp/dcql/credential_query_handler.go:36`, `eudi/openid4vp/client.go:57` |
+| Credential storage | GORM models with explicit TODO for polymorphic multi-format support | `eudi/storage/db/models/credentials.go:11` |
+| Holder/device keys | ECDSA P-256 key storage keyed by JWK thumbprint, reusable as-is | `eudi/storage/db/holderbindingkey_store.go`, `irma/irmaclient/keybinding_storage.go` |
+| CBOR | `fxamacker/cbor v1.5.1` (legacy, used for revocation) | `go.mod` |
+| COSE | none | — |
+| Integration tests | dockerized issuers/verifiers (`docker-compose.yml`: veramo OID4VCI issuer, python EUDI PID issuer, OID4VP verifier) driven from `internal/sessiontest/` | `internal/sessiontest/openid4vci_issuance_test.go`, `openid4vp_*_test.go` |
+
+The SD-JWT VC integration (`eudi/credentials/sdjwtvc/`, `eudi/openid4vp/eudi_sdjwt_dcql/`)
+is the architectural precedent: a self-contained credential-format package plus a
+DCQL handler, wired into the client through existing interfaces.
+
+## 2. Scope and non-goals
+
+**In scope (wallet/holder side):**
+
+- Receiving `mso_mdoc` credentials via OpenID4VCI (pre-authorized + authorization code
+  flows, batch issuance) and verifying them against trust anchors before storage.
+- Storing mdoc credentials and their device keys alongside SD-JWT VCs.
+- Answering DCQL `mso_mdoc` queries and producing a `DeviceResponse` in a vp_token
+  (response modes `direct_post` and `direct_post.jwt`), with selective disclosure and
+  `deviceSignature` device auth.
+- Enough *issuer/verifier-side* mdoc code to build test fixtures and run hermetic
+  end-to-end tests in-process (this code is production-quality and may later back a
+  Yivi mdoc issuer, but exposing a public issuer API is not a goal of this plan).
+
+**Out of scope (for now):**
+
+- `deviceMac` device auth (requires ECDH with an ephemeral reader key; OpenID4VP flows
+  in practice use `deviceSignature`). The data model will represent both variants.
+- Proximity flows (BLE/NFC device engagement, session encryption from 18013-5 §9.1.1).
+- Digital Credentials API (`dc_api` response modes / `OpenID4VPDCAPIHandover`) — the
+  handover construction is designed so this can be added later.
+- Zero-knowledge variants (`mso_mdoc_zk`).
+- mdoc revocation/status lists (follow-up; MSO `status` field is parsed and preserved).
+
+## 3. Key design decisions
+
+1. **Dependencies.** Add `github.com/fxamacker/cbor/v2` (different import path than the
+   existing v1, so both coexist; v2 is required for proper tag-24 and deterministic
+   encoding support) and `github.com/veraison/go-cose` for `COSE_Sign1`. `COSE_Key` and
+   (later) `COSE_Mac0` are small enough to implement in-repo on top of cbor/v2.
+
+2. **New package `eudi/credentials/mdoc/`**, sibling of `sdjwtvc/`, containing the full
+   data model, encoding, building (issuer side), and verification (holder + verifier
+   side). No dependency on OpenID4VCI/VP packages — those depend on it.
+
+3. **Reuse the holder-binding key machinery** for mdoc device keys: same ECDSA P-256
+   generation, same encrypted storage, same one-key-per-batch-instance model. The MSO's
+   `deviceKeyInfo.deviceKey` is the COSE_Key form of the JWK that already goes into the
+   OpenID4VCI proof JWT `cnf` claim — no new proof type needed.
+
+4. **DCQL handler interface change.** `PrepareDisclosure(selections, nonce, clientId)`
+   is insufficient for mdoc: the OID4VP `SessionTranscript` handover additionally needs
+   `response_uri` and (for encrypted responses) the verifier's encryption JWK
+   thumbprint. Extend the interface to pass a `DisclosureContext` struct instead of
+   bare `nonce`/`clientId`. This is the only cross-format interface change required.
+
+5. **Storage** follows the existing TODO in `eudi/storage/db/models/credentials.go`:
+   add a `Format` discriminator to `CredentialBatch` / `IssuedCredentialInstance`, store
+   the raw `IssuerSigned` CBOR in `RawCredential`, and store a processed claims
+   projection (namespace → element → JSON value) for display/candidate matching, in the
+   same spot where the processed SD-JWT payload lives today.
+
+6. **SessionTranscript handover**: implement the structure used by current OpenID4VP
+   drafts (multipaz "DRAFT_29" variant, `mdoc/response/MdocDocument.kt` +
+   `openid/OpenID4VP.kt#openID4VPMsoMdoc`):
+
+   ```
+   HandoverInfo   = [ client_id, nonce, jwk_thumbprint | null, response_uri | null ]
+   SessionTranscript = [ null, null, [ "OpenID4VPHandover", SHA-256(cbor(HandoverInfo)) ] ]
+   ```
+
+   Verify against the draft version irmago's verifiers actually implement during M6
+   interop testing; the construction is isolated in one function so a draft-24 variant
+   is a small addition if needed.
+
+---
+
+## 4. Milestones
+
+Each milestone is independently mergeable, fully covered by automated tests, and does
+not regress existing SD-JWT VC / idemix flows (CI gate: existing test suite stays green).
+
+### M1 — CBOR/COSE foundation
+
+**Deliverable:** low-level primitives every later milestone builds on.
+
+- Add `fxamacker/cbor/v2` and `veraison/go-cose` to `go.mod`.
+- `eudi/credentials/mdoc/cbor.go`: encode/decode helpers with the fixed cbor/v2
+  `EncOptions`/`DecOptions` for 18013-5 (core deterministic-ish encoding, tag 24
+  `EncodedCBOR` wrapper type `#6.24(bstr .cbor X)`, full-date tag 1004, tdate tag 0
+  with RFC 3339 no-fractional-seconds UTC).
+- `eudi/credentials/mdoc/cose.go`: `COSE_Key` (EC2/P-256 ⇄ `*ecdsa.PublicKey` ⇄ JWK),
+  thin wrappers around go-cose `Sign1` for sign/verify with protected `alg` and
+  unprotected `x5chain` (label 33) headers.
+
+**Automated tests:**
+
+- Round-trip tests for every helper; deterministic-encoding byte-equality tests.
+- COSE_Sign1 sign/verify against fixed keys; cross-check one signature against a
+  COSE example from RFC 9052 / an ISO 18013-5 Annex D test vector (multipaz keeps
+  these in `multipaz/src/commonTest/.../mdoc/TestVectors.kt` — port the hex blobs).
+- COSE_Key ⇄ JWK ⇄ ecdsa.PublicKey conversion fuzz/round-trip tests.
+
+### M2 — mdoc data model: parsing and verification
+
+**Deliverable:** `eudi/credentials/mdoc/` can parse and cryptographically verify an
+mdoc produced by any conformant issuer. This is the holder's "check before storing"
+capability and the core of any later verifier.
+
+Types (mirroring multipaz `mdoc/mso/MobileSecurityObject.kt`,
+`mdoc/issuersigned/IssuerSignedItem.kt`, `mdoc/response/DeviceResponse.kt`):
+
+- `IssuerSignedItem` (digestID, random ≥16 bytes, elementIdentifier, elementValue) —
+  **must preserve original encoded bytes** for digest recomputation.
+- `IssuerNameSpaces`, `IssuerSigned` (`nameSpaces` + `issuerAuth` COSE_Sign1).
+- `MobileSecurityObject` (version, digestAlgorithm, docType, valueDigests,
+  deviceKeyInfo incl. keyAuthorizations, validityInfo, optional status).
+- `Document`, `DeviceSigned`, `DeviceAuth` (signature | mac), `DeviceResponse`.
+
+Verification (`Verifier` type, mirroring multipaz `DeviceResponse.verify`):
+
+1. issuerAuth COSE_Sign1 signature with leaf cert from x5chain;
+2. x5chain validation to a configured IACA trust anchor set — reuse/extend the existing
+   `eudi/trustmodel.go` / `trustanchors.go` X.509 infrastructure;
+3. recomputed digests of all present IssuerSignedItems == MSO valueDigests entries;
+4. docType consistency, validityInfo window, digest algorithm allow-list;
+5. (DeviceResponse only) DeviceAuth `deviceSignature` over `DeviceAuthentication =
+   ["DeviceAuthentication", SessionTranscript, docType, #6.24(DeviceNameSpaces)]`
+   against the MSO device key.
+
+**Automated tests:**
+
+- Parse + verify the ISO 18013-5 Annex D mDL test vector (issuer-signed structure and
+  full DeviceResponse, including the known SessionTranscript) — ported from multipaz.
+- Negative tests: tampered element value (digest mismatch), wrong cert chain, expired
+  validityInfo, unknown digest algorithm, duplicate digestIDs, salt < 16 bytes.
+
+### M3 — mdoc building: issuer and device sides
+
+**Deliverable:** the ability to *create* valid mdocs and DeviceResponses in-process.
+Required for hermetic tests of M4–M6; doubles as the seed of a future Yivi mdoc issuer.
+
+- `Builder` for `IssuerNameSpaces`: shuffled random digestIDs, crypto/rand 16-byte
+  salts (multipaz `IssuerNamespaces.Builder`).
+- MSO construction from a built namespace set + device public key + validity window;
+  issuerAuth signing with a DS certificate (x5chain in unprotected header).
+- Test PKI helpers: generate IACA root + DS certificate with the 18013-5 profile
+  (multipaz `MdocUtil.generateIacaCertificate` / `generateDsCertificate`) under
+  `eudi/credentials/mdoc/testutil/` or `internal/`.
+- `DeviceResponse` builder: selective disclosure by filtering IssuerSignedItems on
+  requested `[namespace, element]` pairs; `DeviceAuthentication` assembly;
+  `deviceSignature` with a device private key; SessionTranscript taken as an opaque
+  input (handover construction comes in M6).
+
+**Automated tests:**
+
+- Full in-process round trip: build → sign → encode → decode → verify (M2 verifier),
+  for single- and multi-namespace documents, with and without selective disclosure.
+- Property test: any subset of disclosed elements verifies; any modified element fails.
+- Byte-level golden-file test for one fixed-rand fixture to catch encoding drift.
+
+### M4 — wallet storage and client surface
+
+**Deliverable:** mdoc credentials are first-class citizens in wallet storage, credential
+listing, and logs — installable via an internal API (no OpenID4VCI yet).
+
+- `common/clientmodels/enums.go`: add `Format_MsoMdoc CredentialFormat = "mso_mdoc"`.
+- `eudi/storage/db/models/credentials.go`: add the format discriminator and mdoc
+  claims projection (the existing polymorphic-association TODO); GORM auto-migration
+  covers schema evolution — add an explicit migration test from an SD-JWT-only DB.
+- Device key storage: store/retrieve mdoc device keys through the existing
+  `HolderBindingKey` model and `irmaclient` key-binding storage (keys are indexed by
+  JWK thumbprint; the COSE_Key⇄JWK conversion from M1 makes this transparent).
+- Map mdoc claims into `clientmodels.SelectableCredentialInstance` /
+  `CredentialDescriptor` so the app UI can render them (claim path = `[namespace,
+  element]`); wire into credential listing, deletion, and `eudi_logs`.
+- `yivi eudi credentials` CLI (`yivi/cli/eudicli/credentials.go`) lists mdocs; add a
+  `yivi eudi mdoc` inspect command analogous to `sdjwt.go` (decode + verify a
+  base64url IssuerSigned/DeviceResponse blob).
+
+**Automated tests:**
+
+- Storage round-trip incl. encryption-at-rest, batch bookkeeping (`RemainingCount`),
+  and migration-from-existing-DB test.
+- Listing/log tests extended from the existing `eudi_logs_test.go` patterns, with
+  fixtures generated by M3.
+
+### M5 — OpenID4VCI issuance of mso_mdoc
+
+**Deliverable:** the wallet completes pre-authorized-code and authorization-code flows
+for an `mso_mdoc` credential configuration, verifies, and stores the result.
+
+- Implement `MdocFormatVerifier.Verify()` for real
+  (`eudi/openid4vci/metadata_validators.go:161`): require `doctype`, validate `claims`
+  paths (`[namespace, element]`), check `cryptographic_binding_methods_supported`
+  contains `cose_key` and signing algs are supported (ES256 first).
+- Lift the SD-JWT-only gate in `ValidateSupportedFeatures()`
+  (`metadata_validators.go:176`) for `mso_mdoc`.
+- Credential response handling in `eudi/openid4vci/session.go`: for `mso_mdoc`,
+  base64url-decode the credential into `IssuerSigned` CBOR, then:
+  1. verify with M2 (issuer signature, IACA trust anchors, digests, validity);
+  2. check MSO `deviceKeyInfo.deviceKey` equals the key sent in the proof JWT `cnf`;
+  3. check docType matches the offered credential configuration;
+  4. store via M4 (batch issuance: one device key + one mdoc per instance).
+- Display/consent: derive the preview shown to the user from the credential
+  configuration `claims` metadata + decoded element values.
+
+**Automated tests:**
+
+- Unit tests for the metadata validator (valid/invalid doctype, claims, binding
+  methods) mirroring the existing SD-JWT validator tests.
+- Hermetic integration test: a minimal in-process Go mdoc issuer (httptest server
+  implementing the OID4VCI endpoints, minting credentials with M3) driven through the
+  full client flow in `internal/sessiontest/openid4vci_issuance_test.go` style —
+  pre-auth flow, auth-code flow, batch size 2, tampered-credential rejection,
+  device-key-mismatch rejection.
+- Interop test: enable the mdoc PID variant in the dockerized python EUDI issuer
+  (`testdata/eudi-pid-issuer-py/conf/config_issuer_backend.yaml` currently notes
+  "mdoc variants are not configured") and extend
+  `internal/sessiontest/eudi_pid_python_issuer_test.go` to issue
+  `eu.europa.ec.eudi.pid_mdoc`.
+- `yivi eudi receive` works against both issuers (manual smoke; CLI flag coverage in
+  unit tests).
+
+### M6 — OpenID4VP disclosure of mso_mdoc
+
+**Deliverable:** the wallet answers DCQL queries with format `mso_mdoc` end to end.
+
+- **Interface change** (small, cross-format): extend
+  `DcqlCredentialQueryHandler.PrepareDisclosure` to take a `DisclosureContext{Nonce,
+  ClientId, ResponseUri, VerifierEncryptionJwk}`; update the two SD-JWT handlers
+  (they ignore the new fields) and `eudi/openid4vp/client.go`.
+- New package `eudi/openid4vp/mdoc_dcql/` implementing the handler:
+  - `CanHandleCredentialQuery`: format `mso_mdoc` (+ `meta.doctype_value`).
+  - `FindCandidates`: match stored mdocs by docType; map requested claim paths
+    `[namespace, element]` against the stored claims projection; honor `claim_sets`.
+  - `PrepareDisclosure`: build HandoverInfo/SessionTranscript (per §3.6), filter
+    IssuerSignedItems per user selection, sign `DeviceAuthentication` with the stored
+    device key, assemble `DeviceResponse` (one per query), base64url-encode into the
+    vp_token map, emit `CredentialLogs`.
+- Respect `client_metadata.vp_formats["mso_mdoc"].alg`; single-use instance
+  bookkeeping identical to SD-JWT batches.
+- Encrypted responses: `direct_post.jwt` already exists for SD-JWT
+  (`eudi/openid4vp/response.go`); ensure the mdoc vp_token flows through it and the
+  verifier's encryption JWK thumbprint lands in HandoverInfo.
+
+**Automated tests:**
+
+- Unit tests for query matching (docType, claims, claim_sets, multiple credentials,
+  no-candidates → obtainable descriptors).
+- Hermetic end-to-end test: in-process verifier (M2 + handover reconstruction)
+  receives `direct_post` and `direct_post.jwt` responses; asserts issuer signature,
+  digests, DeviceAuth against the reconstructed SessionTranscript, and that
+  *undisclosed elements are absent*.
+- Negative tests: wrong nonce / clientId / responseUri in transcript ⇒ DeviceAuth
+  verification fails; replayed device signature with new nonce fails.
+- Interop test against a dockerized external verifier supporting mdoc (extend
+  `testdata/openid4vp-verifier` config, or add the multipaz / EUDI reference verifier
+  to `docker-compose.yml`), in the style of `openid4vp_veramo_disclosure_test.go`.
+- Combined query test: one DCQL query set requesting an SD-JWT VC *and* an mdoc in the
+  same session.
+
+### M7 — hardening, conformance, docs
+
+**Deliverable:** release-ready quality gate.
+
+- Run the OpenID Foundation OID4VP/OID4VCI conformance suite where applicable; record
+  results in `docs/`.
+- Fuzz tests on the CBOR parsers (`go test -fuzz` targets for `IssuerSigned`,
+  `DeviceResponse`, `MSO`) — untrusted input enters here from issuers and requests.
+- Cross-implementation fixture exchange: verify multipaz-generated DeviceResponses in
+  irmago and vice versa (check a small fixture corpus into `testdata/eudi/mdoc/`).
+- CHANGELOG entry, package-level docs in `eudi/credentials/mdoc/`, update branch docs.
+
+---
+
+## 5. Dependency graph
+
+```
+M1 (CBOR/COSE) ─→ M2 (parse/verify) ─→ M3 (build/sign) ─→ M4 (storage/client)
+                                                            ├─→ M5 (OpenID4VCI)
+                                                            └─→ M6 (OpenID4VP)  ─→ M7
+M5 and M6 are independent of each other and can be developed in parallel.
+```
+
+## 6. Risks and open questions
+
+- **OpenID4VP draft alignment.** The handover structure changed between drafts (origin
+  vs client_id ordering, jwk thumbprint addition). Must pin against what the Yivi
+  verifier stack and the chosen interop verifiers implement; isolated in one function.
+- **cbor v1/v2 coexistence.** Two CBOR libraries in the module is acceptable but the
+  legacy v1 usage (revocation) should eventually migrate; out of scope here.
+- **`go-cose` API fit.** go-cose enforces its own header handling; if x5chain or raw
+  R||S signature handling fights us, fall back to a minimal in-repo COSE_Sign1 over
+  cbor/v2 (it is ~4 fields). Decide during M1.
+- **Claims projection fidelity.** mdoc element values are CBOR (can include tdate,
+  full-date, binary like portraits). The JSON projection for UI/DCQL matching must
+  define a stable mapping (e.g. tag 1004 → `"YYYY-MM-DD"` string, bstr → base64url);
+  DCQL value matching must follow OpenID4VP rules for non-string values.
+- **Python EUDI issuer mdoc config.** Enabling the mdoc PID variant requires IACA/DS
+  certificate config in `testdata/eudi-pid-issuer-py/`; budget time for this in M5.


### PR DESCRIPTION
Adds two planning documents:

**`docs/mdoc-implementation-plan.md`** — the implementation plan for landing the `mso_mdoc` credential format in irmago, covering issuance to the wallet via OpenID4VCI and disclosure via OpenID4VP (DCQL). It covers the current state of the `openid4vci` branch, scope and non-goals, key design decisions (CBOR/COSE dependencies, new `eudi/credentials/mdoc/` package, device key reuse, the `DcqlCredentialQueryHandler` interface extension, SessionTranscript handover construction), and independently mergeable, automatically tested milestones, using [multipaz](https://github.com/openwallet-foundation-labs/identity-credential) as the reference implementation.

**`docs/av-profile-compliance-plan.md`** — a cross-check of the mdoc plan against the [EU Age Verification technical specification](https://ageverification.dev/av-doc-technical-specification/docs/architecture-and-technical-specifications/) and its [Annex A AV profile](https://ageverification.dev/av-doc-technical-specification/docs/annexes/annex-A/annex-A-av-profile/), plus a delivery plan for making [go-passport-issuer](https://github.com/privacybydesign/go-passport-issuer) an AV-compliant Attestation Provider issuing `eu.europa.ec.av.1` proof-of-age mdocs over OpenID4VCI. Key findings: the mdoc plan is largely AV-compatible as-is; the main gaps are the W3C Digital Credentials API presentation path (ISO 18013-7 Annex C, HPKE-encrypted responses — the AV profile's *primary* channel, added as milestone M8), support for unsigned OpenID4VP requests with the `redirect_uri` client-id scheme, MSO timestamp-precision truncation, and ETSI TS 119 612 trusted-list support.

## Tracking issues

The plans have been converted to issues — one tracking issue with the milestones as sub-issues:

- #562 — ISO/IEC 18013-5 mdoc support + EU AV profile compliance (tracking issue)
  - irmago milestones:
    - #563 — M1: CBOR/COSE foundation
    - #564 — M2: data model — parsing and verification
    - #565 — M3: building — issuer and device sides
    - #566 — M4: wallet storage and client surface
    - #567 — M5: OpenID4VCI issuance of mso_mdoc
    - #568 — M6: OpenID4VP disclosure of mso_mdoc
    - #569 — M7: hardening, conformance, docs
    - #572 — M8: Digital Credentials API presentation (ISO 18013-7 Annex C)
  - EU AV profile / go-passport-issuer phases (sub-issues of #562 in [privacybydesign/go-passport-issuer](https://github.com/privacybydesign/go-passport-issuer/issues)):
    - [go-passport-issuer#115](https://github.com/privacybydesign/go-passport-issuer/issues/115) — AV P1: proof_of_age mdoc minting
    - [go-passport-issuer#116](https://github.com/privacybydesign/go-passport-issuer/issues/116) — AV P2: OpenID4VCI issuer core
    - [go-passport-issuer#117](https://github.com/privacybydesign/go-passport-issuer/issues/117) — AV P3: wire OpenID4VCI issuance into the document-validation flow
    - [go-passport-issuer#118](https://github.com/privacybydesign/go-passport-issuer/issues/118) — AV P4: authorization code flow
    - [go-passport-issuer#119](https://github.com/privacybydesign/go-passport-issuer/issues/119) — AV P5: AV trust & operational compliance
    - [go-passport-issuer#120](https://github.com/privacybydesign/go-passport-issuer/issues/120) — AV P6: AV reference implementation interop & conformance

The AV-profile deltas have been appended to the affected milestone issues as "EU AV profile addendum" sections.
