### PR TITLE
Let a session request set its own nextSession timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- A session request that chains into another one can now set its own `nextSession.timeout`, in seconds, bounding the `/commitments` or `/proofs` handler that fetches the next request from the requestor while the client waits. Those two endpoints were bounded by the server-wide `WriteTimeout` of 4 seconds, which is not enough for a requestor that has to make a round trip of its own — asking a browser, a wallet or another backend what to issue next — before it can compose that request, especially while the user is on a slow mobile connection. The new `max_next_session_timeout` server option is the upper bound, defaulting to 15 seconds: a request asking for more is refused when the session is started rather than silently shortened, so the requestor learns which timeout it is actually going to get. 15 keeps that ceiling under the 20 second deadline `irma.HTTPTransport` puts on a request of its own, which bounds both the IRMA app waiting on `/proofs` and the server's own POST to the `nextSession` URL, so a higher maximum could not be honoured anyway. Sessions that do not chain are unaffected, as is a timeout below `WriteTimeout`: the timeout only ever lengthens the handler, never shortens it.
 
 ## [1.3.1] - 2026-09-01
 ### Added

--- a/irma/requests.go
+++ b/irma/requests.go
@@ -161,6 +161,13 @@ type RequestorBaseRequest struct {
 
 type NextSessionData struct {
 	URL string `json:"url"` // URL from which to get the next session after this one
+	// Seconds to wait for URL to respond, overriding the server's default request timeout.
+	// Capped by the server's max_next_session_timeout. Zero means the default.
+	//
+	// Requestors that compose the next session request only after a round trip of their own
+	// (asking a browser, a wallet, or another backend what to issue) need more than the default
+	// few seconds, especially when the user is on a slow mobile connection.
+	Timeout int `json:"timeout,omitempty"`
 }
 
 // RequestorRequest is the message with which requestors start an IRMA session. It contains a

--- a/irma/requests.go
+++ b/irma/requests.go
@@ -162,7 +162,8 @@ type RequestorBaseRequest struct {
 type NextSessionData struct {
 	URL string `json:"url"` // URL from which to get the next session after this one
 	// Seconds to wait for URL to respond, overriding the server's default request timeout.
-	// Capped by the server's max_next_session_timeout. Zero means the default.
+	// A value above the server's max_next_session_timeout is refused when the session is
+	// started. Zero, or anything below the default, means the default.
 	//
 	// Requestors that compose the next session request only after a round trip of their own
 	// (asking a browser, a wallet, or another backend what to issue) need more than the default

--- a/irma/server/api.go
+++ b/irma/server/api.go
@@ -79,6 +79,11 @@ const (
 const (
 	ReadTimeout  = 2 * time.Second
 	WriteTimeout = 2 * ReadTimeout
+
+	// DefaultMaxNextSessionTimeout is the default upper bound in seconds on
+	// Configuration.MaxNextSessionTimeout. Kept below the 20 second deadline the IRMA app
+	// applies to a request of its own (responseDeadline in transport.go)
+	DefaultMaxNextSessionTimeout = 15
 )
 
 var PostSizeLimit int64 = 10 << 20 // 10 MB
@@ -513,19 +518,25 @@ func TimeoutMiddleware(except []string, timeout time.Duration) func(http.Handler
 				}
 			}
 
-			// We set the timeout as deadline in the request's context such that the next handler
-			// can abort its actions and return an appropriate error response. If the next handler does
-			// not return a response within 200 milliseconds after the deadline expires, then we assume
-			// it froze and invoke the http.TimeoutHandler, which will send a 503 Service Unavailable.
-			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctx, cancel := context.WithTimeout(r.Context(), timeout)
-				defer cancel()
-				next.ServeHTTP(w, r.WithContext(ctx))
-			})
-
-			http.TimeoutHandler(nextHandler, timeout+200*time.Millisecond, "").ServeHTTP(w, r)
+			TimeoutHandler(next, timeout).ServeHTTP(w, r)
 		})
 	}
+}
+
+// TimeoutHandler bounds next to the given timeout.
+//
+// We set the timeout as deadline in the request's context such that the next handler
+// can abort its actions and return an appropriate error response. If the next handler does
+// not return a response within 200 milliseconds after the deadline expires, then we assume
+// it froze and invoke the http.TimeoutHandler, which will send a 503 Service Unavailable.
+func TimeoutHandler(next http.Handler, timeout time.Duration) http.Handler {
+	withDeadline := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	return http.TimeoutHandler(withDeadline, timeout+200*time.Millisecond, "")
 }
 
 // LogMiddleware is middleware for logging HTTP requests and responses.

