### PR TITLE
feat(eudi/storage): NewStorageWithDialector for a caller-supplied GORM dialector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `storage.NewStorageWithDialector(dialector, fs)`: open the EUDI holder database on any GORM dialector (e.g. `gorm.io/driver/postgres`) rather than only sqlcipher, for server-side / multi-tenant deployments. `NewStorage` is unchanged (it builds the sqlcipher dialector and delegates). The caller owns the at-rest encryption posture of a non-sqlcipher driver.
+
+### Fixed
+- `AutoMigrate` of the EUDI holder models is now ordered parents-before-children, so it also runs on foreign-key-enforcing drivers (e.g. Postgres) and not only SQLite.
 
 ## [1.1.1] - 2026-07-14
 ### Security

--- a/eudi/storage/storage.go
+++ b/eudi/storage/storage.go
@@ -31,7 +31,8 @@ type storage struct {
 	fs filesystem.FileSystemStorage
 }
 
-// NewStorage opens (or creates) a SQLite database at path, then auto-migrates all registered models.
+// NewStorage opens (or creates) an sqlcipher-encrypted SQLite database at dbPath,
+// then delegates to NewStorageWithDialector to auto-migrate all registered models.
 // The dbPath can be ":memory:" to use an in-memory database (useful for testing) or a path to a file.
 // Note: the default transaction has been DISABLED, which means, any Create or Update operation should be wrapped in a transaction (either directly or using the UnitOfWork) to ensure data integrity.
 func NewStorage(aesKey [32]byte, dbPath string, storagePath string) (Storage, error) {
@@ -57,7 +58,33 @@ func NewStorage(aesKey [32]byte, dbPath string, storagePath string) (Storage, er
 	}
 
 	connector := sqlcipher.NewConnector(dbPath, aesKey[:])
-	dbLogger := logger.New(
+	return NewStorageWithDialector(sqlcipher.Dialector{Connector: connector}, filesystem.NewFileSystemStorage(aesKey, storagePath))
+}
+
+// NewStorageWithDialector opens the holder database on any GORM dialector and
+// auto-migrates the credential-holder models, pairing it with the given file
+// storage. The models are dialector-agnostic GORM structs, so a caller can back
+// the holder engine with its own database — e.g. sqlcipher (encrypted SQLite,
+// one wallet per file) via NewStorage, or gorm.io/driver/postgres for a
+// server-side, multi-tenant deployment. The caller owns the encryption posture
+// of the chosen dialector (sqlcipher encrypts at rest; a plain database does not).
+func NewStorageWithDialector(dialector gorm.Dialector, fs filesystem.FileSystemStorage) (Storage, error) {
+	db, err := gorm.Open(dialector, &gorm.Config{Logger: newDBLogger()})
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	// TODO: separate the migration logic from the storage initialization logic, so that we can run migrations without needing to initialize the whole storage
+	// This will also save us from executing migrations every time we're creating UnitOfWork instances (which will create new repositories, which will otherwise auto-migrate their models if needed)
+	if err := autoMigrateHolderModels(db); err != nil {
+		return nil, err
+	}
+
+	return &storage{db: db, fs: fs}, nil
+}
+
+func newDBLogger() logger.Interface {
+	return logger.New(
 		log.New(os.Stdout, "\r\n", log.LstdFlags),
 		logger.Config{
 			SlowThreshold:             200 * time.Millisecond,
@@ -66,15 +93,16 @@ func NewStorage(aesKey [32]byte, dbPath string, storagePath string) (Storage, er
 			Colorful:                  true,
 		},
 	)
-	db, err := gorm.Open(sqlcipher.Dialector{Connector: connector}, &gorm.Config{Logger: dbLogger})
-	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
-	}
+}
 
-	// TODO: separate the migration logic from the storage initialization logic, so that we can run migrations without needing to initialize the whole storage
-	// This will also save us from executing migrations every time we're creating UnitOfWork instances (which will create new repositories, which will otherwise auto-migrate their models if needed)
-
-	err = db.AutoMigrate(
+func autoMigrateHolderModels(db *gorm.DB) error {
+	// Dependency order (parents before children): a referenced table must exist
+	// before the table whose foreign key points at it. SQLite tolerates any order,
+	// but Postgres (and any FK-enforcing driver) rejects a CREATE TABLE whose
+	// inline REFERENCES target does not exist yet, so the order matters here.
+	if err := db.AutoMigrate(
+		&models.CredentialBatch{},
+		&models.IssuedCredentialInstance{},
 		&models.HolderBindingKey{},
 		&models.ECDSAKeyMetadata{},
 		&models.RSAKeyMetadata{},
@@ -83,21 +111,12 @@ func NewStorage(aesKey [32]byte, dbPath string, storagePath string) (Storage, er
 		&models.CredentialDisplay{},
 		&models.CredentialClaim{},
 		&models.ClaimDisplay{},
-		&models.CredentialBatch{},
-		&models.IssuedCredentialInstance{},
 		&models.EudiLogEntry{},
 		&models.EudiLogCredential{},
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("auto-migrate database failed: %w", err)
+	); err != nil {
+		return fmt.Errorf("auto-migrate database failed: %w", err)
 	}
-
-	// Initialize the repositories, which will auto-migrate their models if needed
-	return &storage{
-		db: db,
-		fs: filesystem.NewFileSystemStorage(aesKey, storagePath),
-	}, nil
+	return nil
 }
 
 // Db returns the underlying gorm.DB, for use by repositories in this package.

--- a/eudi/storage/storage_test.go
+++ b/eudi/storage/storage_test.go
@@ -1,12 +1,16 @@
 package storage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/privacybydesign/irmago/eudi/storage/db/models"
 	"github.com/privacybydesign/irmago/eudi/storage/db/sqlcipher"
+	"github.com/privacybydesign/irmago/eudi/storage/filesystem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
 )
 
 // TestNewStorage_EncryptsDatabase is the direct regression guard for the bug where
@@ -38,4 +42,40 @@ func TestNewStorage_EncryptsDatabase(t *testing.T) {
 	copy(wrongKey[:], "fedcba9876543210fedcba9876543210")
 	_, err = NewStorage(wrongKey, dbPath, dir)
 	require.Error(t, err, "opening the encrypted database with the wrong key must fail")
+}
+
+// TestNewStorageWithDialector_MigratesViaSeam checks the dialector seam runs the
+// holder-model AutoMigrate independently of the concrete driver (here sqlcipher
+// in-memory), so callers can supply their own dialector (e.g. Postgres).
+func TestNewStorageWithDialector_MigratesViaSeam(t *testing.T) {
+	var aesKey [32]byte
+	copy(aesKey[:], "0123456789abcdef0123456789abcdef")
+
+	connector := sqlcipher.NewConnector(":memory:", aesKey[:])
+	s, err := NewStorageWithDialector(
+		sqlcipher.Dialector{Connector: connector},
+		filesystem.NewFileSystemStorage(aesKey, t.TempDir()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	assert.True(t, s.Db().Migrator().HasTable(&models.CredentialMetadata{}),
+		"the seam must auto-migrate the holder models")
+}
+
+// TestNewStorageWithDialector_Postgres proves the holder models migrate onto a
+// Postgres dialector — the server-side, multi-tenant deployment path. Skipped
+// unless EUDI_TEST_POSTGRES_DSN points at a (throwaway) database.
+func TestNewStorageWithDialector_Postgres(t *testing.T) {
+	dsn := os.Getenv("EUDI_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set EUDI_TEST_POSTGRES_DSN to run the Postgres-backed holder storage test")
+	}
+
+	s, err := NewStorageWithDialector(postgres.Open(dsn), filesystem.NewFileSystemStorage([32]byte{}, t.TempDir()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	assert.True(t, s.Db().Migrator().HasTable(&models.CredentialMetadata{}),
+		"the Postgres seam must auto-migrate the holder models")
 }


### PR DESCRIPTION
## Why

The Yivi Business Wallet needs the EUDI **holder** engine backed by **PostgreSQL** (server-side, multi-tenant) rather than sqlcipher (one encrypted SQLite file per wallet). Today `storage.NewStorage` hardcodes the sqlcipher dialector, so the credential-holder models can only live in a per-wallet file.

## What

- Extract **`NewStorageWithDialector(dialector gorm.Dialector, fs filesystem.FileSystemStorage) (Storage, error)`** — opens the holder DB on any GORM dialector and runs the same `AutoMigrate` over the credential-holder models. Callers can now back the engine with their own database (e.g. `gorm.io/driver/postgres`, already in `go.mod`).
- `NewStorage(aesKey, dbPath, storagePath)` is **behaviourally unchanged** — it builds the sqlcipher dialector + file storage and delegates to the new function. The legacy plaintext-migration path is untouched.
- Extracted `newDBLogger()` and `autoMigrateHolderModels()` helpers.
- **Ordered `AutoMigrate` parents-before-children.** SQLite tolerated the previous order, but Postgres (and any FK-enforcing driver) rejects a `CREATE TABLE` whose inline `REFERENCES` target does not exist yet (`HolderBindingKey` → `issued_credential_instances`). The resulting schema is identical on sqlcipher.

## Caller's responsibility (documented on the new function)

The chosen dialector owns the at-rest encryption posture: sqlcipher encrypts at rest for free; a plain database does not — the caller must add its own encryption (e.g. column-level / envelope) for a non-encrypted driver.

## Tests

- `TestNewStorageWithDialector_MigratesViaSeam` — always-on, sqlcipher in-memory, asserts the holder models migrate through the seam.
- `TestNewStorageWithDialector_Postgres` — gated by `EUDI_TEST_POSTGRES_DSN`; verified locally against a throwaway Postgres (all 12 holder tables created). `go test ./eudi/storage/` passes.

Consumed by yivi-businesswallet's attestations-holder work (v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
