### PR TITLE
ci: drop windows/arm (removed in Go 1.26) and catch broken build targets on PRs

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go.mod
 
     - name: Determine artifact output filename
       id: artifact-name-generator

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -140,6 +140,9 @@ jobs:
             arch: 386
           - os: darwin
             arch: arm
+          # Go 1.26 removed the 32-bit windows/arm port (windows/arm64 remains).
+          - os: windows
+            arch: arm
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -13,16 +13,9 @@ on:
 
 jobs:
 
+  # Host build of the whole module (cgo/sqlcipher enabled) that both compile-checks
+  # every package and produces the yivi-linux-amd64 binary the integration tests run.
   build:
-    strategy:
-      matrix:
-        os: [ linux, darwin, windows ]
-        arch: [ amd64, 386, arm, arm64 ]
-        exclude:
-          - os: darwin
-            arch: 386
-          - os: darwin
-            arch: arm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +36,34 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yivi-${{ matrix.os }}-${{ matrix.arch }}
+          name: yivi-linux-amd64
           path: build/yivi
+
+  # Cross-compile every release target on PRs with the same composite action the
+  # Delivery workflow uses, so an unsupported GOOS/GOARCH pair (e.g. the windows/arm
+  # port removed in Go 1.26) fails here instead of only after merge to master.
+  build-release-artifact:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ linux, darwin, windows ]
+        arch: [ amd64, 386, arm, arm64 ]
+        exclude:
+          - os: darwin
+            arch: 386
+          - os: darwin
+            arch: arm
+          # Go 1.26 removed the 32-bit windows/arm port (windows/arm64 remains).
+          - os: windows
+            arch: arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build artifact
+        uses: ./.github/actions/build
+        with:
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `Delivery` workflow started failing on `master` after #581 raised Go to 1.26:

```
go: unsupported GOOS/GOARCH pair windows/arm
```

Go 1.26 **removed the 32-bit `windows/arm` port** ([release notes](https://go.dev/doc/go1.26#windows)). `go tool dist list` under go1.26.3 confirms the only remaining Windows ports are `windows/386`, `windows/amd64`, and `windows/arm64`.

### Why PR checks didn't catch this

Two reasons:

1. The `Delivery` workflow (which actually cross-compiles each target via `.github/actions/build`, setting `GOOS`/`GOARCH`) only runs on `push: master` / `release` / `workflow_dispatch` — **not on `pull_request`**. So the failing job never ran while #581 was open.
2. `status-checks.yml` *did* have a `build` job with the same `os × arch` matrix that runs on PRs, but its step ran plain `go build ./...` with **no `GOOS`/`GOARCH`** — so all 9 legs compiled for the host (linux/amd64) and only labelled the uploaded artifact differently. The `build (windows, arm)` leg never cross-compiled, so it was green.

### Changes

- **delivery.yml**: exclude `windows/arm` from the release matrix.
- **status-checks.yml**: add a `build-release-artifact` job that cross-compiles every release target on PRs using the same `.github/actions/build` composite action Delivery uses (with the `windows/arm` exclude), so an unsupported target pair fails on the PR instead of after merge. The existing `build` job stays a single host build (cgo/sqlcipher) that still produces the `yivi-linux-amd64` binary the integration tests consume.
- **actions/build**: point the shared action at `go-version-file: go.mod` instead of a stale `^1.21` pin, so its toolchain matches the rest of CI.

### Impact

The `yivi-windows-arm.exe` (32-bit ARM Windows) release artifact is no longer produced. Windows-on-ARM is covered by `windows/arm64`; 32-bit ARM Windows is not a real consumer target.

Verified locally with go1.26.3 (matching CI) that `windows/arm` is the only matrix pair the toolchain no longer supports; all other targets (`./yivi`, `CGO_ENABLED=0`) cross-compile cleanly.

> [!NOTE]
> Once merged, consider adding `build-release-artifact` to the required status checks in branch protection so the cross-compile gate is enforced.