--- a/irma/server/conf.go
+++ b/irma/server/conf.go
@@ -68,6 +68,8 @@ type Configuration struct {
 	MaxSessionLifetime int `json:"max_session_lifetime" mapstructure:"max_session_lifetime"`
 	// Determines how long a session result is preserved in minutes (default value 0 means 5)
 	SessionResultLifetime int `json:"session_result_lifetime" mapstructure:"session_result_lifetime"`
+	// Upper bound in seconds on the nextSession.timeout a requestor may ask for
+	MaxNextSessionTimeout int `json:"max_next_session_timeout" mapstructure:"max_next_session_timeout"`
 
 	// Used in the "iss" field of result JWTs from /result-jwt and /getproof
 	JwtIssuer string `json:"jwt_issuer" mapstructure:"jwt_issuer"`
@@ -174,6 +176,9 @@ func (conf *Configuration) Check() error {
 	}
 	if conf.SessionResultLifetime == 0 {
 		conf.SessionResultLifetime = 5
+	}
+	if conf.MaxNextSessionTimeout == 0 {
+		conf.MaxNextSessionTimeout = DefaultMaxNextSessionTimeout
 	}
 
 	// loop to avoid repetetive err != nil line triplets

--- a/irma/server/irmaserver/api.go
+++ b/irma/server/irmaserver/api.go
@@ -140,7 +140,13 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 	r.Use(server.LogMiddleware("client", opts))
 
 	r.Use(server.SizeLimitMiddleware)
-	r.Use(server.TimeoutMiddleware([]string{"/statusevents", "/updateevents"}, server.WriteTimeout))
+	// /commitments and /proofs are excepted here and bounded by nextSessionTimeoutMiddleware
+	// instead, which can read the session's own timeout. They still get server.WriteTimeout
+	// when the session does not chain into another one.
+	r.Use(server.TimeoutMiddleware(
+		[]string{"/statusevents", "/updateevents", "/commitments", "/proofs"},
+		server.WriteTimeout,
+	))
 
 	notfound := &irma.RemoteError{Status: 404, ErrorName: string(server.ErrorInvalidRequest.Type)}
 	notallowed := &irma.RemoteError{Status: 405, ErrorName: string(server.ErrorInvalidRequest.Type)}
@@ -165,8 +171,10 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 			r.Group(func(r chi.Router) {
 				r.Use(s.pairingMiddleware)
 				r.Get("/request", s.handleSessionGetRequest)
-				r.Post("/commitments", s.handleSessionCommitments)
-				r.Post("/proofs", s.handleSessionProofs)
+				// Finishing a chained session means fetching the next request from the
+				// requestor while the client waits, so these two need the session's timeout.
+				r.With(s.nextSessionTimeoutMiddleware).Post("/commitments", s.handleSessionCommitments)
+				r.With(s.nextSessionTimeoutMiddleware).Post("/proofs", s.handleSessionProofs)
 			})
 		})
 	})
@@ -243,6 +251,12 @@ func (s *Server) startNextSession(
 
 	pairingRecommended := false
 	if rrequest.Base().NextSession != nil && rrequest.Base().NextSession.URL != "" {
+		if timeout := rrequest.Base().NextSession.Timeout; timeout > s.conf.MaxNextSessionTimeout {
+			return nil, "", nil, errors.Errorf(
+				"nextSession timeout of %d seconds exceeds the maximum of %d",
+				timeout, s.conf.MaxNextSessionTimeout,
+			)
+		}
 		pairingRecommended = true
 	} else if action == irma.ActionDisclosing {
 		err := request.Disclosure().Disclose.Iterate(func(attr *irma.AttributeRequest) error {

--- a/irma/server/irmaserver/api.go
+++ b/irma/server/irmaserver/api.go
@@ -173,8 +173,8 @@ func (s *Server) HandlerFunc() http.HandlerFunc {
 				r.Get("/request", s.handleSessionGetRequest)
 				// Finishing a chained session means fetching the next request from the
 				// requestor while the client waits, so these two need the session's timeout.
-				r.With(s.nextSessionTimeoutMiddleware).Post("/commitments", s.handleSessionCommitments)
-				r.With(s.nextSessionTimeoutMiddleware).Post("/proofs", s.handleSessionProofs)
+				r.With(nextSessionTimeoutMiddleware).Post("/commitments", s.handleSessionCommitments)
+				r.With(nextSessionTimeoutMiddleware).Post("/proofs", s.handleSessionProofs)
 			})
 		})
 	})
@@ -253,7 +253,7 @@ func (s *Server) startNextSession(
 	if rrequest.Base().NextSession != nil && rrequest.Base().NextSession.URL != "" {
 		if timeout := rrequest.Base().NextSession.Timeout; timeout > s.conf.MaxNextSessionTimeout {
 			return nil, "", nil, errors.Errorf(
-				"nextSession timeout of %d seconds exceeds the maximum of %d",
+				"nextSession.timeout of %d seconds exceeds the server maximum of %d",
 				timeout, s.conf.MaxNextSessionTimeout,
 			)
 		}

--- a/irma/server/irmaserver/helpers.go
+++ b/irma/server/irmaserver/helpers.go
@@ -620,6 +620,36 @@ func (s *Server) sessionMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// nextSessionTimeout returns how long the handler for this session may take.
+func (s *Server) nextSessionTimeout(session *sessionData) time.Duration {
+	next := session.Rrequest.Base().NextSession
+	if next == nil || next.Timeout <= 0 {
+		return server.WriteTimeout
+	}
+
+	seconds := next.Timeout
+	if limit := s.conf.MaxNextSessionTimeout; seconds > limit {
+		s.conf.Logger.Warnf(
+			"session requested a next session timeout of %d seconds, capping at the configured maximum of %d",
+			seconds, limit,
+		)
+		seconds = limit
+	}
+
+	timeout := time.Duration(seconds) * time.Second
+	if timeout < server.WriteTimeout {
+		return server.WriteTimeout
+	}
+	return timeout
+}
+
+func (s *Server) nextSessionTimeoutMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		session := r.Context().Value("session").(*sessionData)
+		server.TimeoutHandler(next, s.nextSessionTimeout(session)).ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) pairingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session := r.Context().Value("session").(*sessionData)

--- a/irma/server/irmaserver/helpers.go
+++ b/irma/server/irmaserver/helpers.go
@@ -621,32 +621,27 @@ func (s *Server) sessionMiddleware(next http.Handler) http.Handler {
 }
 
 // nextSessionTimeout returns how long the handler for this session may take.
-func (s *Server) nextSessionTimeout(session *sessionData) time.Duration {
+//
+// Only a session that chains into another one carries a timeout of its own, and
+// startNextSession refused the request outright if that timeout exceeded
+// Configuration.MaxNextSessionTimeout.
+func nextSessionTimeout(session *sessionData) time.Duration {
 	next := session.Rrequest.Base().NextSession
-	if next == nil || next.Timeout <= 0 {
+	if next == nil || next.URL == "" {
 		return server.WriteTimeout
 	}
 
-	seconds := next.Timeout
-	if limit := s.conf.MaxNextSessionTimeout; seconds > limit {
-		s.conf.Logger.Warnf(
-			"session requested a next session timeout of %d seconds, capping at the configured maximum of %d",
-			seconds, limit,
-		)
-		seconds = limit
-	}
-
-	timeout := time.Duration(seconds) * time.Second
+	timeout := time.Duration(next.Timeout) * time.Second
 	if timeout < server.WriteTimeout {
 		return server.WriteTimeout
 	}
 	return timeout
 }
 
-func (s *Server) nextSessionTimeoutMiddleware(next http.Handler) http.Handler {
+func nextSessionTimeoutMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session := r.Context().Value("session").(*sessionData)
-		server.TimeoutHandler(next, s.nextSessionTimeout(session)).ServeHTTP(w, r)
+		server.TimeoutHandler(next, nextSessionTimeout(session)).ServeHTTP(w, r)
 	})
 }
 

--- a/irma/server/irmaserver/helpers_test.go
+++ b/irma/server/irmaserver/helpers_test.go
@@ -26,11 +26,6 @@ func TestAnonimizeRequest(t *testing.T) {
 func TestNextSessionTimeout(t *testing.T) {
 	const disclosure = `{"@context":"https://irma.app/ld/request/disclosure/v2","context":"AQ==","nonce":"MtILupG0g0J23GNR1YtupQ==","devMode":true,"disclose":[[["test.test.email.email"]]]}`
 
-	s := &Server{conf: &server.Configuration{
-		MaxNextSessionTimeout: 15,
-		Logger:                server.NewLogger(0, true, false),
-	}}
-
 	for _, tc := range []struct {
 		name     string
 		request  string
@@ -52,20 +47,38 @@ func TestNextSessionTimeout(t *testing.T) {
 			expected: 12 * time.Second,
 		},
 		{
-			name:     "a timeout above the maximum is capped",
-			request:  `{"nextSession":{"url":"https://example.com","timeout":600},"request":` + disclosure + `}`,
-			expected: 15 * time.Second,
-		},
-		{
 			name:     "a timeout below the default does not shorten the handler",
 			request:  `{"nextSession":{"url":"https://example.com","timeout":1},"request":` + disclosure + `}`,
+			expected: server.WriteTimeout,
+		},
+		{
+			// Without a URL nothing is fetched, so there is nothing to wait for.
+			name:     "a timeout without a next session URL is ignored",
+			request:  `{"nextSession":{"timeout":12},"request":` + disclosure + `}`,
 			expected: server.WriteTimeout,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := server.ParseSessionRequest(tc.request)
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, s.nextSessionTimeout(&sessionData{Rrequest: req}))
+			require.Equal(t, tc.expected, nextSessionTimeout(&sessionData{Rrequest: req}))
 		})
 	}
+}
+
+// A timeout above the configured maximum is refused when the session is started, which is what
+// lets nextSessionTimeout use the stored value as is.
+func TestNextSessionTimeoutAboveMaximumIsRefused(t *testing.T) {
+	conf := sessionsConf(t)
+	conf.MaxNextSessionTimeout = 15
+	s, err := New(conf)
+	require.NoError(t, err)
+	defer s.Stop()
+
+	_, _, _, err = s.StartSession(
+		`{"nextSession":{"url":"https://example.com","timeout":600},"request":{"@context":"https://irma.app/ld/request/disclosure/v2","disclose":[[["test.test.email.email"]]]}}`,
+		nil,
+		"",
+	)
+	require.ErrorContains(t, err, "nextSession.timeout of 600 seconds exceeds the server maximum of 15")
 }

--- a/irma/server/irmaserver/helpers_test.go
+++ b/irma/server/irmaserver/helpers_test.go
@@ -3,6 +3,7 @@ package irmaserver
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/privacybydesign/irmago/irma/server"
 	"github.com/stretchr/testify/require"
@@ -20,4 +21,51 @@ func TestAnonimizeRequest(t *testing.T) {
 	out, err = json.Marshal(purgeRequest(req))
 	require.NoError(t, err)
 	require.Equal(t, `{"validity":120,"request":{"@context":"https://irma.app/ld/request/issuance/v2","context":"AQ==","nonce":"wrmq+QY8r86nbGTI+mMAzg==","devMode":true,"disclose":[[["test.test.email.email"]]],"credentials":[{"validity":2000000000,"keyCounter":2,"credential":"irma-demo.RU.studentCard","attributes":null}]}}`, string(out))
+}
+
+func TestNextSessionTimeout(t *testing.T) {
+	const disclosure = `{"@context":"https://irma.app/ld/request/disclosure/v2","context":"AQ==","nonce":"MtILupG0g0J23GNR1YtupQ==","devMode":true,"disclose":[[["test.test.email.email"]]]}`
+
+	s := &Server{conf: &server.Configuration{
+		MaxNextSessionTimeout: 15,
+		Logger:                server.NewLogger(0, true, false),
+	}}
+
+	for _, tc := range []struct {
+		name     string
+		request  string
+		expected time.Duration
+	}{
+		{
+			name:     "no next session falls back to the default",
+			request:  `{"request":` + disclosure + `}`,
+			expected: server.WriteTimeout,
+		},
+		{
+			name:     "next session without a timeout falls back to the default",
+			request:  `{"nextSession":{"url":"https://example.com"},"request":` + disclosure + `}`,
+			expected: server.WriteTimeout,
+		},
+		{
+			name:     "next session timeout is honoured",
+			request:  `{"nextSession":{"url":"https://example.com","timeout":12},"request":` + disclosure + `}`,
+			expected: 12 * time.Second,
+		},
+		{
+			name:     "a timeout above the maximum is capped",
+			request:  `{"nextSession":{"url":"https://example.com","timeout":600},"request":` + disclosure + `}`,
+			expected: 15 * time.Second,
+		},
+		{
+			name:     "a timeout below the default does not shorten the handler",
+			request:  `{"nextSession":{"url":"https://example.com","timeout":1},"request":` + disclosure + `}`,
+			expected: server.WriteTimeout,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := server.ParseSessionRequest(tc.request)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, s.nextSessionTimeout(&sessionData{Rrequest: req}))
+		})
+	}
 }


### PR DESCRIPTION

Finishing a chained session means fetching the next request from the requestor while the client waits, but `/commitments `and `/proofs` were bounded by the server-wide `WriteTimeout` of 4 seconds. That is too short for a requestor (Pubhubs) that has to make a round trip of its own before it can compose the next request, especially over a slow mobile connection.
 
`nextSession` now takes an optional timeout in seconds. Those two endpoints move off `TimeoutMiddleware` onto a new `nextSessionTimeoutMiddleware` that reads the session's own value; everything else, and any session that does not chain, keeps `WriteTimeout`. The requestor's value is bounded by the new `max_next_session_timeout `config option, defaulting to 15 seconds to stay under the 20 second deadline the IRMA app applies to its own requests, and a value below `WriteTimeout` never shortens the handler.
